### PR TITLE
Add human-readable anchor link to Python connectors table

### DIFF
--- a/doc/book/connectors/__go.rst
+++ b/doc/book/connectors/__go.rst
@@ -10,6 +10,8 @@ The following connectors are available:
 
 *   Community-supported `FZambia/tarantool <https://github.com/FZambia/tarantool>`_.
 
+..  _go-feature-comparison:
+
 Feature comparison
 ------------------
 

--- a/doc/book/connectors/__python.rst
+++ b/doc/book/connectors/__python.rst
@@ -49,6 +49,8 @@ The table below contains a feature comparison for asynctnt, gtarantool and
 tarantool-python. aiotarantool is absent there because it is quite outdated and
 unmaintained.
 
+..  _python-feature-comparison:
+
 Feature comparison
 ------------------
 


### PR DESCRIPTION
link is `#python-feature-comparison`:

https://develop.tarantool.io/en/doc/add-python-connector-comparison-link/book/connectors/#python-feature-comparison

Requested by @Totktonada 