### PR TITLE
Add an explicit requirement to capitalize Tarantool

### DIFF
--- a/doc/contributing/docs/style.rst
+++ b/doc/contributing/docs/style.rst
@@ -170,6 +170,14 @@ For this reason, it's best to avoid using them.
 Spelling and punctuation
 ------------------------
 
+Tarantool capitalization
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The word "Tarantool" is capitalized because it's a product name.
+The only context where it can start with a lowercase "t" is code.
+Learn more about :doc:`code formatting in Tarantool documentation </contributing/docs/markup/code>`.
+
+
 US vs British spelling
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
We have a "Writing about code" section, but the user may not be sure when to consult it. This is an important product-related requirement, so I decided to make it explicit and provide a link to the section.