### PR TITLE
Rename the "Cluster" menu item as "Cluster on Cartridge" in 1.10

### DIFF
--- a/.github/workflows/push-translation.yml
+++ b/.github/workflows/push-translation.yml
@@ -1,7 +1,7 @@
 name: Push translation sources
 
 on:
-  pull_request:
+  workflow_dispatch:
     paths:
       - 'doc/**/*.rst'
       - 'conf.py'

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -71,7 +71,7 @@
                 book/box/authentication
                 book/box/triggers
                 reference/reference_rock/vshard/vshard_index
-                Cluster <book/cartridge/index>
+                Cluster on Cartridge <book/cartridge/index>
                 book/app_server/index
                 book/admin/index
                 book/replication/index

--- a/doc/toctree.rst
+++ b/doc/toctree.rst
@@ -11,7 +11,7 @@
     book/box/authentication
     book/box/triggers
     reference/reference_rock/vshard/vshard_index
-    Cluster <book/cartridge/index>
+    Cluster on Cartridge <book/cartridge/index>
     book/app_server/index
     book/admin/index
     book/replication/index


### PR DESCRIPTION
Follow-up to #1996