### PR TITLE
Update __php.rst

### DIFF
--- a/doc/1.9/book/connectors/__php.rst
+++ b/doc/1.9/book/connectors/__php.rst
@@ -2,12 +2,11 @@
                             PHP
 =====================================================================
 
-The most commonly used PHP driver is
-`tarantool-php <https://github.com/tarantool/tarantool-php>`_.
-It is not supplied as part of the Tarantool repository; it must be installed
-separately, for example with :program:`git`. See `installation instructions
-<https://github.com/tarantool/tarantool-php/blob/master/#installing-and-building>`_.
-in the driver's :file:`README` file.
+`tarantool-php <https://github.com/tarantool/tarantool-php>`_ is the official PHP connector for Tarantool.
+It is not supplied as part of the Tarantool repository and must be installed
+separately (see `installation instructions
+<https://github.com/tarantool/tarantool-php/blob/master/#installing-and-building>`_
+in the connector's :file:`README` file).
 
 Here is a complete PHP program that inserts ``[99999,'BB']`` into a space named
 ``examples`` via the PHP API. Before trying to run, check that the server instance is
@@ -26,10 +25,10 @@ The program will open a socket connection with the Tarantool instance at
     $tarantool = new Tarantool('localhost', 3301);
 
     try {
-        $tarantool->insert('examples', array(99999, 'BB'));
+        $tarantool->insert('examples', [99999, 'BB']);
         echo "Insert succeeded\n";
     } catch (Exception $e) {
-        echo "Exception: ", $e->getMessage(), "\n";
+        echo $e->getMessage(), "\n";
     }
 
 The example program only shows one request and does not show all that's
@@ -37,8 +36,7 @@ necessary for good practice. For that, please see
 `tarantool/tarantool-php <https://github.com/tarantool/tarantool-php>`_
 project at GitHub.
 
-Besides, you can use an alternative PHP driver from
-another GitHub project: it includes a *client*
-(see `tarantool-php/client <https://github.com/tarantool-php/client>`_)
-and a *mapper* for that client
-(see `tarantool-php/mapper <https://github.com/tarantool-php/mapper>`_).
+Besides, there is another `GitHub project <https://github.com/tarantool-php>`_ which includes 
+an `alternative connector <https://github.com/tarantool-php/client>`_ written in pure PHP, 
+an `object mapper <https://github.com/tarantool-php/mapper>`_, a `queue <https://github.com/tarantool-php/queue>`_
+and other packages.

--- a/doc/1.9/book/connectors/__php.rst
+++ b/doc/1.9/book/connectors/__php.rst
@@ -5,7 +5,7 @@
 `tarantool-php <https://github.com/tarantool/tarantool-php>`_ is the official PHP connector for Tarantool.
 It is not supplied as part of the Tarantool repository and must be installed
 separately (see `installation instructions
-<https://github.com/tarantool/tarantool-php/blob/master/#installing-and-building>`_
+<https://github.com/tarantool/tarantool-php/#installing-and-building>`_
 in the connector's :file:`README` file).
 
 Here is a complete PHP program that inserts ``[99999,'BB']`` into a space named

--- a/doc/1.9/book/connectors/__php.rst
+++ b/doc/1.9/book/connectors/__php.rst
@@ -17,7 +17,7 @@ a file named :file:`example.php` and say
 The program will open a socket connection with the Tarantool instance at
 ``localhost:3301``, then send an :ref:`INSERT<box_space-insert>` request, then — if all is well — print
 "Insert succeeded". If the tuple already exists, the program will print
-“Duplicate key exists in unique index 'primary' in space 'examples'”.
+"Duplicate key exists in unique index 'primary' in space 'examples'".
 
 .. code-block:: php
 
@@ -36,7 +36,7 @@ necessary for good practice. For that, please see
 `tarantool/tarantool-php <https://github.com/tarantool/tarantool-php>`_
 project at GitHub.
 
-Besides, there is another `GitHub project <https://github.com/tarantool-php>`_ which includes 
-an `alternative connector <https://github.com/tarantool-php/client>`_ written in pure PHP, 
+Besides, there is another community-driven `GitHub project <https://github.com/tarantool-php>`_ 
+which includes an `alternative connector <https://github.com/tarantool-php/client>`_ written in pure PHP, 
 an `object mapper <https://github.com/tarantool-php/mapper>`_, a `queue <https://github.com/tarantool-php/queue>`_
 and other packages.


### PR DESCRIPTION
1. The documentation section is called "Connectors", so, IMHO, using the "connector" term instead of the "driver" is less confusing.
2. The `"Exception: ", ` part was removed because docs state that 
    > the program will print “Duplicate key exists in unique index 'primary' in space 'examples'”.`

    (but not "Exception: Duplicate key ...")
3. The tarantool-php project includes more than just a client and a mapper, and I think it's good to mention that explicitly :)
4. The `a *mapper* for that client` part is a bit confusing, the mapper is not for the client, but uses it internally.