### PR TITLE
Fix box.atomic description

### DIFF
--- a/doc/1.10/book/box/box_txn_management.rst
+++ b/doc/1.10/book/box/box_txn_management.rst
@@ -158,7 +158,7 @@ Below is a list of all functions for transaction management.
 
 .. _box-atomic:
 
-.. function:: box.atomic(function-name [, function-arguments])
+.. function:: box.atomic(tx-function [, function-arguments])
 
     Execute a function, acting as if the function starts with an implicit
     :ref:`box.begin() <box-begin>` and ends with an implicit


### PR DESCRIPTION
This arg is passed to pcall which does not accept string as its 1st arg.