### PR TITLE
Add only .po for changed .rst files on pull-translations

### DIFF
--- a/.github/workflows/pull-translation.yml
+++ b/.github/workflows/pull-translation.yml
@@ -2,6 +2,11 @@ name: Pull translations
 
 on:
   workflow_dispatch:
+    inputs:
+      commit_po_for_unchanged_rst:
+        description: 'Update translations for unchanged .rst'
+        default: "false"
+        required: True
     branches:
       - '!latest'
 
@@ -14,6 +19,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: "${{ secrets.TARANTOOLBOT_TOKEN }}"
+          fetch-depth: 2
 
       - name: Set branch name from source branch
         run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
@@ -40,8 +46,16 @@ jobs:
       - name: Cleanup translation files
         run: make cleanup-po
 
+      - name: Set $CHANGED_POS for changed .rst files only
+        run: echo "CHANGED_POS=$(echo "$(git diff --name-only | grep .po | sed "s/.po//" | sed "s/locale\/ru\/LC_MESSAGES\///")" | awk -v rst="$(git diff-tree --no-commit-id --name-only -r HEAD | grep .rst | tr "\n" " ")" 'rst ~ $0{ print "locale/ru/LC_MESSAGES/"$0".po" }')" >> $GITHUB_ENV
+        if: ${{github.event.inputs.commit_po_for_unchanged_rst == 'false'}}
+
+      - name: Set $CHANGED_POS for all .rst files
+        run: echo "CHANGED_POS=.po" >> $GITHUB_ENV
+        if: ${{github.event.inputs.commit_po_for_unchanged_rst != 'false'}}
+
       - name: Commit translation files
         uses: stefanzweifel/git-auto-commit-action@v4.1.2
         with:
           commit_message: "Update translations"
-          file_pattern: "*.po"
+          file_pattern: "${{ env.CHANGED_POS }}"


### PR DESCRIPTION
When translation is ready Crowdin tends to download all
the translated .po files. It can be annoying when the
Crowdin branch has more changed files then it needed
for the current PR. It forces the author to clean PR manually.

The fixed pull-translation workflow contains a filter
which allows to add only corresponding .po files to
the changed .rst files in the current branch.

Closes #2434