### PR TITLE
Use :code: as the default Sphinx role

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'ext.CustomJSONBuilder',
 ]
 
+default_role = 'code'
 
 imgmath_image_format = 'svg'
 


### PR DESCRIPTION
In sources coming from Lua code, inline code is formatted with
single backticks, as in Markdown.
In Sphinx, single backticks mark text with a "default" role,
which by default is None, resulting in a cursive formatting.
This change makes :code: the default role in this Sphinx project,
resulting in all text `like this` formatted as inline code.

https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-default_role

Related to #1532