### PR TITLE
fixes gh-1626 Varbinary supported in bitset indexes

### DIFF
--- a/doc/reference/reference_lua/box_space/create_index.rst
+++ b/doc/reference/reference_lua/box_space/create_index.rst
@@ -202,7 +202,7 @@ and what index types are allowed.
               <limitations_bytes_in_index_key>`. A varbinary byte sequence
               does not have a :ref:`collation <index-collation>`
               because its contents are not UTF-8 characters
-            - memtx TREE, HASH or BITSET (since version 2.7) indexes;
+            - memtx TREE, HASH or BITSET (since version :doc:`2.7.1 </release/2.7.1>`) indexes;
 
               vinyl TREE indexes
             - '\\65 \\66 \\67'

--- a/doc/release/2.7.1.rst
+++ b/doc/release/2.7.1.rst
@@ -40,7 +40,7 @@ Core
 
 -   Now it is allowed to define an index without extra braces when there
     is only one part: ``parts = {field1, type1, ...}`` (gh-2866).
--   Bitset index now supports the varbinary type (gh-5392).
+-   :ref:`Bitset index <indexes-bitset>` now supports the varbinary type (gh-5392).
 -   Index-related options now can’t be specified in their definition due
     to a more pedantic key-parts verification (gh-5473).
 -   A warning is now logged when schema version is older than last


### PR DESCRIPTION
fixes #1626 