### PR TITLE
Fixes gh-367 Wrong return type in 'taptest:check()' documentation

### DIFF
--- a/doc/1.6/reference/reference_lua/tap.rst
+++ b/doc/1.6/reference/reference_lua/tap.rst
@@ -45,7 +45,8 @@ so on.
         Will display ``# bad plan: ...`` if the number of completed tests is not
         equal to the number of tests specified by ``taptest:plan(...)``.
 
-        :return: nil
+        :return: true or false.
+        :rtype:  boolean
 
     .. method:: diag(message)
 


### PR DESCRIPTION
Fix #367 