### PR TITLE
Compatibility guarantees for updating Tarantool 

### DIFF
--- a/doc/book/admin/upgrades.rst
+++ b/doc/book/admin/upgrades.rst
@@ -4,6 +4,9 @@
 Upgrades
 ================================================================================
 
+For information about backwards compatibility,
+see the :ref:`compatibility guarantees <compatibility_guarantees>` description.
+
 .. _admin-upgrades_db:
 
 --------------------------------------------------------------------------------

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -2,7 +2,7 @@ Compatibility guarantees
 ========================
 
 Backwards compatibility is guaranteed between all versions in the same :term:`release series`.
-It is also appreciated, but not guaranteed between different release series (major number changes).
+It is also appreciated but not guaranteed between different release series (major number changes).
 
 *   Pre-releases and releases of one release series are compatible in all
     senses defined below (any release with any release).
@@ -23,14 +23,14 @@ Binary data layout
 A newer release (its runtime) is backward compatible with an older one.
 It means a more recent release should work on top of data
 (``*.xlog``, ``*.snap``, ``*.vylog``, ``*.run``) from the older one.
-All functionality that is part of the older release is working in this configuration.
+All functionality of the older release is working in this configuration.
 It should work between :term:`release series` as well.
 
 An attempt to use a new feature results in one of these options:
 
 *   The attempt is successful.
 
-*   There is meaningful error about the old data layout until the database schema upgrade.
+*   There is a meaningful error about the old data layout until the database schema upgrade.
     It does not lead to a service outage or data corruption.
     An instance can upgrade the data layout using the :ref:`box.schema.upgrade() <admin-upgrades>` call
     to enable all new release features (when all instances of the replicaset are run on the same Tarantool version).
@@ -46,7 +46,7 @@ Responses have the same format, but mappings may contain fields not present in t
 ``net.box`` client of the older release is able to work
 with the newer one, except the features introduced in the newer release.
 ``net.box`` client of the newer release is fully operational with the server
-running under the older one, except the features that are not implemented in the older release.
+running under the older one, except the features not implemented in the older release.
 
 Replication protocol
 --------------------
@@ -66,10 +66,10 @@ Lua code
 
 If a code is run on an older release, it will operate with the same effect on a
 newer one. However, only meaningful code counts.
-If any code throws an error, but starts doing something useful, the change is considered compatible.
+If any code throws an error but starts doing something useful, the change is considered compatible.
 
-A room for new functionality is still here. It is poddible to add new options, more
-fields to a returning table and more returning values (multireturn).
+A room for new functionality is still here: adding new options, more
+fields to a returning table, and more returning values (multireturn).
 
 Adding a new built-in module or a new global value is considered as the compatible change.
 
@@ -96,23 +96,25 @@ SQL code
 If any request is run with the same effect, the change is
 compatible (except the requests that always lead to an error).
 
-What is okay:
+Examples of compatible changes:
 
-Add a new keyword.
-Add a new type.
-Add a new built-in function.
-Add a new system table that starts from underscore.
-Add a new collation.
-Technically those changes may break a working code in case of a name clash,
-but the probability of this situation is considered as negligible. (We can
-restrict this rule in a future.)
+*   Add a new keyword.
+*   Add a new type.
+*   Add a new built-in function.
+*   Add a new system table that starts from underscore.
+*   Add a new collation.
+*   Add an implicit or explicit cast rule for a set of operations {X} and a list
+    of types [Y] if [operation from {X}]([list of values of [Y] types]) had no
+    meaning before the change.
 
+Technically, those changes may break a working code in case of a name clash,
+but the probability of it is negligible.
 
 Examples of NOT compatible changes:
 
-Change how data is stored in the database.
-Change how type arithmetic works (say, implicit casting rules).
-Change of a literal type.
+*   Change how data is stored in the database.
+*   Change the result of working implicit or explicit cast.
+*   Change of a literal type.
 
 C code
 ------
@@ -120,10 +122,10 @@ C code
 If a module or a C stored procedure is run on an older release,
 it will operate with the same effect on a newer one.
 
-It is okay to add a new function or a new structure to the public C API.
+It is okay to add a new function or structure to the public C API.
 It must use one of the Tarantool prefixes (``box_``, ``fiber_``, ``luaT_``, ``luaM_`` and so on) or introduce a new one.
 
