### PR TITLE
Upload pot files to Crowdin when translation changes

### DIFF
--- a/.github/workflows/upload-crowdin.yml
+++ b/.github/workflows/upload-crowdin.yml
@@ -1,0 +1,27 @@
+name: Upload translation sources
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - latest
+    paths:
+      - 'locale/**.pot'
+jobs:
+  upload-crowdin:
+    runs-on: ubuntu-latest
+    container: tarantool/doc-builder:v1
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Push Pot-files to crowdin
+      uses: crowdin/github-action@1.0.21
+      with:
+        upload_sources: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+        CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
This workflow begins after update-pot commits new or updated pot files

Closes #1935