### PR TITLE
introduced epub build target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,11 @@ set(SPHINX_RU_HTML_DIR             "${SPHINX_OUTPUT_DIR}/html/ru/")
 set(SPHINX_EN_JSON_DIR             "${SPHINX_OUTPUT_DIR}/json/_build_en/json")
 set(SPHINX_RU_JSON_DIR             "${SPHINX_OUTPUT_DIR}/json/_build_ru/json")
 
+set(SPHINX_BUILD_EPUB_DIR          ${SPHINX_OUTPUT_DIR}/_epub_en/)
+set(SPHINX_BUILD_EPUB_RU_DIR       ${SPHINX_OUTPUT_DIR}/_epub_ru/)
+set(SPHINX_EN_EPUB_DIR             ${SPHINX_OUTPUT_DIR}/epub/en/)
+set(SPHINX_RU_EPUB_DIR             ${SPHINX_OUTPUT_DIR}/epub/ru/)
+
 add_custom_target(html ALL
     COMMAND "${SPHINX_EXECUTABLE}"
         -b html
@@ -157,6 +162,28 @@ add_custom_target(linkcheck
         "${SPHINX_BUILD_HTML_DIR}"
     COMMENT "Linkcheck filter"
 )
+
+add_custom_target(epub ALL
+    COMMAND "${SPHINX_EXECUTABLE}"
+        -b epub
+        -d "${SPHINX_BUILD_EPUB_DIR}"
+        -c epub/
+        "${CMAKE_CURRENT_SOURCE_DIR}/doc"
+        "${SPHINX_EN_EPUB_DIR}"
+    COMMENT "Building English epub with Sphinx"
+)
+
+add_custom_target(epub-ru ALL
+    COMMAND "${SPHINX_EXECUTABLE}"
+        -b epub
+        -d "${SPHINX_BUILD_EPUB_RU_DIR}"
+        -c epub/
+        -D language=ru
+        "${CMAKE_CURRENT_SOURCE_DIR}/doc"
+        "${SPHINX_RU_EPUB_DIR}"
+    COMMENT "Building Russian epub with Sphinx"
+)
+
 
 if (LATEX_FOUND)
     add_custom_target(pdf-ru ALL COMMENT "PDF generation")

--- a/epub/conf.py
+++ b/epub/conf.py
@@ -1,0 +1,24 @@
+exec(open('../conf.py').read())
+
+master_doc = 'singlehtml'
+
+locale_dirs = ['../locale']
+
+extensions = [
+    'sphinx.ext.todo',
+    'sphinx.ext.imgmath',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.intersphinx',
+    'sphinxcontrib.rsvgconverter',
+    'ext.custom',
+    'ext.LuaDomain',
+    'ext.LuaLexer',
+    'ext.TapLexer',
+    'ext.TarantoolSessionLexer',
+    'ext.DropdownList',
+    'ext.WebPageSection',
+    'ext.WebPageButtons',
+    'ext.WebPageMap',
+    'ext.ModuleBlock',
+    'ext.DownloadPageBlock'
+]


### PR DESCRIPTION
Apparently pdfs are unreadable of ebook reader PocketBook, thus I've created epub target (using the same sphinx-build facilities). 

Those generated epubs are rendered properly on ebook reader. Though require some extra love (i.e. cover page and code trimming to fit in page)