### PR TITLE
Added description of limitations for number of tuples in index

### DIFF
--- a/doc/book/box/limitations.rst
+++ b/doc/book/box/limitations.rst
@@ -95,3 +95,9 @@ Limitations
 **Number of replicas in a replica set**
 
     32 (``vclock.VCLOCK_MAX``).
+
+**Number of tuples in an index**
+
+    2 147 483 647 (ref_).
+
+.. _ref: https://github.com/tarantool/small/blob/master/small/matras.h#L87-L89

--- a/locale/ru/LC_MESSAGES/book.po
+++ b/locale/ru/LC_MESSAGES/book.po
@@ -25711,6 +25711,10 @@ msgstr "**Количество реплик в наборе реплик**"
 msgid "32 (``vclock.VCLOCK_MAX``)."
 msgstr "32 (``vclock.VCLOCK_MAX``)."
 
+#: ../doc/book/box/limitations.rst:99
+msgid "**Number of tuples in an index**"
+msgstr "**Количество кортежей в индексе**"
+
 #: ../doc/book/box/triggers.rst:6
 msgid "Triggers"
 msgstr "Триггеры"


### PR DESCRIPTION
Since we found out about this limitation of the index size in our own experience ([4678](https://github.com/tarantool/tarantool/issues/4678)) - I am adding information about the limitation in the documentation.