### PR TITLE
[2pt] Add comparison table of Go connectors

### DIFF
--- a/doc/getting_started/getting_started_go.rst
+++ b/doc/getting_started/getting_started_go.rst
@@ -245,3 +245,185 @@ To send bare Lua code for execution, use ``Eval``:
 .. code-block:: go
 
     resp, err = connection.Eval("return 4 + 5", []interface{}{})
+
+.. _getting_started-go-comparison:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Feature comparison
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are two more connectors from open-source community available:
+`viciious/go-tarantool <https://github.com/viciious/go-tarantool>`_ and
+`FZambia/tarantool <https://github.com/FZambia/tarantool>`_. 
+
+Last update: January 2022
+
+..  list-table::
+    :header-rows: 1
+    :stub-columns: 1
+
+    *   -
+        -   `tarantool/go-tarantool <https://github.com/tarantool/go-tarantool>`_
+        -   `viciious/go-tarantool <https://github.com/viciious/go-tarantool>`_
+        -   `FZambia/tarantool <https://github.com/FZambia/tarantool>`_
+
+    *   -   License
+        -   BSD 2-Clause
+        -   MIT
+        -   BSD 2-Clause
+
+    *   -   Last update
+        -   2022
+        -   2021
+        -   2021
+
+    *   -   Documentation
+        -   README with examples, API described in code comments
+        -   README with examples, code comments
+        -   README with examples
+
+    *   -   Testing / CI / CD
+        -   GitHub Actions
+        -   Travis CI
+        -   GitHub Actions
+
+    *   -   GitHub Stars
+        -   127
+        -   43
+        -   12
+
+    *   -   Static analysis
+        -   No
+        -   golint
+        -   golangci-lint
+
+    *   -   Packaging
+        -   go get
+        -   go get
+        -   go get
+
+    *   -   Code coverage
+        -   No
+        -   No
+        -   No
+
+    *   -   msgpack driver
+        -   `vmihailenco/msgpack/v2 <https://github.com/vmihailenco/msgpack/tree/v2>`_ (`#124 <https://github.com/tarantool/go-tarantool/issues/124>`_)
+        -   `tinylib/msgp <https://github.com/tinylib/msgp>`_
+        -   `vmihailenco/msgpack/v5 <https://github.com/vmihailenco/msgpack/tree/v5>`_
+
+    *   -   Async work
+        -   Yes
+        -   Yes
+        -   Yes
+
+    *   -   Schema reload
+        -   Yes (manual pull)
+        -   Yes (manual pull)
+        -   Yes (manual pull)
+
+    *   -   Space / index names
+        -   Yes
+        -   Yes
+        -   Yes
+
+    *   -   Tuples as structures
+        -   Yes (structure and marshall functions must be predefined in Go code)
+        -   No
+        -   Yes (structure and marshall functions must be predefined in Go code)
+
+    *   -   Access tuple fields by names
+        -   Only if marshalled to structure
+        -   No
+        -   Only if marshalled to structure
+
+    *   -   `SQL <https://www.tarantool.io/en/doc/latest/reference/reference_sql/>`_ support
+        -   No (`#62 <https://github.com/tarantool/go-tarantool/issues/62>`_)
+        -   No (`#18 <https://github.com/viciious/go-tarantool/issues/18>`_, closed)
+        -   No
+
+    *   -   `Interactive transactions <https://www.tarantool.io/en/doc/latest/book/box/stream/>`_
+        -   No (`#101 <https://github.com/tarantool/go-tarantool/issues/101>`_)
+        -   No
+        -   No
+
+    *   -   `Varbinary <https://www.tarantool.io/en/doc/latest/book/box/data_model/>`_ support
+        -   Yes (with in-built language tools)
+        -   Yes (with in-built language tools)
+        -   Yes (decodes to string by default, see `#6 <https://github.com/FZambia/tarantool/issues/6>`_)
+
+    *   -   `UUID <https://www.tarantool.io/en/doc/latest/book/box/data_model/>`_ support
+        -   Yes
+        -   No
+        -   No
+
+    *   -   Decimal support
+        -   No (`#96 <https://github.com/tarantool/go-tarantool/issues/96>`_)
+        -   No
+        -   No
+
+    *   -   `EXT_ERROR <https://www.tarantool.io/ru/doc/latest/dev_guide/internals/msgpack_extensions/#the-error-type>`_
+            support
+        -   No
+        -   No
+        -   No
+
+    *   -   `Datetime <https://github.com/tarantool/tarantool/discussions/6244>`_ support
+        -   No (`#118 <https://github.com/tarantool/go-tarantool/issues/118>`_)
+        -   No
+        -   No
+
+    *   -   `box.session.push() responses <https://www.tarantool.io/ru/doc/latest/reference/reference_lua/box_session/push/>`_
+        -   No (`#67 <https://github.com/tarantool/go-tarantool/issues/67>`_)
+        -   No (`#21 <https://github.com/viciious/go-tarantool/issues/21>`_)
+        -   Yes
+
+    *   -   `Session settings <https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_space/_session_settings/>`_
+        -   No
+        -   No
+        -   No
+
+    *   -   `Graceful shutdown <https://github.com/tarantool/tarantool/issues/5924>`_
+        -   No
+        -   No
+        -   No
+
+    *   -   `IPROTO_ID (feature discovering) <https://github.com/tarantool/tarantool/issues/6253>`_
+        -   No
+        -   No
+        -   No
+
+    *   -   `tarantool/crud <https://github.com/tarantool/crud>`_ support
+        -   No
+        -   No
+        -   No
+
+    *   -   Connection pool
+        -   Yes (round-robin failover, no balancing, master discovering planned in `#113 <https://github.com/tarantool/go-tarantool/issues/113>`_)
+        -   No
+        -   No
+
+    *   -   Implicit reconnecting strategy
+        -   Yes (see comments in `#129 <https://github.com/tarantool/go-tarantool/issues/129>`_)
+        -   No (handle reconnects explicitly, refer to `#11 <https://github.com/viciious/go-tarantool/issues/11>`_)
+        -   Yes (see comments in `#7 <https://github.com/FZambia/tarantool/issues/7>`_)
+
+    *   -   Support retrying
+        -   No
+        -   No
+        -   No
+
+    *   -   `Watchers <https://github.com/tarantool/tarantool/pull/6510>`_
+        -   No
+        -   No
+        -   No
+
+    *   -   Language features
+        -   No  (`#48 <https://github.com/tarantool/go-tarantool/issues/48>`_)
+        -   context
+        -   context
+
+    *   -   Miscellanious
+        -   Supports `tarantool/queue <https://github.com/tarantool/queue>`_ API
+        -   Can mimic a Tarantool instance (also as replica)
+        -   API is experimental and breaking changes may happen

