### PR TITLE
Don't try to translate files without text

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -1,4 +1,4 @@
-name: Update translation sources
+name: Update main translation branch
 
 on:
   workflow_dispatch:
@@ -7,8 +7,10 @@ on:
       - latest
     paths:
       - 'doc/**/*.rst'
+      - 'locale/ru/**/*.po'
+      - 'crowdin.yml'
 jobs:
-  autocommit-pot-files:
+  update-translations:
     runs-on: ubuntu-latest
     container: tarantool/doc-builder:v1
 

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -20,5 +20,10 @@ files: [
       "ru" : "ru",
      }
   },
+
+  "ignore": [
+    "/en/singlehtml.*",
+    "/en/toctree.*",
+  ]
  }
 ]


### PR DESCRIPTION
Empty .po files used to cause an error when uploading them
with the Crowdin action.