-A symbol from a used library must not be exported directly,
+A symbol from a used library must not be exported directly
 because the library may be used in a module by itself, and the clash can lead to problems.
 Exception: when the whole public API of the library is exported (as for libcurl).
 

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -65,7 +65,7 @@ An instance running on a newer release can work as:
 
 The database schema upgrade (``box.schema.upgrade()``) must be performed when all replicaset instances
 run on the same Tarantool version.
-The upgrade might cause downtime if the application leans on internal schema representation.
+An application should not lean on internal schema representation because it can be changed with the upgrade.
 
 ..  _cg_lua_code:
 

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -5,9 +5,8 @@ Compatibility guarantees
 
 Backwards compatibility is guaranteed between all versions in the same :term:`release series`.
 It is also appreciated but not guaranteed between different release series (major number changes).
-
-*   Pre-releases and releases of one release series are compatible in all
-    senses defined below (any release with any release).
+Pre-releases and releases of one release series are compatible in all
+senses defined below (any release with any release):
 
 *   Pre-releases and releases of consequent series are compatible by data
     layout, binary protocol, and replication protocol.

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -10,7 +10,7 @@ It is also appreciated but not guaranteed between different release series (majo
     senses defined below (any release with any release).
 
 *   Pre-releases and releases of consequent series are compatible by data
-    layout, binary protocol and replication protocol.
+    layout, binary protocol, and replication protocol.
 
 *   No guarantees are given regarding compatibility between
     pre-releases/releases of non-consequent release series if the opposite
@@ -24,13 +24,13 @@ It is also appreciated but not guaranteed between different release series (majo
 Binary data layout
 ------------------
 
-A newer release (its runtime) is backward compatible with an older one.
-It means a more recent release should work on top of data
+Any newer release (its runtime) is backward compatible with any older one.
+It means the more recent release can work on top of data
 (``*.xlog``, ``*.snap``, ``*.vylog``, ``*.run``) from the older one.
-All functionality of the older release is working in this configuration.
-It should work between :term:`release series` as well.
+All functionality of the older release can work in this configuration.
+The same compatibility is maintained between :term:`release series` as well.
 
-An attempt to use a new feature results in one of these options:
+An attempt to use a new feature results in one of the options:
 
 *   The attempt is successful.
 

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -94,7 +94,7 @@ Examples of compatible changes:
 *   Add or extend the ``__lt`` or ``__le`` metamethod
     (if the attempt to use ``<``, ``<=`` etc. leads to an error before the change).
 
-*   Extend existing `__eq` metamethod implementation
+*   Extend existing ``__eq`` metamethod implementation
     (if the attempt to use it leads to an error before the change).
 
 Examples of **incompatible** changes:
@@ -123,7 +123,7 @@ Examples of compatible changes:
 *   Add an implicit or explicit cast rule for a set of operations {X} and a list
     of types [Y] if [operation from {X}]([list of values of [Y] types]) had not been
     implemented before the change.
-*   Change the order of tuples in the resultset of ``SELECT` in case `ORDER BY` is not specified.
+*   Change the order of tuples in the result set of ``SELECT`` in case ``ORDER BY`` is not specified.
 
 Technically, those changes may break some working code in case of a name clash,
 but the probability of it is negligible.

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -34,36 +34,35 @@ An attempt to use a new feature results in one of the options:
 
 *   The attempt is successful.
 
-*   There is a meaningful error about the old data layout until the database schema upgrade.
-    It does not lead to a service outage or data corruption.
-    An instance can upgrade the data layout using the :ref:`box.schema.upgrade() <admin-upgrades>` call
-    to enable all new release features (when all instances of the replicaset are run on the same Tarantool version).
+*   There is an error message about the old data layout.
+    The error does not lead to service outage or data corruption.
+    There is a way to avoid the message, if an instance upgrades the data layout
+    by calling the :ref:`box.schema.upgrade() <admin-upgrades>`. The call enables
+    all new release features (when all instances of the replicaset are processed on the same Tarantool version).
 
 ..  _cg_binary_protocol:
 
 Binary protocol
 ---------------
 
-The binary protocol evolves without breaking compatibility with old clients.
-All binary protocol requests operational in an older release should work on a newer one.
-They do not change the meaning.
+All binary protocol requests operational in an older release keep working in a newer one.
 Responses have the same format, but mappings may contain fields not present in the older release.
 
-``net.box`` client of the older release is able to work
-with the newer one, except the features introduced in the newer release.
-``net.box`` client of the newer release is fully operational with the server
-running under the older one, except the features not implemented in the older release.
+A ``net.box`` client of an older release can work
+with a server running a newer release. However, ``net.box`` features introduced in the newer release won't work.
+A ``net.box`` client of a newer release is fully operational with a server
+running a older release. However, only the features implemented in the older release will work.
 
 ..  _cg_replication_protocol:
 
 Replication protocol
 --------------------
 
-An instance run on a newer release may work as:
+An instance running on a newer release can work as:
 
 *   upstream (master) of an instance with an older release
 
-*   downstream (replica) without a database schema upgrade.
+*   downstream (replica) without database schema upgrade.
 
 The database schema upgrade (``box.schema.upgrade()``) must be performed when all replicaset instances
 run on the same Tarantool version.
@@ -74,31 +73,33 @@ The upgrade does not cause downtime if the application does not lean on internal
 Lua code
 --------
 
-If a code is run on an older release, it will operate with the same effect on a
+If a code is processed on an older release, it will operate with the same effect on a
 newer one. However, only meaningful code counts.
 If any code throws an error but starts doing something useful, the change is considered compatible.
 
-A room for new functionality is still here: adding new options, more
-fields to a returning table, and more returning values (multireturn).
+There is still room for new functionality: adding new options, more
+fields to a return table, and more return values (multireturn).
 
-Adding a new built-in module or a new global value is considered as the compatible change.
+Adding a new built-in module or a new global value is considered as a compatible change.
 
-Adding a new field to an existing metatable is okay if it is not listed in the Lua 5.1 Reference Manual. Otherwise, it should be proven that it may not break any meaningful code.
+Adding a new field to an existing metatable is okay if it is not listed
+in the `Lua 5.1 Reference Manual <https://www.lua.org/manual/5.1/>`_.
+Otherwise, it should be proven that it won't break any meaningful code.
 
 Examples of compatible changes:
 
-*   Add ``__pairs``, ``__ipairs`` to a metatable of a userdata.
+*   Add ``__pairs``, ``__ipairs`` to a metatable of a userdata object.
     It is not from Lua 5.1, and the userdata has no default behaviour for ``pairs()`` and `ipairs()` calls.
 
-*   Add ``__lt``, ``__le`` metamethod
-    (if the attempt to use ``<``, ``<=`` and so on leads to an error before the change).
+*   Add the ``__lt`` or ``__le`` metamethod
+    (if the attempt to use ``<``, ``<=`` etc. leads to an error before the change).
 
-Examples of NOT compatible changes:
+Examples of **incompatible** changes:
 
 *   Add ``__pairs``, ``__ipairs`` to a metatable of a table or cdata
-    (it already has its own behavior before the change).
+    (it already has a defined behavior before the change).
 
-*   Add ``__eq`` metamethod (``==`` already returns some result`).
+*   Add the ``__eq`` metamethod (``==`` already returns some result`).
 
 
 ..  _cg_sql_code:
@@ -106,24 +107,24 @@ Examples of NOT compatible changes:
 SQL code
 --------
 
-If any request is run with the same effect, the change is
-compatible (except the requests that always lead to an error).
+If any request is processed on an older release, it will operate with the same effect on a
+newer one (except the requests that always lead to an error).
 
 Examples of compatible changes:
 
 *   Add a new keyword.
 *   Add a new type.
 *   Add a new built-in function.
-*   Add a new system table that starts from underscore.
+*   Add a new system table that has a name starting with an underscore.
 *   Add a new collation.
 *   Add an implicit or explicit cast rule for a set of operations {X} and a list
     of types [Y] if [operation from {X}]([list of values of [Y] types]) had no
     meaning before the change.
 
-Technically, those changes may break a working code in case of a name clash,
+Technically, those changes may break some working code in case of a name clash,
 but the probability of it is negligible.
 
-Examples of NOT compatible changes:
+Examples of **incompatible** changes:
 
 *   Change how data is stored in the database.
 *   Change the result of working implicit or explicit cast.
@@ -134,7 +135,7 @@ Examples of NOT compatible changes:
 C code
 ------
 
-If a module or a C stored procedure is run on an older release,
+If a module or a C stored procedure runs on an older release,
 it will operate with the same effect on a newer one.
 
 It is okay to add a new function or structure to the public C API.
@@ -146,5 +147,5 @@ Exception: when the whole public API of the library is exported (as for libcurl)
 
 Do not introduce new functions or structures with the ``lua_`` and ``luaL_`` prefixes.
 Those prefixes are for the Lua runtime.
-Use ``luaT_`` for Tarantool specific functions, and ``luaM_`` for general-purpose ones.
+Use ``luaT_`` for Tarantool-specific functions, and ``luaM_`` for general-purpose ones.
 

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -1,8 +1,6 @@
 Compatibility guarantees
 ========================
 
-This chapter consists of six parts.
-
 Backward compatibility (binary data layout)
 -------------------------------------------
 
@@ -17,31 +15,30 @@ An attempt to use a new feature results in one of these options:
 
 *   There is meaningful error about the old data layout until the database schema upgrade.
     It does not lead to a service outage or data corruption.
-    An instance can upgrade the data layout using the ``box.schema.upgrade()`` call
+    An instance can upgrade the data layout using the :ref:`box.schema.upgrade() <admin-upgrades>` call
     to enable all new release features (when all instances of the replicaset are run on the same Tarantool version).
 
 Backward compatibility (binary protocol)
 ----------------------------------------
 
-All binary protocol requests that were operational in an older release are
-remain operational on a newer release and does not change meaning. Responses
-have the same format, but mappings may have fields that were not present in
-the older release.
+All binary protocol requests operational in an older release should work on a newer one.
+They do not change the meaning.
+Responses have the same format, but mappings may contain fields not present in the older release.
 
-net.box client of the older release able to work with the newer release
-(except, maybe, functionality introduced in the newer release). net.box
-client of the newer release is fully operational with the server that is run
-under the older release (except, maybe, functionality that the older release
-does not implement).
+``net.box`` client of the older release is able to work
+with the newer one, except the features introduced in the newer release.
+``net.box`` client of the newer release is fully operational with the server
+running under the older one, except the features that are not implemented in the older release.
 
 Backward compatibility (replication protocol)
 ---------------------------------------------
 
-A instance that is run on a newer release may work as upstream (master) of an
-instance with an older release or as downstream (replica) without database
-schema upgrade.
+An instance run on a newer release may work as:
 
-The database schema upgrade (box.schema.upgrade()) must be performed when
-all replicaset instances run on the same tarantool version. The upgrade does
-not cause downtime (if the application does not lean on internal schema
-representation).
+*   upstream (master) of an instance with an older release
+
+*   downstream (replica) without a database schema upgrade.
+
+The database schema upgrade (``box.schema.upgrade()``) must be performed when all replicaset instances
+run on the same Tarantool version.
+The upgrade does not cause downtime if the application does not lean on internal schema representation.

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -1,0 +1,47 @@
+Compatibility guarantees
+========================
+
+This chapter consists of six parts.
+
+Backward compatibility (binary data layout)
+-------------------------------------------
+
+A newer release (its runtime) is backward compatible with an older one.
+It means a more recent release should work on top of data
+(``*.xlog``, ``*.snap``, ``*.vylog``, ``*.run``) from the older one.
+All functionality that is part of the older release is working in this configuration.
+
+An attempt to use a new feature results in one of these options:
+
+*   The attempt is successful.
+
+*   There is meaningful error about the old data layout until the database schema upgrade.
+    It does not lead to a service outage or data corruption.
+    An instance can upgrade the data layout using the ``box.schema.upgrade()`` call
+    to enable all new release features (when all instances of the replicaset are run on the same Tarantool version).
+
+Backward compatibility (binary protocol)
+----------------------------------------
+
+All binary protocol requests that were operational in an older release are
+remain operational on a newer release and does not change meaning. Responses
+have the same format, but mappings may have fields that were not present in
+the older release.
+
+net.box client of the older release able to work with the newer release
+(except, maybe, functionality introduced in the newer release). net.box
+client of the newer release is fully operational with the server that is run
+under the older release (except, maybe, functionality that the older release
+does not implement).
+
+Backward compatibility (replication protocol)
+---------------------------------------------
+
+A instance that is run on a newer release may work as upstream (master) of an
+instance with an older release or as downstream (replica) without database
+schema upgrade.
+
+The database schema upgrade (box.schema.upgrade()) must be performed when
+all replicaset instances run on the same tarantool version. The upgrade does
+not cause downtime (if the application does not lean on internal schema
+representation).

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -1,3 +1,5 @@
+..  _compatibility_guarantees:
+
 Compatibility guarantees
 ========================
 
@@ -17,6 +19,8 @@ It is also appreciated but not guaranteed between different release series (majo
 *   No guarantees are given regarding compatibility between alpha/beta
     versions and between alpha/beta and pre-release/release even within one series.
 
+..  _cg_data_layout:
+
 Binary data layout
 ------------------
 
@@ -35,6 +39,8 @@ An attempt to use a new feature results in one of these options:
     An instance can upgrade the data layout using the :ref:`box.schema.upgrade() <admin-upgrades>` call
     to enable all new release features (when all instances of the replicaset are run on the same Tarantool version).
 
+..  _cg_binary_protocol:
+
 Binary protocol
 ---------------
 
@@ -48,6 +54,8 @@ with the newer one, except the features introduced in the newer release.
 ``net.box`` client of the newer release is fully operational with the server
 running under the older one, except the features not implemented in the older release.
 
+..  _cg_replication_protocol:
+
 Replication protocol
 --------------------
 
@@ -60,6 +68,8 @@ An instance run on a newer release may work as:
 The database schema upgrade (``box.schema.upgrade()``) must be performed when all replicaset instances
 run on the same Tarantool version.
 The upgrade does not cause downtime if the application does not lean on internal schema representation.
+
+..  _cg_lua_code:
 
 Lua code
 --------
@@ -90,6 +100,9 @@ Examples of NOT compatible changes:
 
 *   Add ``__eq`` metamethod (``==`` already returns some result`).
 
+
+..  _cg_sql_code:
+
 SQL code
 --------
 
@@ -115,6 +128,8 @@ Examples of NOT compatible changes:
 *   Change how data is stored in the database.
 *   Change the result of working implicit or explicit cast.
 *   Change of a literal type.
+
+..  _cg_c_code:
 
 C code
 ------

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -117,15 +117,15 @@ Examples of compatible changes:
 *   Add a new system table that has a name starting with an underscore.
 *   Add a new collation.
 *   Add an implicit or explicit cast rule for a set of operations {X} and a list
-    of types [Y] if [operation from {X}]([list of values of [Y] types]) had no
-    meaning before the change.
+    of types [Y] if [operation from {X}]([list of values of [Y] types]) had not been
+    implemented before the change.
+*   Change the order of tuples in the resultset of ``SELECT` in case `ORDER BY` is not specified.
 
 Technically, those changes may break some working code in case of a name clash,
 but the probability of it is negligible.
 
 Examples of **incompatible** changes:
 
-*   Change how data is stored in the database.
 *   Change the result of working implicit or explicit cast.
 *   Change of a literal type.
 

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -76,8 +76,8 @@ If a code is processed on an older release, it will operate with the same effect
 newer one. However, only meaningful code counts.
 If any code throws an error but starts doing something useful, the change is considered compatible.
 
-There is still room for new functionality: adding new options, more
-fields to a return table, and more return values (multireturn).
+There is still room for new functionality: adding new options (fields in a table argument),
+new arguments to the end, more fields to a return table, and more return values (multireturn).
 
 Adding a new built-in module or a new global value is considered as a compatible change.
 
@@ -87,18 +87,22 @@ Otherwise, it should be proven that it won't break any meaningful code.
 
 Examples of compatible changes:
 
-*   Add ``__pairs``, ``__ipairs`` to a metatable of a userdata object.
-    The fields are not from Lua 5.1, and the userdata has no default behaviour for ``pairs()`` and ``ipairs()`` calls.
+*   Add ``__pairs``, ``__ipairs`` to a metatable of a userdata/cdata object.
+    The fields are not from Lua 5.1, and the userdata/cdata has no default behaviour
+    for ``pairs()`` and ``ipairs()`` calls.
 
-*   Add the ``__lt`` or ``__le`` metamethod
+*   Add or extend the ``__lt`` or ``__le`` metamethod
     (if the attempt to use ``<``, ``<=`` etc. leads to an error before the change).
+
+*   Extend existing `__eq` metamethod implementation
+    (if the attempt to use it leads to an error before the change).
 
 Examples of **incompatible** changes:
 
-*   Add ``__pairs``, ``__ipairs`` to a metatable of a table or cdata
+*   Add ``__pairs``, ``__ipairs`` to a metatable of a table
     (it already has a defined behavior before the change).
 
-*   Add the ``__eq`` metamethod (``==`` already returns some result`).
+*   Add the ``__eq`` metamethod (any pair of Lua objects already has a defined behavior).
 
 
 ..  _cg_sql_code:

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -1,13 +1,30 @@
 Compatibility guarantees
 ========================
 
-Backward compatibility (binary data layout)
--------------------------------------------
+Backwards compatibility is guaranteed between all versions in the same :term:`release series`.
+It is also appreciated, but not guaranteed between different release series (major number changes).
+
+*   Pre-releases and releases of one release series are compatible in all
+    senses defined below (any release with any release).
+
+*   Pre-releases and releases of consequent series are compatible by data
+    layout, binary protocol and replication protocol.
+
+*   No guarantees are given regarding compatibility between
+    pre-releases/releases of non-consequent release series if the opposite
+    is not stated in the :ref:`release notes <release_notes>`.
+
+*   No guarantees are given regarding compatibility between alpha/beta
+    versions and between alpha/beta and pre-release/release even within one series.
+
+Binary data layout
+------------------
 
 A newer release (its runtime) is backward compatible with an older one.
 It means a more recent release should work on top of data
 (``*.xlog``, ``*.snap``, ``*.vylog``, ``*.run``) from the older one.
 All functionality that is part of the older release is working in this configuration.
+It should work between :term:`release series` as well.
 
 An attempt to use a new feature results in one of these options:
 
@@ -18,9 +35,10 @@ An attempt to use a new feature results in one of these options:
     An instance can upgrade the data layout using the :ref:`box.schema.upgrade() <admin-upgrades>` call
     to enable all new release features (when all instances of the replicaset are run on the same Tarantool version).
 
-Backward compatibility (binary protocol)
-----------------------------------------
+Binary protocol
+---------------
 
+The binary protocol evolves without breaking compatibility with old clients.
 All binary protocol requests operational in an older release should work on a newer one.
 They do not change the meaning.
 Responses have the same format, but mappings may contain fields not present in the older release.
@@ -30,8 +48,8 @@ with the newer one, except the features introduced in the newer release.
 ``net.box`` client of the newer release is fully operational with the server
 running under the older one, except the features that are not implemented in the older release.
 
-Backward compatibility (replication protocol)
----------------------------------------------
+Replication protocol
+--------------------
 
 An instance run on a newer release may work as:
 
@@ -42,3 +60,74 @@ An instance run on a newer release may work as:
 The database schema upgrade (``box.schema.upgrade()``) must be performed when all replicaset instances
 run on the same Tarantool version.
 The upgrade does not cause downtime if the application does not lean on internal schema representation.
+
+Lua code
+--------
+
+If a code is run on an older release, it will operate with the same effect on a
+newer one. However, only meaningful code counts.
+If any code throws an error, but starts doing something useful, the change is considered compatible.
+
+A room for new functionality is still here. It is poddible to add new options, more
+fields to a returning table and more returning values (multireturn).
+
+Adding a new built-in module or a new global value is considered as the compatible change.
+
+Adding a new field to an existing metatable is okay if it is not listed in the Lua 5.1 Reference Manual. Otherwise, it should be proven that it may not break any meaningful code.
+
+Examples of compatible changes:
+
+*   Add ``__pairs``, ``__ipairs`` to a metatable of a userdata.
+    It is not from Lua 5.1, and the userdata has no default behaviour for ``pairs()`` and `ipairs()` calls.
+
+*   Add ``__lt``, ``__le`` metamethod
+    (if the attempt to use ``<``, ``<=`` and so on leads to an error before the change).
+
+Examples of NOT compatible changes:
+
+*   Add ``__pairs``, ``__ipairs`` to a metatable of a table or cdata
+    (it already has its own behavior before the change).
+
+*   Add ``__eq`` metamethod (``==`` already returns some result`).
+
+SQL code
+--------
+
+If any request is run with the same effect, the change is
+compatible (except the requests that always lead to an error).
+
+What is okay:
+
+Add a new keyword.
+Add a new type.
+Add a new built-in function.
+Add a new system table that starts from underscore.
+Add a new collation.
+Technically those changes may break a working code in case of a name clash,
+but the probability of this situation is considered as negligible. (We can
+restrict this rule in a future.)
+
+
+Examples of NOT compatible changes:
+
+Change how data is stored in the database.
+Change how type arithmetic works (say, implicit casting rules).
+Change of a literal type.
+
+C code
+------
+
+If a module or a C stored procedure is run on an older release,
+it will operate with the same effect on a newer one.
+
+It is okay to add a new function or a new structure to the public C API.
+It must use one of the Tarantool prefixes (``box_``, ``fiber_``, ``luaT_``, ``luaM_`` and so on) or introduce a new one.
+
+A symbol from a used library must not be exported directly,
+because the library may be used in a module by itself, and the clash can lead to problems.
+Exception: when the whole public API of the library is exported (as for libcurl).
+
+Do not introduce new functions or structures with the ``lua_`` and ``luaL_`` prefixes.
+Those prefixes are for the Lua runtime.
+Use ``luaT_`` for Tarantool specific functions, and ``luaM_`` for general-purpose ones.
+

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -14,7 +14,7 @@ It is also appreciated but not guaranteed between different release series (majo
 
 *   No guarantees are given regarding compatibility between
     pre-releases/releases of non-consequent release series if the opposite
-    is not stated in the :ref:`release notes <release_notes>`.
+    is not stated in the :doc:`release notes <notes>`.
 
 *   No guarantees are given regarding compatibility between alpha/beta
     versions and between alpha/beta and pre-release/release even within one series.

--- a/doc/release/compatibility.rst
+++ b/doc/release/compatibility.rst
@@ -66,7 +66,7 @@ An instance running on a newer release can work as:
 
 The database schema upgrade (``box.schema.upgrade()``) must be performed when all replicaset instances
 run on the same Tarantool version.
-The upgrade does not cause downtime if the application does not lean on internal schema representation.
+The upgrade might cause downtime if the application leans on internal schema representation.
 
 ..  _cg_lua_code:
 
@@ -82,14 +82,14 @@ fields to a return table, and more return values (multireturn).
 
 Adding a new built-in module or a new global value is considered as a compatible change.
 
-Adding a new field to an existing metatable is okay if it is not listed
+Adding a new field to an existing metatable is okay if the field is not listed
 in the `Lua 5.1 Reference Manual <https://www.lua.org/manual/5.1/>`_.
 Otherwise, it should be proven that it won't break any meaningful code.
 
 Examples of compatible changes:
 
 *   Add ``__pairs``, ``__ipairs`` to a metatable of a userdata object.
-    It is not from Lua 5.1, and the userdata has no default behaviour for ``pairs()`` and `ipairs()` calls.
+    The fields are not from Lua 5.1, and the userdata has no default behaviour for ``pairs()`` and ``ipairs()`` calls.
 
 *   Add the ``__lt`` or ``__le`` metamethod
     (if the attempt to use ``<``, ``<=`` etc. leads to an error before the change).
@@ -139,7 +139,7 @@ If a module or a C stored procedure runs on an older release,
 it will operate with the same effect on a newer one.
 
 It is okay to add a new function or structure to the public C API.
-It must use one of the Tarantool prefixes (``box_``, ``fiber_``, ``luaT_``, ``luaM_`` and so on) or introduce a new one.
+It must use one of the Tarantool prefixes (``box_``, ``fiber_``, ``luaT_``, ``luaM_`` and so on) or some new prefix.
 
 A symbol from a used library must not be exported directly
 because the library may be used in a module by itself, and the clash can lead to problems.

--- a/doc/release/index.rst
+++ b/doc/release/index.rst
@@ -11,5 +11,6 @@ Release notes
 
     policy_index
     notes
+    compatibility
     major-features
     calendar

--- a/doc/release/policy.rst
+++ b/doc/release/policy.rst
@@ -114,7 +114,7 @@ Release versions conform to a set of requirements:
 
 Backwards compatibility is guaranteed between all versions in the same release series.
 It is also appreciated, but not guaranteed between different release series (major number changes).
-See :doc:`the compatibility guarantees page </release/compatibility>` for details.
+See :doc:`compatibility guarantees page </release/compatibility>` for details.
 
 Pre-release versions
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/release/policy.rst
+++ b/doc/release/policy.rst
@@ -114,7 +114,7 @@ Release versions conform to a set of requirements:
 
 Backwards compatibility is guaranteed between all versions in the same release series.
 It is also appreciated, but not guaranteed between different release series (major number changes).
-A detailed description of compatibility guarantees will be published later.
+See :doc:`the compatibility guarantees page </release/compatibility>` for details.
 
 Pre-release versions
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #2218 
Deploy: https://develop.tarantool.io/en/doc/gh-2218-compatibility/release/compatibility/