### PR TITLE
Fix typo: nill → nil

### DIFF
--- a/doc/reference/reference_rock/vshard/vshard_api.rst
+++ b/doc/reference/reference_rock/vshard/vshard_api.rst
@@ -710,7 +710,7 @@ Router public API
         :return:
 
             * result of ``function_name`` on success
-            * nill, err otherwise
+            * nil, err otherwise
 
     .. _router_api-replicaset_callrw:
 
@@ -738,7 +738,7 @@ Router public API
         :return:
 
             * result of ``function_name`` on success
-            * nill, err otherwise
+            * nil, err otherwise
 
         .. code-block:: lua
 
@@ -777,7 +777,7 @@ Router public API
         :return:
 
             * result of ``function_name`` on success
-            * nill, err otherwise
+            * nil, err otherwise
 
     .. _router_api-replicaset_callre:
 
@@ -806,7 +806,7 @@ Router public API
         :return:
 
             * result of ``function_name`` on success
-            * nill, err otherwise
+            * nil, err otherwise
 
 .. _vshard_api_reference-router_internal_api:
 

--- a/locale/ru/LC_MESSAGES/reference/reference_rock/vshard/vshard_api.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_rock/vshard/vshard_api.po
@@ -1089,7 +1089,7 @@ msgstr "массив аргументов функции"
 msgid "result of ``function_name`` on success"
 msgstr "результат вызываемой функции при успехе"
 
-msgid "nill, err otherwise"
+msgid "nil, err otherwise"
 msgstr "nil, err иначе"
 
 msgid ""


### PR DESCRIPTION
Fix #2339