### PR TITLE
Update python connector comparison table

### DIFF
--- a/doc/book/connectors/__python.rst
+++ b/doc/book/connectors/__python.rst
@@ -54,7 +54,7 @@ unmaintained.
 Feature comparison
 ------------------
 
-Last update: February 2022
+Last update: May 2022
 
 ..  list-table::
     :header-rows: 1
@@ -78,7 +78,7 @@ Last update: February 2022
     *   -   Known Issues
         -   `issue #18 <https://github.com/igorcoding/asynctnt/issues/18>`__ (no running event loop)
         -   None
-        -   `issue #105 <https://github.com/tarantool/tarantool-python/issues/105>`__ (unpack of binary data)
+        -   None
 
     *   -   Documentation
         -   Yes (`github.io <https://igorcoding.github.io/asynctnt/>`__)
@@ -93,12 +93,12 @@ Last update: February 2022
     *   -   Testing / CI / CD
         -   GitHub Actions
         -   No (tests exist)
-        -   AppVeyor (only Windows)
+        -   GitHub Actions
 
     *   -   GitHub Stars
-        -   51
+        -   52
         -   17
-        -   78
+        -   83
 
     *   -   Static Analysis
         -   Yes (Flake8)
@@ -156,7 +156,7 @@ Last update: February 2022
     *   -   `Varbinary support <https://www.tarantool.io/en/doc/latest/book/box/data_model/>`__
         -   No
         -   No
-        -   Yes (`issue #105 <https://github.com/tarantool/tarantool-python/issues/105>`__)
+        -   Yes
 
     *   -   `UUID support <https://www.tarantool.io/en/doc/latest/book/box/data_model/>`__
         -   No
@@ -216,7 +216,7 @@ Last update: February 2022
     *   -   Connection pool
         -   No
         -   No
-        -   Yes (round robin failover)
+        -   Yes (with master discovery)
 
     *   -   Support of `PEP 249 -- Python Database API Specification v2.0 <https://www.python.org/dev/peps/pep-0249/>`__
         -   No

--- a/locale/ru/LC_MESSAGES/book/connectors.po
+++ b/locale/ru/LC_MESSAGES/book/connectors.po
@@ -1033,8 +1033,8 @@ msgstr ""
 "tarantool-python. aiotarantool здесь отсутствует, так как он устарел и "
 "больше не поддерживается."
 
-msgid "Last update: February 2022"
-msgstr "Последнее обновление: февраль 2022"
+msgid "Last update: May 2022"
+msgstr "Последнее обновление: май 2022"
 
 msgid "Parameter"
 msgstr "Параметры"
@@ -1292,8 +1292,8 @@ msgstr ""
 "Есть (reconnect_max_attempts, reconnect_delay), проверка состояния "
 "соединения"
 
-msgid "Yes (round robin failover)"
-msgstr "Есть (циклическое восстановление после сбоев)"
+msgid "Yes (with master discovery)"
+msgstr "Есть (с обнаружением мастера)"
 
 msgid ""
 "Support of `PEP 249 -- Python Database API Specification v2.0 "


### PR DESCRIPTION
Since the release of tarantool-python 0.8.0 [1] several things has
changed.

* Issue tarantool/tarantool-python#105 has been fixed [2].
* CI has been migrated to GitHub Actions [3].
* New connection pool (ConnectionPool) with master discovery
  was introduced [4].
* old connection pool (MeshConnection) with round-robin failover was
  deprecated [4].

These changes together with GitHub stars update are introduced with this
patch.

1. https://github.com/tarantool/tarantool-python/releases/tag/0.8.0
2. https://github.com/tarantool/tarantool-python/pull/211
3. https://github.com/tarantool/tarantool-python/pull/213
4. https://github.com/tarantool/tarantool-python/pull/207