### PR TITLE
Explain what to do with optional parameters

### DIFF
--- a/doc/contributing/docs/_includes/function_template.rst
+++ b/doc/contributing/docs/_includes/function_template.rst
@@ -5,7 +5,9 @@
     Create and start a fiber. The fiber is created and begins to run immediately.
 
     :param function: the function to be associated with the fiber
-    :param function-arguments: what will be passed to function
+    :param function-arguments: what will be passed to function.
+                               If the arguments are optional, put them in
+                               square brackets in the function declaration.
 
     :return: created fiber object
     :rtype: userdata

--- a/doc/contributing/docs/examples.rst
+++ b/doc/contributing/docs/examples.rst
@@ -69,7 +69,6 @@ For every function or class method parameter, list the following details:
 
 *   General description
 *   Type
-*   If optional, indicate *(optional)* in parentheses
 *   Default value (if optional), possible values
 
 In the "Possible errors" section of the function or class method,


### PR DESCRIPTION
A slight change to the rules for documenting API function parameters.

The `(optional)` mark for each parameter looks redundant, because we already see in the function declaration which arguments are optional and which are required.