### PR TITLE
Update return types of time64 functions

### DIFF
--- a/doc/dev_guide/reference_capi/clock.rst
+++ b/doc/dev_guide/reference_capi/clock.rst
@@ -7,7 +7,7 @@
                 double clock_process(void)
                 double clock_thread(void)
 
-.. c:function:: uint64_t clock_realtime64(void)
-                uint64_t clock_monotonic64(void)
-                uint64_t clock_process64(void)
-                uint64_t clock_thread64(void)
+.. c:function:: int64_t clock_realtime64(void)
+                int64_t clock_monotonic64(void)
+                int64_t clock_process64(void)
+                int64_t clock_thread64(void)

--- a/doc/dev_guide/reference_capi/fiber.rst
+++ b/doc/dev_guide/reference_capi/fiber.rst
@@ -127,9 +127,17 @@
 
     Report loop begin time as double (cheap).
 
-.. c:function:: uint64_t fiber_time64(void)
+.. c:function:: int64_t fiber_time64(void)
 
-    Report loop begin time as 64-bit int.
+    Report loop begin time as 64-bit int. Uses real time clock.
+
+.. c:function:: double fiber_clock(void)
+
+    Report loop begin time as double (cheap). Uses monotonic clock.
+
+.. c:function:: int64_t fiber_clock64(void)
+
+    Report loop begin time as 64-bit int. Uses monotonic clock.
 
 .. c:function:: void fiber_reschedule(void)
 

--- a/doc/reference/reference_lua/clock.rst
+++ b/doc/reference/reference_lua/clock.rst
@@ -71,7 +71,7 @@ Below is a list of all ``clock`` functions.
     The wall clock time. Derived from C function clock_gettime(CLOCK_REALTIME).
 
     :return: seconds or nanoseconds since epoch (1970-01-01 00:00:00), adjusted.
-    :rtype: number or number64
+    :rtype: number or cdata (ctype<int64_t>)
 
     **Example:**
 
@@ -96,7 +96,7 @@ Below is a list of all ``clock`` functions.
     elapsed time.
 
     :return: seconds or nanoseconds since the last time that the computer was booted.
-    :rtype: number or number64
+    :rtype: number or cdata (ctype<int64_t>)
 
     **Example:**
 
@@ -117,7 +117,7 @@ Below is a list of all ``clock`` functions.
     within a CPU.
 
     :return: seconds or nanoseconds since processor start.
-    :rtype: number or number64
+    :rtype: number or cdata (ctype<int64_t>)
 
     **Example:**
 
@@ -138,7 +138,7 @@ Below is a list of all ``clock`` functions.
     thread within a CPU.
 
     :return: seconds or nanoseconds since the transaction processor thread started.
-    :rtype: number or number64
+    :rtype: number or cdata (ctype<int64_t>)
 
     **Example:**
 

--- a/doc/reference/reference_lua/fiber.rst
+++ b/doc/reference/reference_lua/fiber.rst
@@ -582,7 +582,7 @@ recommended.
     :return: current system time (in microseconds since the epoch)
              as a 64-bit integer. The time is taken from the event
              loop clock.
-    :rtype: cdata
+    :rtype: cdata (ctype<int64_t>)
 
     **Example:**
 
@@ -632,7 +632,7 @@ recommended.
     :return: a number of seconds as 64-bit integer, representing
              elapsed wall-clock time since some time in the past that is
              guaranteed not to change during the life of the process
-    :rtype: cdata
+    :rtype: cdata (ctype<int64_t>)
 
 
 ..  class:: fiber_object


### PR DESCRIPTION
Fixes #2840 
Adds missing C functions `fiber_clock` and `fiber_clock64`