--- a/doc/getting_started/getting_started_go.rst
+++ b/doc/getting_started/getting_started_go.rst
@@ -403,12 +403,12 @@ Last update: January 2022
         -   No
         -   No
 
-    *   -   Implicit reconnecting strategy
+    *   -   Transparent reconnecting
         -   Yes (see comments in `#129 <https://github.com/tarantool/go-tarantool/issues/129>`_)
         -   No (handle reconnects explicitly, refer to `#11 <https://github.com/viciious/go-tarantool/issues/11>`_)
         -   Yes (see comments in `#7 <https://github.com/FZambia/tarantool/issues/7>`_)
 
-    *   -   Support retrying
+    *   -   Transparent request retrying
         -   No
         -   No
         -   No

--- a/doc/getting_started/getting_started_go.rst
+++ b/doc/getting_started/getting_started_go.rst
@@ -423,7 +423,7 @@ Last update: January 2022
         -   context
         -   context
 
-    *   -   Miscellanious
+    *   -   Miscellaneous
         -   Supports `tarantool/queue <https://github.com/tarantool/queue>`_ API
         -   Can mimic a Tarantool instance (also as replica)
         -   API is experimental and breaking changes may happen

--- a/doc/getting_started/getting_started_go.rst
+++ b/doc/getting_started/getting_started_go.rst
@@ -252,7 +252,7 @@ To send bare Lua code for execution, use ``Eval``:
 Feature comparison
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are two more connectors from open-source community available:
+There are two more connectors from the open-source community available:
 `viciious/go-tarantool <https://github.com/viciious/go-tarantool>`_ and
 `FZambia/tarantool <https://github.com/FZambia/tarantool>`_. 
 

