### PR TITLE
Change 'Cluster' to 'Cartridge' in the main menu

### DIFF
--- a/doc/toctree.rst
+++ b/doc/toctree.rst
@@ -13,7 +13,7 @@
     book/box/authentication
     book/box/triggers
     reference/reference_rock/vshard/vshard_index
-    Cartridge <book/cartridge/index>
+    Cluster on Cartridge <book/cartridge/index>
     book/app_server/index
     book/admin/index
     book/replication/index

--- a/doc/toctree.rst
+++ b/doc/toctree.rst
@@ -13,7 +13,7 @@
     book/box/authentication
     book/box/triggers
     reference/reference_rock/vshard/vshard_index
-    Cluster <book/cartridge/index>
+    Cartridge <book/cartridge/index>
     book/app_server/index
     book/admin/index
     book/replication/index


### PR DESCRIPTION
Resolves #1996

Small changes to the Cartridge doc index page: https://github.com/tarantool/cartridge/pull/1774