### PR TITLE
Add Grafana dashboard documentation on tarantool.io

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "modules/tarantool-operator"]
 	path = modules/tarantool-operator
 	url = https://github.com/tarantool/tarantool-operator.git
+[submodule "modules/grafana-dashboard"]
+	path = modules/grafana-dashboard
+	url = https://github.com/tarantool/grafana-dashboard

--- a/update_submodules.sh
+++ b/update_submodules.sh
@@ -23,6 +23,7 @@ cartridge_cli_dest="${rst_dest}/cartridge_cli"
 cartridge_cli_index_dest="${cartridge_cli_dest}/index.rst"
 monitoring_root="${project_root}/modules/metrics/doc/monitoring"
 monitoring_dest="${project_root}/doc/book"
+monitoring_grafana_root="${project_root}/modules/grafana-dashboard/doc/monitoring"
 luatest_root="${project_root}/modules/luatest/"
 luatest_dest="${project_root}/doc/reference/reference_rock/luatest"
 
@@ -37,6 +38,7 @@ yes | cp "${luatest_root}/README.rst" "${luatest_dest}"
 
 mkdir -p "${monitoring_dest}"
 yes | cp -rf "${monitoring_root}" "${monitoring_dest}/"
+yes | cp -rf "${monitoring_grafana_root}" "${monitoring_dest}/"
 
 mkdir -p "${cartridge_cli_dest}"
 yes | cp -rf "${cartridge_cli_root}/README.rst" "${cartridge_cli_index_dest}"


### PR DESCRIPTION
Closes https://github.com/tarantool/grafana-dashboard/issues/45 together with https://github.com/tarantool/metrics/pull/185 and https://github.com/tarantool/grafana-dashboard/pull/50

Dependency structure: `grafana-dashboard` includes folder 'monitoring' with documentation text and images that should merged with `metrics` folder 'monitoring' on doc build; `metrics` adds documentation to index page; `doc` adds grafana-dashoard as a submodule and fetches its content.