### PR TITLE
fix brew install option

### DIFF
--- a/doc/dev_guide/building_from_source.rst
+++ b/doc/dev_guide/building_from_source.rst
@@ -183,7 +183,7 @@ if you use MacPorts.
 
     $ git submodule update --init --recursive
 
-    $ brew install -y git openssl readline curl icu4c libiconv zlib cmake
+    $ brew install git openssl readline curl icu4c libiconv zlib cmake
 
     $ pip install --user -r test-run/requirements.txt
 


### PR DESCRIPTION
There is no brew '-y' option. It raises 'Error: invalid option: -y'

Close #2346