--- a/locale/ru/LC_MESSAGES/getting_started/getting_started_go.po
+++ b/locale/ru/LC_MESSAGES/getting_started/getting_started_go.po
@@ -660,7 +660,7 @@ msgstr ""
 "<https://github.com/FZambia/tarantool/issues/7>`_)"
 
 msgid "Support retrying"
-msgstr "Поддержка повторной попытки подключения"
+msgstr "Повторная отправка запросов"
 
 msgid "`Watchers <https://github.com/tarantool/tarantool/pull/6510>`_"
 msgstr ""

--- a/locale/ru/LC_MESSAGES/getting_started/getting_started_go.po
+++ b/locale/ru/LC_MESSAGES/getting_started/getting_started_go.po
@@ -636,8 +636,8 @@ msgstr ""
 "мастера планируется в `#113 <https://github.com/tarantool/go-"
 "tarantool/issues/113>`_)"
 
-msgid "Implicit reconnecting strategy"
-msgstr "Стратегия повторного подключения по умолчанию"
+msgid "Transparent reconnecting"
+msgstr "Прозрачное переподключение"
 
 msgid ""
 "Yes (see comments in `#129 <https://github.com/tarantool/go-"
@@ -659,8 +659,8 @@ msgstr ""
 "Есть (см. комментарии к `#7 "
 "<https://github.com/FZambia/tarantool/issues/7>`_)"
 
-msgid "Support retrying"
-msgstr "Повторная отправка запросов"
+msgid "Transparent request retrying"
+msgstr "Прозрачная переотправка запроса"
 
 msgid "`Watchers <https://github.com/tarantool/tarantool/pull/6510>`_"
 msgstr ""

--- a/locale/ru/LC_MESSAGES/getting_started/getting_started_go.po
+++ b/locale/ru/LC_MESSAGES/getting_started/getting_started_go.po
@@ -372,3 +372,317 @@ msgstr ""
 
 msgid "resp, err = connection.Eval(\"return 4 + 5\", []interface{}{})"
 msgstr "resp, err = connection.Eval(\"return 4 + 5\", []interface{}{})"
