### PR TITLE
Integrate tracing docs into the doc website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,9 @@ locale/*
 /doc/getting_started/getting_started_cxx.rst
 /doc/getting_started/_includes/
 /doc/book/connectors/cxx/
+
+# tracing submodule: leaving only tracing_overview
+
+/doc/reference/reference_rock/tracing/
+/locale/en/reference/reference_rock/tracing/
+/locale/ru/LC_MESSAGES/reference/reference_rock/tracing/

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "modules/tntcxx"]
 	path = modules/tntcxx
 	url = https://github.com/tarantool/tntcxx.git
+[submodule "modules/tracing"]
+	path = modules/tracing
+	url = https://github.com/tarantool/tracing

--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -121,7 +121,8 @@ ldoc --ext=rst --dir=rst --toctree="API" .
 mkdir -p "${tracing_dest}/_includes/"
 yes | cp -fa "${tracing_root}/rst/." "${tracing_dest}"
 pandoc -f gfm -t rst -o "${tracing_dest}/_includes/readme.rst" "${tracing_root}/README.md"
-yes | mv -f "${tracing_dest}/index.rst" "${tracing_dest}/_includes/"
-# remove header from included file
+yes | mv -f "${tracing_dest}/index.rst" "${tracing_dest}/_includes/api.rst"
+# remove header from included README file
 sed -i '1,3d' "${tracing_dest}/_includes/readme.rst"
-# TODO delete topics
+# edit paths in the included API file
+sed -i 's,modules,\.\.\/modules,g' "${tracing_dest}/_includes/api.rst"

--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -125,4 +125,5 @@ yes | mv -f "${tracing_dest}/index.rst" "${tracing_dest}/_includes/api.rst"
 # remove header from included README file
 sed -i '1,3d' "${tracing_dest}/_includes/readme.rst"
 # edit paths in the included API file
-sed -i 's,modules,\.\.\/modules,g' "${tracing_dest}/_includes/api.rst"
+# Addressing in sphinx includes sometimes defies common logic
+sed -i 's,modules,tracing\/modules,g' "${tracing_dest}/_includes/api.rst"

--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -122,4 +122,6 @@ mkdir -p "${tracing_dest}/_includes/"
 yes | cp -fa "${tracing_root}/rst/." "${tracing_dest}"
 pandoc -f gfm -t rst -o "${tracing_dest}/_includes/readme.rst" "${tracing_root}/README.md"
 yes | mv -f "${tracing_dest}/index.rst" "${tracing_dest}/_includes/"
+# remove header from included file
+sed -i '1,3d' "${tracing_dest}/_includes/readme.rst"
 # TODO delete topics

--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -107,3 +107,19 @@ mkdir -p "${tntcxx_gs_dest}/_includes"
 yes | cp -rf "${tntcxx_root}/doc/tntcxx_getting_started.rst" "${tntcxx_gs_dest}/getting_started_cxx.rst"
 yes | cp -rf "${tntcxx_root}/examples/" "${tntcxx_gs_dest}/_includes/examples/"
 yes | cp -rf "${tntcxx_root}/doc/tntcxx_api.rst" "${tntcxx_api_dest}/cxx/"
+
+
+# Tracing module
+tracing_root="${project_root}/modules/tracing"
+tracing_dest="${project_root}/doc/reference/reference_rock/tracing"
+
+# Generate tracing docs
+cd "${tracing_root}"
+ldoc --ext=rst --dir=rst --toctree="API" .
+
+# Copy tracing docs to the right place
+mkdir -p "${tracing_dest}/_includes/"
+yes | cp -fa "${tracing_root}/rst/." "${tracing_dest}"
+pandoc -f gfm -t rst -o "${tracing_dest}/_includes/readme.rst" "${tracing_root}/README.md"
+yes | mv -f "${tracing_dest}/index.rst" "${tracing_dest}/_includes/"
+# TODO delete topics

--- a/doc/reference/reference_rock/index.rst
+++ b/doc/reference/reference_rock/index.rst
@@ -7,12 +7,13 @@ Rocks reference
 
 This reference covers third-party Lua modules for Tarantool.
 
-.. toctree::
-    :maxdepth: 2
+..  toctree::
+    :maxdepth: 1
 
-    dbms
+    Module cartridge <https://www.tarantool.io/doc/latest/book/cartridge/>
     expirationd
+    Module luatest <luatest/luatest_overview>
     membership
+    Module tracing <tracing_overview>
     vshard/index
-    ../../book/cartridge/index
-    luatest/luatest_overview
+    dbms

--- a/doc/reference/reference_rock/luatest/luatest_overview.rst
+++ b/doc/reference/reference_rock/luatest/luatest_overview.rst
@@ -1,6 +1,5 @@
-**********************
-Luatest
-**********************
+Module luatest
+==============
 
 More about Luatest API see :ref:`below <luatest-api>`.
 
@@ -9,3 +8,4 @@ More about Luatest API see :ref:`below <luatest-api>`.
 .. _luatest-api:
 
 .. include:: _includes/index.rst
+    

--- a/doc/reference/reference_rock/tracing_overview.rst
+++ b/doc/reference/reference_rock/tracing_overview.rst
@@ -7,4 +7,4 @@ More about ``tracing`` API see :ref:`below <tracing-api>`.
 
 ..  _tracing-api:
 
-..  include:: tracing/_includes/index.rst
+..  include:: tracing/_includes/api.rst

--- a/doc/reference/reference_rock/tracing_overview.rst
+++ b/doc/reference/reference_rock/tracing_overview.rst
@@ -8,3 +8,12 @@ More about ``tracing`` API see :ref:`below <tracing-api>`.
 ..  _tracing-api:
 
 ..  include:: tracing/_includes/api.rst
+
+.. toctree::
+   :maxdepth: 1
+
+   tracing/modules/opentracing
+   tracing/modules/opentracing.span
+   tracing/modules/opentracing.span_context
+   tracing/modules/opentracing.tracer
+   tracing/modules/zipkin.tracer

--- a/doc/reference/reference_rock/tracing_overview.rst
+++ b/doc/reference/reference_rock/tracing_overview.rst
@@ -1,0 +1,10 @@
+Module tracing
+==============
+
+More about ``tracing`` API see :ref:`below <tracing-api>`. 
+
+..  include:: tracing/_includes/readme.rst
+
+..  _tracing-api:
+
+..  include:: tracing/_includes/index.rst


### PR DESCRIPTION
Resolves https://github.com/tarantool/enterprise_doc/issues/109 and https://github.com/tarantool/enterprise_doc/issues/128

TODO:
- [x] figure out why the redundant "Tracing for Tarantool" link appears in the toctree
- [ ] why are the tracing API contents not displayed? (looks like an addressing problem)
- [ ] what is the best place for the changelog?