### PR TITLE
Add Cartridge Kubernetes guide

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "modules/luatest"]
 	path = modules/luatest
 	url = https://github.com/tarantool/luatest
+[submodule "modules/tarantool-operator"]
+	path = modules/tarantool-operator
+	url = https://github.com/tarantool/tarantool-operator.git

--- a/doc/book/cartridge/index.rst
+++ b/doc/book/cartridge/index.rst
@@ -23,4 +23,5 @@ This documentation contains the following sections:
    troubleshooting
    Cartridge API<cartridge_api/index>
    Cartridge CLI<cartridge_cli/index>
+   Cartridge Kubernetes guide<cartridge_kubernetes_guide/index>
    Changelog <CHANGELOG>

--- a/update_submodules.sh
+++ b/update_submodules.sh
@@ -26,6 +26,9 @@ monitoring_dest="${project_root}/doc/book"
 luatest_root="${project_root}/modules/luatest/"
 luatest_dest="${project_root}/doc/reference/reference_rock/luatest"
 
+cartridge_kubernetes_root="${project_root}/modules/tarantool-operator/doc/cartridge_kubernetes_guide"
+cartridge_kubernetes_dest="${rst_dest}/"
+
 cd "${luatest_root}"
 ldoc --ext=rst --dir=rst --toctree="API" .
 cd "${luatest_dest}"
@@ -37,6 +40,9 @@ yes | cp -rf "${monitoring_root}" "${monitoring_dest}/"
 
 mkdir -p "${cartridge_cli_dest}"
 yes | cp -rf "${cartridge_cli_root}/README.rst" "${cartridge_cli_index_dest}"
+
+mkdir -p "${cartridge_kubernetes_dest}"
+yes | cp -rf "${cartridge_kubernetes_root}" "${cartridge_kubernetes_dest}"
 
 cd "${cartridge_root}" || exit
 tarantoolctl rocks install \
@@ -56,3 +62,4 @@ cd "${po_src}" || exit
 mkdir -p "${po_dest}"
 find . -name '*.po' -exec cp -r --parents {} "${po_dest}" \;
 
+sed -i -e '/Cartridge CLI<cartridge_cli\/index>/a\' -e '\ \ \ Cartridge Kubernetes guide<cartridge_kubernetes_guide/index>' "${rst_dest}/index.rst"


### PR DESCRIPTION
Rst sources: [link](https://github.com/tarantool/tarantool-operator/blob/kubernetes-guide/doc/cartridge_kubernetes_guide/index.rst)
Location in the doc: `book/cartridge/cartridge_kubernetes_guide`

For local build:
After updating submodules add to `doc/book/cartridge/index.rst` this line
```
Cartridge Kubernetes guide<cartridge_kubernetes_guide/index>
```