+
+msgid "Feature comparison"
+msgstr "Сравнение функций"
+
+msgid ""
+"There are two more connectors from the open-source community available: "
+"`viciious/go-tarantool <https://github.com/viciious/go-tarantool>`_ and "
+"`FZambia/tarantool <https://github.com/FZambia/tarantool>`_."
+msgstr ""
+"Есть еще два доступных коннектора от опенсорс-сообщества: `viciious/go-"
+"tarantool <https://github.com/viciious/go-tarantool>`_ и `FZambia/tarantool "
+"<https://github.com/FZambia/tarantool>`_."
+
+msgid "Last update: January 2022"
+msgstr "Последнее обновление: январь 2022"
+
+msgid "`tarantool/go-tarantool <https://github.com/tarantool/go-tarantool>`_"
+msgstr "`tarantool/go-tarantool <https://github.com/tarantool/go-tarantool>`_"
+
+msgid "`viciious/go-tarantool <https://github.com/viciious/go-tarantool>`_"
+msgstr "`viciious/go-tarantool <https://github.com/viciious/go-tarantool>`_"
+
+msgid "`FZambia/tarantool <https://github.com/FZambia/tarantool>`_"
+msgstr "`FZambia/tarantool <https://github.com/FZambia/tarantool>`_"
+
+msgid "License"
+msgstr "Лицензия"
+
+msgid "BSD 2-Clause"
+msgstr "BSD 2-Clause"
+
+msgid "MIT"
+msgstr "MIT"
+
+msgid "Last update"
+msgstr "Последнее обновление"
+
+msgid "2022"
+msgstr "2022"
+
+msgid "2021"
+msgstr "2021"
+
+msgid "Documentation"
+msgstr "Документация"
+
+msgid "README with examples, API described in code comments"
+msgstr "README с примерами. Описание API в комментариях к коду."
+
+msgid "README with examples, code comments"
+msgstr "README с примерами и комментариями к коду"
+
+msgid "README with examples"
+msgstr "README с примерами"
+
+msgid "Testing / CI / CD"
+msgstr "Тестирование / CI / CD"
+
+msgid "GitHub Actions"
+msgstr "GitHub Actions"
+
+msgid "Travis CI"
+msgstr "Travis CI"
+
+msgid "GitHub Stars"
+msgstr "Звезды GitHub"
+
+msgid "127"
+msgstr "127"
+
+msgid "43"
+msgstr "43"
+
+msgid "12"
+msgstr "12"
+
+msgid "Static analysis"
+msgstr "Статический анализ"
+
+msgid "No"
+msgstr "Нет"
+
+msgid "golint"
+msgstr "golint"
+
+msgid "golangci-lint"
+msgstr "golangci-lint"
+
+msgid "Packaging"
+msgstr "Формат пакета"
+
+msgid "go get"
+msgstr "go get"
+
+msgid "Code coverage"
+msgstr "Покрытие кода"
+
+msgid "msgpack driver"
+msgstr "драйвер msgpack"
+
+msgid ""
+"`vmihailenco/msgpack/v2 <https://github.com/vmihailenco/msgpack/tree/v2>`_ "
+"(`#124 <https://github.com/tarantool/go-tarantool/issues/124>`_)"
+msgstr ""
+"`vmihailenco/msgpack/v2 <https://github.com/vmihailenco/msgpack/tree/v2>`_ "
+"(`#124 <https://github.com/tarantool/go-tarantool/issues/124>`_)"
+
+msgid "`tinylib/msgp <https://github.com/tinylib/msgp>`_"
+msgstr "`tinylib/msgp <https://github.com/tinylib/msgp>`_"
+
+msgid ""
+"`vmihailenco/msgpack/v5 <https://github.com/vmihailenco/msgpack/tree/v5>`_"
+msgstr ""
+"`vmihailenco/msgpack/v5 <https://github.com/vmihailenco/msgpack/tree/v5>`_"
+
+msgid "Async work"
+msgstr "Асинхронная работа"
+
+msgid "Yes"
+msgstr "Есть"
+
+msgid "Schema reload"
+msgstr "Обновление схемы"
+
+msgid "Yes (manual pull)"
+msgstr "Есть (запускается вручную)"
+
+msgid "Space / index names"
+msgstr "Имена спейсов/индексов"
+
+msgid "Tuples as structures"
+msgstr "Кортежи как структуры"
+
+msgid "Yes (structure and marshall functions must be predefined in Go code)"
+msgstr ""
+"Есть (структура и функции маршалинга должны быть предопределены в коде Go)"
+
+msgid "Access tuple fields by names"
+msgstr "Доступ к полям кортежей по именам"
+
+msgid "Only if marshalled to structure"
+msgstr "Только при маршалинге в структуру"
+
+msgid ""
+"`SQL <https://www.tarantool.io/en/doc/latest/reference/reference_sql/>`_ "
+"support"
+msgstr ""
+"Поддержка `SQL "
+"<https://www.tarantool.io/en/doc/latest/reference/reference_sql/>`_"
+
+msgid "No (`#62 <https://github.com/tarantool/go-tarantool/issues/62>`_)"
+msgstr "Нет (`#62 <https://github.com/tarantool/go-tarantool/issues/62>`_)"
+
+msgid ""
+"No (`#18 <https://github.com/viciious/go-tarantool/issues/18>`_, closed)"
+msgstr ""
+"Нет (`#18 <https://github.com/viciious/go-tarantool/issues/18>`_, тикет "
+"закрыт)"
+
+msgid ""
+"`Interactive transactions "
+"<https://www.tarantool.io/en/doc/latest/book/box/stream/>`_"
+msgstr ""
+"`Интерактивные транзакции "
+"<https://www.tarantool.io/en/doc/latest/book/box/stream/>`_"
+
+msgid "No (`#101 <https://github.com/tarantool/go-tarantool/issues/101>`_)"
+msgstr "Нет (`#101 <https://github.com/tarantool/go-tarantool/issues/101>`_)"
+
+msgid ""
+"`Varbinary <https://www.tarantool.io/en/doc/latest/book/box/data_model/>`_ "
+"support"
+msgstr ""
+"Поддержка `varbinary "
+"<https://www.tarantool.io/en/doc/latest/book/box/data_model/>`_"
+
+msgid "Yes (with in-built language tools)"
+msgstr "Есть (со встроенными инструментами языка)"
+
+msgid ""
+"Yes (decodes to string by default, see `#6 "
+"<https://github.com/FZambia/tarantool/issues/6>`_)"
+msgstr ""
+"Есть (декодирование в строку по умолчанию, см. `#6 "
+"<https://github.com/FZambia/tarantool/issues/6>`_)"
+
+msgid ""
+"`UUID <https://www.tarantool.io/en/doc/latest/book/box/data_model/>`_ "
+"support"
+msgstr ""
+"Поддержка `UUID "
+"<https://www.tarantool.io/en/doc/latest/book/box/data_model/>`_"
+
+msgid "Decimal support"
+msgstr "Поддержка типа данных decimal"
+
+msgid "No (`#96 <https://github.com/tarantool/go-tarantool/issues/96>`_)"
+msgstr "Нет (`#96 <https://github.com/tarantool/go-tarantool/issues/96>`_)"
+
+msgid ""
+"`EXT_ERROR "
+"<https://www.tarantool.io/ru/doc/latest/dev_guide/internals/msgpack_extensions/#the-"
+"error-type>`_ support"
+msgstr ""
+"Поддержка `EXT_ERROR "
+"<https://www.tarantool.io/ru/doc/latest/dev_guide/internals/msgpack_extensions/#the-"
+"error-type>`_"
+
+msgid ""
+"`Datetime <https://github.com/tarantool/tarantool/discussions/6244>`_ "
+"support"
+msgstr ""
+"Поддержка `datetime "
+"<https://github.com/tarantool/tarantool/discussions/6244>`_"
+
+msgid "No (`#118 <https://github.com/tarantool/go-tarantool/issues/118>`_)"
+msgstr "Нет (`#118 <https://github.com/tarantool/go-tarantool/issues/118>`_)"
+
+msgid ""
+"`box.session.push() responses "
+"<https://www.tarantool.io/ru/doc/latest/reference/reference_lua/box_session/push/>`_"
+msgstr ""
+"`Возвращаемые значения box.session.push() "
+"<https://www.tarantool.io/ru/doc/latest/reference/reference_lua/box_session/push/>`_"
+
+msgid "No (`#67 <https://github.com/tarantool/go-tarantool/issues/67>`_)"
+msgstr "Нет (`#67 <https://github.com/tarantool/go-tarantool/issues/67>`_)"
+
+msgid "No (`#21 <https://github.com/viciious/go-tarantool/issues/21>`_)"
+msgstr "Нет (`#21 <https://github.com/viciious/go-tarantool/issues/21>`_)"
+
+msgid ""
+"`Session settings "
+"<https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_space/_session_settings/>`_"
+msgstr ""
+"`Настройки сессии "
+"<https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_space/_session_settings/>`_"
+
+msgid ""
+"`Graceful shutdown <https://github.com/tarantool/tarantool/issues/5924>`_"
+msgstr ""
+"`Мягкое завершение <https://github.com/tarantool/tarantool/issues/5924>`_"
+
+msgid ""
+"`IPROTO_ID (feature discovering) "
+"<https://github.com/tarantool/tarantool/issues/6253>`_"
+msgstr ""
+"`IPROTO_ID (поиск поддерживаемых функций) "
+"<https://github.com/tarantool/tarantool/issues/6253>`_"
+
+msgid "`tarantool/crud <https://github.com/tarantool/crud>`_ support"
+msgstr "поддержка `tarantool/crud <https://github.com/tarantool/crud>`_"
+
+msgid "Connection pool"
+msgstr "Пул соединений"
+
+msgid ""
+"Yes (round-robin failover, no balancing, master discovering planned in `#113"
+" <https://github.com/tarantool/go-tarantool/issues/113>`_)"
+msgstr ""
+"Есть (циклическое переключение при сбое, без балансировки, алгоритм поиска "
+"мастера планируется в `#113 <https://github.com/tarantool/go-"
+"tarantool/issues/113>`_)"
+
+msgid "Implicit reconnecting strategy"
+msgstr "Стратегия повторного подключения по умолчанию"
+
+msgid ""
+"Yes (see comments in `#129 <https://github.com/tarantool/go-"
+"tarantool/issues/129>`_)"
+msgstr ""
+"Есть (см. комментарии к `#129 <https://github.com/tarantool/go-"
+"tarantool/issues/129>`_)"
+
+msgid ""
+"No (handle reconnects explicitly, refer to `#11 "
+"<https://github.com/viciious/go-tarantool/issues/11>`_)"
+msgstr ""
+"Нет (дескриптор переподключается явно, см. `#11 "
+"<https://github.com/viciious/go-tarantool/issues/11>`_)"
+
+msgid ""
+"Yes (see comments in `#7 <https://github.com/FZambia/tarantool/issues/7>`_)"
+msgstr ""
+"Есть (см. комментарии к `#7 "
+"<https://github.com/FZambia/tarantool/issues/7>`_)"
+
+msgid "Support retrying"
+msgstr "Поддержка повторной попытки подключения"
+
+msgid "`Watchers <https://github.com/tarantool/tarantool/pull/6510>`_"
+msgstr ""
+"`Наблюдатели (watchers) <https://github.com/tarantool/tarantool/pull/6510>`_"
+
+msgid "Language features"
+msgstr "Возможности языка"
+
+msgid "No  (`#48 <https://github.com/tarantool/go-tarantool/issues/48>`_)"
+msgstr "Нет (`#48 <https://github.com/tarantool/go-tarantool/issues/48>`_)"
+
+msgid "context"
+msgstr "контекст"
+
+msgid "Miscellanious"
+msgstr "Разное"
+
+msgid "Supports `tarantool/queue <https://github.com/tarantool/queue>`_ API"
+msgstr "Поддержка API `tarantool/queue <https://github.com/tarantool/queue>`_"
+
+msgid "Can mimic a Tarantool instance (also as replica)"
+msgstr "Может имитировать инстанс Tarantool (также как реплика)"
+
+msgid "API is experimental and breaking changes may happen"
+msgstr "Это экспериментальный API и он может значительно измениться"

