### PR TITLE
removed george-edison55-precise-backports repository from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: true
 
 addons:
   apt:
-    sources:
-      - george-edison55-precise-backports
     packages:
       - cmake
       - cmake-data


### PR DESCRIPTION
fix #1236