### PR TITLE
Fix 1.10.7 release date

### DIFF
--- a/doc/release/1.10.7.rst
+++ b/doc/release/1.10.7.rst
@@ -3,7 +3,7 @@ Tarantool 1.10.7
 
 Release: :tarantool-release:`1.10.7`
 
-Date: 2019-07-17 Tag: 1.10.7-1-gb93a33a
+Date: 2020-07-17 Tag: 1.10.7-1-gb93a33a
 
 Overview
 --------


### PR DESCRIPTION
Changed 1.10.7 release date from 2019 to 2020, now it's correct