--- a/locale/ru/LC_MESSAGES/getting_started/getting_started_go.po
+++ b/locale/ru/LC_MESSAGES/getting_started/getting_started_go.po
@@ -419,10 +419,10 @@ msgid "Documentation"
 msgstr "Документация"
 
 msgid "README with examples, API described in code comments"
-msgstr "README с примерами. Описание API в комментариях к коду."
+msgstr "README с примерами, описание API в комментариях к коду"
 
 msgid "README with examples, code comments"
-msgstr "README с примерами и комментариями к коду"
+msgstr "README с примерами, комментарии к коду"
 
 msgid "README with examples"
 msgstr "README с примерами"
@@ -437,7 +437,7 @@ msgid "Travis CI"
 msgstr "Travis CI"
 
 msgid "GitHub Stars"
-msgstr "Звезды GitHub"
+msgstr "GitHub-звезды"
 
 msgid "127"
 msgstr "127"
@@ -461,7 +461,7 @@ msgid "golangci-lint"
 msgstr "golangci-lint"
 
 msgid "Packaging"
-msgstr "Формат пакета"
+msgstr "Способ упаковки"
 
 msgid "go get"
 msgstr "go get"
@@ -470,7 +470,7 @@ msgid "Code coverage"
 msgstr "Покрытие кода"
 
 msgid "msgpack driver"
