### PR TITLE
Add libarchive to CentOS 8 section

### DIFF
--- a/doc/dev_guide/building_from_source.rst
+++ b/doc/dev_guide/building_from_source.rst
@@ -105,8 +105,8 @@ RHEL/CentOS 7
 
 ..  code-block:: console
 
-    $ yum install python-pip
-    $ yum install epel-release
+    $ yum install -y python-pip
+    $ yum install -y epel-release
 
     $ curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
 
@@ -139,10 +139,10 @@ CentOS 8
 
 ..  code-block:: console
 
-    $ dnf install epel-release
+    $ dnf install -y epel-release
 
-    $ dnf install -y git gcc cmake3 make gcc-c++ zlib-devel readline-devel \
-      ncurses-devel openssl-devel libunwind-devel libicu-devel \
+    $ dnf install -y git gcc cmake3 libarchive make gcc-c++ zlib-devel \
+      readline-devel ncurses-devel openssl-devel libunwind-devel libicu-devel \
       python3-pyyaml python3-six python3-gevent
 
     $ git clone https://github.com/tarantool/tarantool.git --recursive


### PR DESCRIPTION
Unfortunately the latest cmake does't work without libarchive nor does it install it as a dependancy (probably it's a bug, see https://programmerah.com/solved-cmake-symbol-lookup-error-cmake-undefined-symbol-archive_write_add_filter_zstd-32832/). So, we have to install it manually. Otherwise we get:

```
[vagrant@localhost ~]$ cmake
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd
```