### PR TITLE
dev_guide: fix Debian/Ubuntu build instruction

### DIFF
--- a/doc/dev_guide/building_from_source.rst
+++ b/doc/dev_guide/building_from_source.rst
@@ -49,7 +49,7 @@ Ubuntu/Debian
 
     $ apt-get -y install git build-essential cmake make zlib1g-dev \
       libreadline-dev libncurses5-dev libssl-dev libunwind-dev libicu-dev \
-      python3 python3-pyyaml python3-six python3-gevent
+      python3 python3-yaml python3-six python3-gevent
 
     $ git clone https://github.com/tarantool/tarantool.git --recursive
 


### PR DESCRIPTION
There is no `python3-pyyaml` package on Debian/Ubuntu. It is called
`python3-yaml`.

Follows up #1757
Fixes #2880