### PR TITLE
Fix empty branch name variable

### DIFF
--- a/.github/workflows/deploy-custom.yml
+++ b/.github/workflows/deploy-custom.yml
@@ -45,11 +45,22 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Fetch submodules
-        run: git fetch --recurse-submodules
+      - name: Pull submodules
+        run: |
+          git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --recurse-submodules
 
-      - name: Set branch name from source branch
-        run: echo "BRANCH_NAME=${INPUT_ENV_NAME}" >> $GITHUB_ENV
+      - name: Update inputs
+        run: |
+          echo "BRANCH_NAME=${{github.event.inputs.env_name}}" >> $GITHUB_ENV
+          echo "workaround until actions/runner#655 is fixed"
+          echo "INPUT_CARTRIDGE=${{github.event.inputs.cartridge}}" >> $GITHUB_ENV
+          echo "INPUT_CARTRIDGE_CLI=${{github.event.inputs.cartridge_cli}}" >> $GITHUB_ENV
+          echo "INPUT_GRAFANA=${{github.event.inputs.grafana}}" >> $GITHUB_ENV
+          echo "INPUT_LUATEST=${{github.event.inputs.luatest}}" >> $GITHUB_ENV
+          echo "INPUT_METRICS=${{github.event.inputs.metrics}}" >> $GITHUB_ENV
+          echo "INPUT_K8S_OPERATOR=${{github.event.inputs.k8s_operator}}" >> $GITHUB_ENV
+          echo "INPUT_CPP_DRIVER=${{github.event.inputs.cpp_driver}}" >> $GITHUB_ENV
 
       - name: Start dev server deployment
         uses: bobheadxi/deployments@v0.5.2
@@ -57,7 +68,7 @@ jobs:
         with:
           step: start
           token: ${{secrets.GITHUB_TOKEN}}
-          env: "branch-${{env.BRANCH_NAME}}"
+          env: ${{env.BRANCH_NAME}}
           ref: ${{github.head_ref}}
 
       - run: cmake .

--- a/pull_submodules.py
+++ b/pull_submodules.py
@@ -45,9 +45,13 @@ def main():
 
 def checkout_submodule(directory, git_ref='origin/master'):
     print(f'Checking out {directory} module into {git_ref}')
-    git_checkout = f'set -ex ; git checkout {git_ref}'
+    path = os.path.join(workdir, directory)
+    print(path)
+    subprocess.check_call('set -ex ; git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"', shell=True,
+                          cwd=path)
+    git_checkout = f'set -ex ; git remote update ; git checkout {git_ref}'
     subprocess.check_call(git_checkout, shell=True,
-                          cwd=os.path.join(workdir, directory))
+                          cwd=path)
 
 
 def mkdir_p(path):


### PR DESCRIPTION
According to [inputs documentation](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs) the input value is available by environment variable `INPUT_<VARIABLE_NAME>`. Unfortunately, the functionality is broken or not implemented https://github.com/actions/runner/issues/665

This PR contains workaround to fit the functionality.

Another fixed issue is that submodules have only default branch available to checkout. It is fixed by the command `git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"`