### PR TITLE
Remove the "Other sources" panel

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,19 +81,3 @@
                 tutorials/index
                 contributing/index
                 release
-
-
-        .. container:: other-sources-menu
-
-            * **Other formats:**
-            * `Single-page HTML <singlehtml.html>`__
-            * `PDF <Tarantool.pdf>`__
-
-            - **See also:**
-            - `Documentation archive <https://tarantool.io/dist/pdf/>`__
-            - `Articles <https://tarantool.io/learn/>`__
-
-            * **Support:**
-            * `Google forum <https://groups.google.com/forum/#!forum/tarantool>`__
-            * `Telegram chat <https://t.me/tarantool>`__
-


### PR DESCRIPTION
Doesn't fit in the new layout.

Part of tarantool/tarantool.io#778