### PR TITLE
Move one-line po-files detector to a script file

### DIFF
--- a/.github/workflows/pull-translation.yml
+++ b/.github/workflows/pull-translation.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: "${{ secrets.TARANTOOLBOT_TOKEN }}"
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Set branch name from source branch
         run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
@@ -47,15 +47,20 @@ jobs:
         run: make cleanup-po
 
       - name: Set $CHANGED_POS for changed .rst files only
-        run: echo "CHANGED_POS=$(echo "$(git diff --name-only | grep .po | sed "s/.po//" | sed "s/locale\/ru\/LC_MESSAGES\///")" | awk -v rst="$(git diff-tree --no-commit-id --name-only -r HEAD | grep .rst | tr "\n" " ")" 'rst ~ $0{ print "locale/ru/LC_MESSAGES/"$0".po" }')" >> $GITHUB_ENV
+        shell: bash
+        run: |
+          set -x
+          . list_changed_po.sh
+          if [ -z "${CHANGED_POS}" ]; then exit 1; fi
+          echo "CHANGED_POS=${CHANGED_POS}" >> $GITHUB_ENV
         if: ${{github.event.inputs.commit_po_for_unchanged_rst == 'false'}}
 
       - name: Set $CHANGED_POS for all .rst files
-        run: echo "CHANGED_POS=.po" >> $GITHUB_ENV
+        run: echo "CHANGED_POS=*.po" >> $GITHUB_ENV
         if: ${{github.event.inputs.commit_po_for_unchanged_rst != 'false'}}
 
       - name: Commit translation files
-        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        uses: stefanzweifel/git-auto-commit-action@v4.12.0
         with:
           commit_message: "Update translations"
           file_pattern: "${{ env.CHANGED_POS }}"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ locale/**/*.mo
 _*_build/
 deploy_key
 .venv
+venv
 output
 *.pyc
 _theme/tarantool/static/design.css.map

--- a/list_changed_po.sh
+++ b/list_changed_po.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# The root directory of .po files
+locale_path=locale/ru/LC_MESSAGES/
+
+ESCAPED_REPLACE=$(printf '%s\n' "$locale_path" | sed -e 's/[\/&]/\\&/g')
+
+unset CHANGED_POS
+
+get_git_diff () {
+  echo "$(git diff --name-only ; git ls-files . --exclude-standard --others)"
+}
+
+get_changed_po () {
+  changed_po_files="$(get_git_diff | grep \\.po)"
+  if [ -z "${changed_po_files}" ]; then
+    echo "ERROR: changed .po files not found"
+    return
+  fi
+  echo "$(get_git_diff | grep \\.po)"
+}
+
+get_po_base_names () {
+  echo "$(get_changed_po | sed "s/.po//" | sed "s/$ESCAPED_REPLACE//")"
+}
+
+get_rst_from_diff () {
+  echo $(git diff-tree --no-commit-id --name-only -r HEAD..origin/latest | grep .rst)
+}
+
+echo "* Getting changed .po files:"
+changed_po="$(get_changed_po)"
+echo $changed_po
+
+echo
+echo "* Getting a list of .rst files to compare with changed .po files:"
+rst_from_diff=$(get_rst_from_diff)
+echo $rst_from_diff
+
+echo
+echo "* Filtering corresponding .po files to the changed .rst in the closest commit:"
+po_files_to_commit=$(get_po_base_names | awk -v rst="$rst_from_diff" -v locale_path=$locale_path 'rst ~ $0{ printf locale_path; print ""$0".po" }')
+echo $po_files_to_commit
+
+if [ -n "${po_files_to_commit}" ]; then
+  export CHANGED_POS="$(echo $po_files_to_commit | tr "\n" " ")"
+else
+  echo "ERROR: could not find any matched po file to commit"
+fi


### PR DESCRIPTION
Move one-line bash, which detects changed .po files command to a script file.