-msgstr "драйвер msgpack"
+msgstr "Драйвер msgpack"
 
 msgid ""
 "`vmihailenco/msgpack/v2 <https://github.com/vmihailenco/msgpack/tree/v2>`_ "
@@ -549,7 +549,7 @@ msgstr ""
 "<https://www.tarantool.io/en/doc/latest/book/box/data_model/>`_"
 
 msgid "Yes (with in-built language tools)"
-msgstr "Есть (со встроенными инструментами языка)"
+msgstr "Есть (встроенными инструментами языка)"
 
 msgid ""
 "Yes (decodes to string by default, see `#6 "
@@ -566,7 +566,7 @@ msgstr ""
 "<https://www.tarantool.io/en/doc/latest/book/box/data_model/>`_"
 
 msgid "Decimal support"
-msgstr "Поддержка типа данных decimal"
+msgstr "Поддержка decimal"
 
 msgid "No (`#96 <https://github.com/tarantool/go-tarantool/issues/96>`_)"
 msgstr "Нет (`#96 <https://github.com/tarantool/go-tarantool/issues/96>`_)"
@@ -619,11 +619,11 @@ msgid ""
 "`IPROTO_ID (feature discovering) "
 "<https://github.com/tarantool/tarantool/issues/6253>`_"
 msgstr ""
