### PR TITLE
Artembo/push pull translations

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -16,6 +16,11 @@ jobs:
       TARANTOOL_UPDATE_URL: ${{secrets.TARANTOOL_DEV_UPDATE_URL}}
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Fetch submodules
+        run: git fetch --recurse-submodules
 
       - name: Set branch name from source branch
         run: echo "BRANCH_NAME=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV
@@ -29,8 +34,9 @@ jobs:
           env: "branch-${{env.BRANCH_NAME}}"
           ref: ${{github.head_ref}}
 
-      - run: bash update_submodules.sh
       - run: cmake .
+      - run: make pull-modules
+      - run: make build-modules
       - run: make json
       - run: make json-ru
       - run: curl ${{secrets.WAKEUP_URL}} --connect-timeout 300 --retry 3 --retry-delay 30 >> /dev/null

--- a/.github/workflows/destroy-deployment.yml
+++ b/.github/workflows/destroy-deployment.yml
@@ -1,4 +1,4 @@
-name: Destroy-deployment
+name: Destroy-deployments
 
 on:
   pull_request:
@@ -9,13 +9,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          curl -X DELETE -d '{"update_key":"${{secrets.TARANTOOL_UPDATE_KEY}}"}' -H "Content-Type: application/json" ${{secrets.TARANTOOL_DEV_UPDATE_URL}}${GITHUB_HEAD_REF##*/}/
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Remove dev server deployment
+      - name: Set branch name from source branch
+        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV
+
+      - run: |
+          curl -X DELETE -d '{"update_key":"${{secrets.TARANTOOL_UPDATE_KEY}}"}' -H "Content-Type: application/json" ${{secrets.TARANTOOL_DEV_UPDATE_URL}}${{env.BRANCH_NAME}}/
+
+      - name: Remove dev server deployment at branch-${{env.BRANCH_NAME}}
         uses: bobheadxi/deployments@v0.5.2
         id: deployment
         with:
           step: deactivate-env
           token: ${{secrets.GITHUB_TOKEN}}
-          env: "branch-${GITHUB_HEAD_REF##*/}"
+          env: "branch-${{env.BRANCH_NAME}}"
+
+      - name: Remove translation deployment at translate-${{env.BRANCH_NAME}}
+        uses: bobheadxi/deployments@v0.5.2
+        id: translation
+        with:
+          step: deactivate-env
+          token: ${{secrets.GITHUB_TOKEN}}
+          env: "translation-${{env.BRANCH_NAME}}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,15 @@ jobs:
       TARANTOOL_UPDATE_URL: ${{secrets.TARANTOOL_UPDATE_URL}}
     steps:
       - uses: actions/checkout@v2
-      - run: bash update_submodules.sh
+        with:
+          submodules: recursive
+
+      - name: Fetch submodules
+        run: git fetch --recurse-submodules
+
       - run: cmake .
+      - run: make pull-modules
+      - run: make build-modules
       - run: make json
       - run: make json-ru
       - run: make singlehtml

--- a/.github/workflows/pull-translation.yml
+++ b/.github/workflows/pull-translation.yml
@@ -1,0 +1,48 @@
+name: Pull translations
+
+on:
+  workflow_dispatch:
+    branches:
+      - '!1.10'
+
+jobs:
+  pull-translations:
+    runs-on: ubuntu-latest
+    container: tarantool/doc-builder:latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          token: "${{ secrets.TARANTOOLBOT_TOKEN }}"
+
+      - name: Set branch name from source branch
+        run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Update pot files
+        run: |
+          cmake .
+          make update-pot
+
+      - name: Pull translations from Crowdin
+        uses: crowdin/github-action@1.0.21
+        with:
+          upload_sources: false
+          upload_translations: false
+          push_translations: false
+          download_translations: true
+          download_language: 'ru'
+          crowdin_branch_name: "${{ env.BRANCH_NAME }}"
+          debug_mode: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Cleanup translation files
+        run: make cleanup-po
+
+      - name: Commit translation files
+        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        with:
+          commit_message: "Update translations"
+          file_pattern: "*.po"

--- a/.github/workflows/push-translation.yml
+++ b/.github/workflows/push-translation.yml
@@ -1,0 +1,53 @@
+name: Push translation sources
+
+on:
+  pull_request:
+    paths:
+      - 'doc/**/*.rst'
+      - 'conf.py'
+      - 'README.rst'
+      - '.github/workflows/push-translation.yml'
+jobs:
+  push-translation-sources:
+    runs-on: ubuntu-latest
+    container: tarantool/doc-builder:latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set branch name from source branch
+        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV
+
+      - name: Start translation service deployment
+        uses: bobheadxi/deployments@v0.5.2
+        id: translation
+        with:
+          step: start
+          token: ${{secrets.GITHUB_TOKEN}}
+          env: "translation-${{env.BRANCH_NAME}}"
+          ref: ${{github.head_ref}}
+
+      - name: Update POT files
+        run: |
+          cmake .
+          make update-pot
+
+      - name: Push POT files to crowdin
+        uses: crowdin/github-action@1.0.21
+        with:
+          upload_sources: true
+          upload_translations: false
+          crowdin_branch_name: "${{ env.BRANCH_NAME }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: update deployment status
+        uses: bobheadxi/deployments@v0.5.2
+        with:
+          step: finish
+          token: ${{secrets.GITHUB_TOKEN}}
+          status: ${{job.status}}
+          deployment_id: ${{steps.translation.outputs.deployment_id}}
+          env_url: https://crowdin.com/project/tarantool-docs/ru#/${{env.BRANCH_NAME}}

--- a/.github/workflows/upload-translations.yml
+++ b/.github/workflows/upload-translations.yml
@@ -1,4 +1,4 @@
-name: Update translation sources
+name: Update translations on the main branch
 
 on:
   workflow_dispatch:
@@ -6,9 +6,11 @@ on:
     branches:
       - "1.10"
     paths:
-      - 'doc/**.rst'
+      - 'doc/**/*.rst'
+      - 'locale/ru/**/*.po'
+      - 'crowdin.yaml'
 jobs:
-  autocommit-pot-files:
+  update-translations:
     runs-on: ubuntu-latest
     container: tarantool/doc-builder:v1
 
@@ -23,18 +25,13 @@ jobs:
     - name: Update pot files
       run: make update-pot
 
-    - name: Push Local Changes
-      uses: stefanzweifel/git-auto-commit-action@v4.1.2
-      with:
-        commit_message: "Update translation sources"
-        file_pattern: "*.pot"
-
     - name: Push Pot-files to crowdin
       uses: crowdin/github-action@1.0.21
       with:
+        crowdin_branch_name: '1.10'
         upload_sources: true
-        debug_mode: true
-        crowdin_branch_name: "1.10"
+        upload_translations: true
+        import_eq_suggestions: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ set(SPHINX_OUTPUT_DIR              "${CMAKE_CURRENT_BINARY_DIR}/output")
 
 set(SPHINX_BUILD_LOCALE_DIR        "${SPHINX_OUTPUT_DIR}/_locale_build/")
 
-set(SPHINX_BUILD_SINGLEHTML_DIR    "${SPHINX_OUTPUT_DIR}/_single_en/")
-set(SPHINX_BUILD_SINGLEHTML_RU_DIR "${SPHINX_OUTPUT_DIR}/_single_ru/")
+set(SPHINX_BUILD_SINGLEHTML_DIR    "${SPHINX_OUTPUT_DIR}/doctrees/single/en/")
+set(SPHINX_BUILD_SINGLEHTML_RU_DIR "${SPHINX_OUTPUT_DIR}/doctrees/single/ru/")
 
 set(SPHINX_BUILD_HTML_DIR          "${SPHINX_OUTPUT_DIR}/_html_en/")
 set(SPHINX_BUILD_HTML_RU_DIR       "${SPHINX_OUTPUT_DIR}/_html_ru/")
@@ -67,10 +67,11 @@ set(SPHINX_BUILD_HTML_RU_OLD_DIR       "${SPHINX_OUTPUT_DIR}/_html_old_ru/")
 set(SPHINX_BUILD_LATEX_DIR         "${SPHINX_OUTPUT_DIR}/_latex_en/")
 set(SPHINX_BUILD_LATEX_RU_DIR      "${SPHINX_OUTPUT_DIR}/_latex_ru/")
 
-set(SPHINX_BUILD_JSON_EN_DIR       "${SPHINX_OUTPUT_DIR}/json/_build_en/doctrees")
-set(SPHINX_BUILD_JSON_RU_DIR       "${SPHINX_OUTPUT_DIR}/json/_build_ru/doctrees")
+set(SPHINX_BUILD_JSON_EN_DIR       "${SPHINX_OUTPUT_DIR}/doctrees/json/en/")
+set(SPHINX_BUILD_JSON_RU_DIR       "${SPHINX_OUTPUT_DIR}/doctrees/json/ru")
 
 set(SPHINX_EN_HTML_DIR             "${SPHINX_OUTPUT_DIR}/html/en/")
+set(SPHINX_EN_AUTOBUILD_DIR        "${SPHINX_OUTPUT_DIR}/html_auto/en/")
 set(SPHINX_RU_HTML_DIR             "${SPHINX_OUTPUT_DIR}/html/ru/")
 set(SPHINX_EN_HTML_OLD_DIR         "${SPHINX_OUTPUT_DIR}/html_old/en/")
 set(SPHINX_RU_HTML_OLD_DIR         "${SPHINX_OUTPUT_DIR}/html_old/ru/")
@@ -91,6 +92,7 @@ add_custom_target(html ALL
         -b html
         -d "${SPHINX_BUILD_HTML_DIR}"
         -c html/
+        -q
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         "${SPHINX_EN_HTML_DIR}"
     COMMENT "Building HTML documentation with Sphinx"
@@ -101,6 +103,7 @@ add_custom_target(json ALL
         -b json
         -d "${SPHINX_BUILD_JSON_EN_DIR}"
         -c html/
+        -q
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         "${SPHINX_EN_JSON_DIR}"
         -D language=en
@@ -112,6 +115,7 @@ add_custom_target(singlehtml ALL
         -b singlehtml
         -d "${SPHINX_BUILD_SINGLEHTML_DIR}"
         -c singlehtml/
+        -q
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         "${SPHINX_EN_HTML_DIR}"
     COMMENT "Building HTML single-page documentation with Sphinx"
@@ -128,11 +132,25 @@ add_custom_target(singlehtml-website
     COMMENT "Building HTML single-page documentation with Sphinx"
 )
 
+add_custom_target(autobuild
+    COMMAND sphinx-autobuild
+        -b html
+        -d "${SPHINX_BUILD_HTML_DIR}"
+        -c html/
+        --host 0.0.0.0
+        --port 8000
+        -A nolang_path=true
+        "${CMAKE_CURRENT_SOURCE_DIR}/doc"
+        "${SPHINX_EN_AUTOBUILD_DIR}"
+    COMMENT "Build & Live-reload on http://127.0.0.1:8000"
+)
+
 add_custom_target(html-ru ALL
     COMMAND "${SPHINX_EXECUTABLE}"
         -b html
         -d "${SPHINX_BUILD_HTML_RU_DIR}"
         -c html/
+        -q
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         "${SPHINX_RU_HTML_DIR}"
         -D language=ru
@@ -166,6 +184,7 @@ add_custom_target(json-ru ALL
         -b json
         -d "${SPHINX_BUILD_JSON_RU_DIR}"
         -c html/
+        -q
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         "${SPHINX_RU_JSON_DIR}"
         -D language=ru
@@ -200,14 +219,10 @@ add_custom_target(update-pot
         -b gettext
         -d "${SPHINX_BUILD_LOCALE_DIR}"
         -c locale/
+        -q
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         "${CMAKE_CURRENT_SOURCE_DIR}/locale/en/"
-    COMMENT "Generate localization templates"
-)
-
-add_custom_command(TARGET update-pot
-    COMMAND make cleanup-pot
-    COMMENT "Update and cleanup translation sources"
+    COMMENT "Update translation sources"
 )
 
 add_custom_target(update-po-no-force
@@ -249,6 +264,7 @@ add_custom_target(linkcheck
         -b linkcheck
         -d "${SPHINX_BUILD_HTML_DIR}"
         -c html
+        -q
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         "${SPHINX_BUILD_HTML_DIR}"
     COMMENT "Linkcheck filter"
@@ -267,6 +283,7 @@ add_custom_target(epub ALL
         -b epub
         -d "${SPHINX_BUILD_EPUB_DIR}"
         -c epub/
+        -q
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         "${SPHINX_EN_EPUB_DIR}"
     COMMENT "Building English epub with Sphinx"
@@ -277,11 +294,25 @@ add_custom_target(epub-ru ALL
         -b epub
         -d "${SPHINX_BUILD_EPUB_RU_DIR}"
         -c epub/
+        -q
         -D language=ru
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
         "${SPHINX_RU_EPUB_DIR}"
     COMMENT "Building Russian epub with Sphinx"
 )
+
+add_custom_target(pull-modules ALL
+    COMMAND /usr/bin/env python3
+        ./pull_submodules.py
+    COMMENT "Update submodules to their latest commits"
+)
+
+add_custom_target(build-modules ALL
+    COMMAND /usr/bin/env bash
+        ./build_submodules.sh
+    COMMENT "Rebuild and copy content from submodules"
+)
+
 
 
 if (LATEX_FOUND)

--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 
-set -x
-
-mkdir -p ~/.ssh/
-ssh-keyscan github.com >> ~/.ssh/known_hosts
-git submodule init
-git submodule update
-git pull --recurse-submodules
-git submodule update --remote --merge
+set -xe
 
 project_root=$(pwd)
 echo "${project_root}"
@@ -23,26 +16,42 @@ cartridge_cli_dest="${rst_dest}/cartridge_cli"
 cartridge_cli_index_dest="${cartridge_cli_dest}/index.rst"
 monitoring_root="${project_root}/modules/metrics/doc/monitoring"
 monitoring_dest="${project_root}/doc/book"
-luatest_root="${project_root}/modules/luatest/"
+#monitoring_grafana_root="${project_root}/modules/grafana-dashboard/doc/monitoring"
+luatest_root="${project_root}/modules/luatest"
 luatest_dest="${project_root}/doc/reference/reference_rock/luatest"
 
 cartridge_kubernetes_root="${project_root}/modules/tarantool-operator/doc/cartridge_kubernetes_guide"
 cartridge_kubernetes_dest="${rst_dest}/"
 
+#tntcxx_root="${project_root}/modules/tntcxx"
+#tntcxx_gs_dest="${project_root}/doc/getting_started"
+#tntcxx_api_dest="${project_root}/doc/book/connectors"
+
+#cp README.rst doc/contributing/docs/_includes/README.rst
+
+mkdir -p "${luatest_dest}/_includes/"
 cd "${luatest_root}"
 ldoc --ext=rst --dir=rst --toctree="API" .
 cd "${luatest_dest}"
 yes | cp -fa "${luatest_root}/rst/." "${luatest_dest}"
 yes | cp "${luatest_root}/README.rst" "${luatest_dest}"
+yes | mv -f "${luatest_dest}/index.rst" "${luatest_dest}/_includes/"
 
-mkdir -p "${monitoring_dest}"
-yes | cp -rf "${monitoring_root}" "${monitoring_dest}/"
+#mkdir -p "${monitoring_dest}"
+#yes | cp -rf "${monitoring_root}" "${monitoring_dest}/"
+#yes | cp -rf "${monitoring_grafana_root}" "${monitoring_dest}/"
 
 mkdir -p "${cartridge_cli_dest}"
 yes | cp -rf "${cartridge_cli_root}/README.rst" "${cartridge_cli_index_dest}"
 
 mkdir -p "${cartridge_kubernetes_dest}"
 yes | cp -rf "${cartridge_kubernetes_root}" "${cartridge_kubernetes_dest}"
+
+#mkdir -p "${tntcxx_api_dest}/cxx/"
+#mkdir -p "${tntcxx_gs_dest}/_includes"
+#yes | cp -rf "${tntcxx_root}/doc/tntcxx_getting_started.rst" "${tntcxx_gs_dest}/getting_started_cxx.rst"
+#yes | cp -rf "${tntcxx_root}/examples/" "${tntcxx_gs_dest}/_includes/examples/"
+#yes | cp -rf "${tntcxx_root}/doc/tntcxx_api.rst" "${tntcxx_api_dest}/cxx/"
 
 cd "${cartridge_root}" || exit
 CMAKE_DUMMY_WEBUI=true tarantoolctl rocks make

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -4,7 +4,7 @@
 "project_id" : "442986"
 "base_path" : "./locale"
 "base_url": "https://crowdin.com"
-
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
 
 
 "preserve_hierarchy": true
@@ -20,5 +20,10 @@ files: [
       "ru" : "ru",
      }
   },
+
+  "ignore": [
+    "/en/singlehtml.*",
+    "/en/toctree.*",
+  ]
  }
 ]

--- a/locale/cleanup.py
+++ b/locale/cleanup.py
@@ -28,6 +28,11 @@ def cleanup_files(extension):
         po_file.header = ''
         po_file.metadata = {}
         po_file.metadata_is_fuzzy = False
+
+        for item in po_file:
+            # item: POEntry = item
+            item.occurrences = None
+
         po_file.save()
 
 

--- a/pull_submodules.py
+++ b/pull_submodules.py
@@ -1,0 +1,66 @@
+#! /usr/bin/env python3
+
+import os
+import subprocess
+
+
+modules_dir = 'modules'
+modules = {
+    'cartridge': 'INPUT_CARTRIDGE',
+    'cartridge-cli': 'INPUT_CARTRIDGE_CLI',
+    # 'grafana-dashboard': 'INPUT_GRAFANA',
+    'luatest': 'INPUT_LUATEST',
+    'metrics': 'INPUT_METRICS',
+    'tarantool-operator': 'INPUT_K8S_OPERATOR',
+    # 'tntcxx': 'INPUT_CPP_DRIVER',
+}
+workdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules')
+
+
+def main():
+    """
+    set -x
+
+    mkdir -p ~/.ssh/
+    ssh-keyscan github.com >> ~/.ssh/known_hosts
+    git submodule update --init
+    git fetch --recurse-submodules
+    git submodule update --remote --checkout
+    """
+
+    in_ci = os.environ.get("CI")
+    if not in_ci:
+        mkdir_p("~/.ssh/")
+        commands = "set -ex ;" \
+                   "ssh-keyscan github.com >> ~/.ssh/known_hosts ;" \
+                   "git submodule update --init ;" \
+                   "git fetch --recurse-submodules"
+
+        subprocess.check_call(commands, shell=True)
+
+    for directory, git_ref_variable in modules.items():
+        git_ref = os.environ.get(git_ref_variable, 'origin/master')
+        checkout_submodule(directory, git_ref)
+
+
+def checkout_submodule(directory, git_ref='origin/master'):
+    print(f'Checking out {directory} module into {git_ref}')
+    path = os.path.join(workdir, directory)
+    print(path)
+    subprocess.check_call('set -ex ; git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"', shell=True,
+                          cwd=path)
+    git_checkout = f'set -ex ; git remote update ; git checkout {git_ref}'
+    subprocess.check_call(git_checkout, shell=True,
+                          cwd=path)
+
+
+def mkdir_p(path):
+    """
+    Creates a directory with subdirectories, just like `mkdir -p path`
+    """
+    import pathlib
+    pathlib.Path(path).mkdir(parents=True, exist_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/upload_output.sh
+++ b/upload_output.sh
@@ -4,22 +4,24 @@ BRANCH=$BRANCH_NAME
 ENDPOINT_URL=$S3_ENDPOINT_URL
 S3_PATH=$S3_UPLOAD_PATH
 
+# don't upload the '*.pickle' files
+find output -name '*.pickle' -delete
+
 # upload json and images
-aws s3 rm $S3_PATH/$BRANCH/json --endpoint-url=$ENDPOINT_URL --recursive
-aws s3 cp output/json $S3_PATH/$BRANCH/json --endpoint-url=$ENDPOINT_URL --recursive --include "*" --exclude "*.jpg" --exclude "*.png" --exclude "*.svg"
-aws s3 cp output/json/_build_en/json/_images $S3_PATH/$BRANCH/images_en --endpoint-url=$ENDPOINT_URL --recursive
-aws s3 cp output/json/_build_ru/json/_images $S3_PATH/$BRANCH/images_ru --endpoint-url=$ENDPOINT_URL --recursive
+aws s3 sync output/json $S3_PATH/$BRANCH/json --endpoint-url=$ENDPOINT_URL --delete --include "*" --exclude "*.jpg" --exclude "*.png" --exclude "*.svg"
+aws s3 sync output/json/_build_en/json/_images $S3_PATH/$BRANCH/images_en --endpoint-url=$ENDPOINT_URL --delete --size-only
+aws s3 sync output/json/_build_ru/json/_images $S3_PATH/$BRANCH/images_ru --endpoint-url=$ENDPOINT_URL --delete --size-only
 
 # upload pdf files
 aws s3 cp --acl public-read output/_latex_en/Tarantool.pdf $S3_PATH/$BRANCH/Tarantool-en.pdf --endpoint-url=$ENDPOINT_URL
 aws s3 cp --acl public-read output/_latex_ru/Tarantool.pdf $S3_PATH/$BRANCH/Tarantool-ru.pdf --endpoint-url=$ENDPOINT_URL
 
 # upload singlehtml and assets
-aws s3 cp --acl public-read output/html/en/_static $S3_PATH/$BRANCH/en/_static --endpoint-url=$ENDPOINT_URL --recursive
-aws s3 cp --acl public-read output/html/en/_images $S3_PATH/$BRANCH/en/_images --endpoint-url=$ENDPOINT_URL --recursive
+aws s3 sync --acl public-read output/html/en/_static $S3_PATH/$BRANCH/en/_static --endpoint-url=$ENDPOINT_URL --delete --size-only
+aws s3 sync --acl public-read output/html/en/_images $S3_PATH/$BRANCH/en/_images --endpoint-url=$ENDPOINT_URL --delete --size-only
 aws s3 cp --acl public-read output/html/en/singlehtml.html $S3_PATH/$BRANCH/en/singlehtml.html --endpoint-url=$ENDPOINT_URL
-aws s3 cp --acl public-read output/html/ru/_static $S3_PATH/$BRANCH/ru/_static --endpoint-url=$ENDPOINT_URL --recursive
-aws s3 cp --acl public-read output/html/ru/_images $S3_PATH/$BRANCH/ru/_images --endpoint-url=$ENDPOINT_URL --recursive
+aws s3 sync --acl public-read output/html/ru/_static $S3_PATH/$BRANCH/ru/_static --endpoint-url=$ENDPOINT_URL --delete --size-only
+aws s3 sync --acl public-read output/html/ru/_images $S3_PATH/$BRANCH/ru/_images --endpoint-url=$ENDPOINT_URL --delete --size-only
 aws s3 cp --acl public-read output/html/ru/singlehtml.html $S3_PATH/$BRANCH/ru/singlehtml.html --endpoint-url=$ENDPOINT_URL
 
 curl --data '{"update_key":"'"$TARANTOOL_UPDATE_KEY"'"}' --header "Content-Type: application/json" --request POST "$TARANTOOL_UPDATE_URL""$BRANCH"/


### PR DESCRIPTION
Documentation sources are .rst files where a tech writer or a developer writes documentation. As soon as we have two languages supported on our website we need to maintain translated 100% of the documentation. For translation, we use Crowdin - saas solution for translating any texts.  
While a new PR with changes in .rst is opened, the translations for these changes are preparing by translators in Crowdin.  
When the translations are ready we can run __Pull translations__ job to download and commit translations into the PR branch.  
This diagram shows how the process works:
![crowdin-time-diagram](https://user-images.githubusercontent.com/23726173/124887107-8c53ca00-dfdd-11eb-9552-5154e469fa33.png)

- push-translation.yml push translation sources to Crowdin on pull request when .rst is changed, create a deployment with a link to Crowdin translations
- pull-translation.yml for getting translations from Crowdin on demand when translation is ready and auto-commit them into the same PR branch
- upload-translations.yml for upload translations to the master Crowdin branch from the git master branch
- destroy deployment with a link to Crowdin translations when the translations (in PR) are merged
- add cleanup.py for re-arranging .po files and make corresponding changes in CMakeLists.txt
- push translation for pushing sources to Crowdin on pull request when .rst is changed
- add pull-translation.yml for getting translations from Crowdin on demand when translation is ready
- copy pull_submodules.py from "latest" branch for consistency