-"`IPROTO_ID (поиск поддерживаемых функций) "
+"`IPROTO_ID (обнаружение поддерживаемых функций) "
 "<https://github.com/tarantool/tarantool/issues/6253>`_"
 
 msgid "`tarantool/crud <https://github.com/tarantool/crud>`_ support"
-msgstr "поддержка `tarantool/crud <https://github.com/tarantool/crud>`_"
+msgstr "Поддержка `tarantool/crud <https://github.com/tarantool/crud>`_"
 
 msgid "Connection pool"
 msgstr "Пул соединений"
@@ -632,7 +632,7 @@ msgid ""
 "Yes (round-robin failover, no balancing, master discovering planned in `#113"
 " <https://github.com/tarantool/go-tarantool/issues/113>`_)"
 msgstr ""
-"Есть (циклическое переключение при сбое, без балансировки, алгоритм поиска "
+"Есть (циклическое восстановление после сбоев; без балансировки; обнаружение "
 "мастера планируется в `#113 <https://github.com/tarantool/go-"
 "tarantool/issues/113>`_)"
 
@@ -673,16 +673,16 @@ msgid "No  (`#48 <https://github.com/tarantool/go-tarantool/issues/48>`_)"
 msgstr "Нет (`#48 <https://github.com/tarantool/go-tarantool/issues/48>`_)"
 
 msgid "context"
-msgstr "контекст"
+msgstr "context"
 
-msgid "Miscellanious"
-msgstr "Разное"
+msgid "Miscellaneous"
+msgstr "Прочее"
 
 msgid "Supports `tarantool/queue <https://github.com/tarantool/queue>`_ API"
 msgstr "Поддержка API `tarantool/queue <https://github.com/tarantool/queue>`_"
 
 msgid "Can mimic a Tarantool instance (also as replica)"
-msgstr "Может имитировать инстанс Tarantool (также как реплика)"
+msgstr "Может имитировать экземпляр Tarantool (в том числе реплику)"
 
 msgid "API is experimental and breaking changes may happen"
-msgstr "Это экспериментальный API и он может значительно измениться"
+msgstr "API коннектора экспериментальный и может значительно измениться"


### PR DESCRIPTION
Compare features of our own tarantool/go-tarantool connector with two open-source connectors: [viciious/go-tarantool](https://github.com/viciious/go-tarantool) and [FZambia/tarantool](https://github.com/FZambia/tarantool).