### PR TITLE
Actualize the API documentation style guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,9 @@
+Contributing
+============
+
+Please see
+our `documentation and localization guidelines <https://www.tarantool.io/en/doc/latest/contributing/docs/>`_
+on the Tarantool website.
+
+Хотите участвовать в локализации Tarantool на русский язык?
+Переходите в `эту GitHub-дискуссию <https://github.com/tarantool/doc/discussions/2738>`_.

--- a/doc/book/box/data_model.rst
+++ b/doc/book/box/data_model.rst
@@ -1035,6 +1035,7 @@ See reference on ``box.space`` for more
    The client server protocol is open and documented.
    See this :ref:`annotated BNF <box_protocol-iproto_protocol>`.
 
+..  _index-box_complexity-factors:
 
 Complexity factors
 ~~~~~~~~~~~~~~~~~~

--- a/doc/contributing/docs.rst
+++ b/doc/contributing/docs.rst
@@ -16,7 +16,7 @@ The guidelines are a work in progress, and we welcome all contributions.
     docs/localization
     docs/terms
     docs/markup
-    docs/examples
+    docs/api
     docs/build
     docs/sphinx-warnings
     docs/infra

--- a/doc/contributing/docs/_includes/confval_template.rst
+++ b/doc/contributing/docs/_includes/confval_template.rst
@@ -1,7 +1,7 @@
 ..  confval:: wal_dir
 
-    Since version 1.6.2.
-    A directory where write-ahead log (``.xlog``) files are stored.
+    Since :tarantool-release:`1.6.2`.
+    The directory where write-ahead log (``.xlog``) files are stored.
     Can be relative to :ref:`work_dir <cfg_basic-work_dir>`.
     Sometimes ``wal_dir`` and :ref:`memtx_dir <cfg_basic-memtx_dir>` are specified with different values,
     so that write-ahead log files and snapshot files can be stored on different disks.

--- a/doc/contributing/docs/_includes/function_template.rst
+++ b/doc/contributing/docs/_includes/function_template.rst
@@ -6,8 +6,6 @@
 
     :param function: the function to be associated with the fiber
     :param function-arguments: what will be passed to function.
-                               If the arguments are optional, put them in
-                               square brackets in the function declaration.
 
     :return: created fiber object
     :rtype: userdata

--- a/doc/contributing/docs/api.rst
+++ b/doc/contributing/docs/api.rst
@@ -1,12 +1,12 @@
-Examples and templates
-======================
+Documenting the API
+===================
 
 This document contains general guidelines for describing the Tarantool API,
 as well as examples and templates.
 
 Use this checklist for documenting a function or a method:
 
-*   General description
+*   General description (in imperative mood)
 *   :ref:`Parameters <documenting_parameters>`
 *   What this function returns (if nothing, write 'none')
 *   Return type (if exists)
@@ -82,7 +82,7 @@ Configuration parameters
 For every configuration parameter, list the following details:
 
 *   Since which Tarantool version
-*   General description
+*   General description (in imperative mood)
 *   Type
 *   Corresponding environment variable (if applicable)
 *   Default value

--- a/doc/contributing/docs/api.rst
+++ b/doc/contributing/docs/api.rst
@@ -18,27 +18,23 @@ For more style-related specifics, consult the :doc:`Language and style </contrib
 Indicating the version
 ----------------------
 
-For every new feature or parameter, please indicate the version it was introduced in.
+For every new module, function, or method, specify the version it first appears in.
 
-With Tarantool features and parameters, use one of the following Sphinx directives:
+For a new parameter, specify the version it first appears in if this parameter is a "feature"
+and the version it's been introduced in differs from
+the version introducing the function/method and all other parameters.
+
+To specify the version, use the following Sphinx directive:
 
 ..  code-block:: rst
-
-    Since :tarantool-release:`2.10.0`.
-    This is a link to the release notes on GitHub.
 
     Since :doc:`2.10.0 </release/2.10.0>`.
     This is a link to the release notes on the Tarantool documentation website.
 
 The result looks like this:
 
-    Since Tarantool :tarantool-release:`2.10.0`.
-    This is a link to the release notes on GitHub.
-
     Since Tarantool :doc:`2.10.0 </release/2.10.0>`.
     This is a link to the release notes on the Tarantool documentation website.
-
-See also the :doc:`guide on writing release notes </contributing/release_notes/>`.
 
 ..  _contributing-api-docs_general-description:
 
@@ -53,6 +49,8 @@ Use one of the two options:
 Checklist
 ---------
 
+Each list item is a characteristic to be described. Some items can be optional.
+
 Function or method
 ^^^^^^^^^^^^^^^^^^
 
@@ -61,8 +59,10 @@ Function or method
 *   :ref:`Parameters <documenting_parameters>`
 *   What this function returns (if nothing, write 'none')
 *   Return type (if exists)
-*   Possible errors (if exist)
-*   Complexity factors (if exist)
+*   :ref:`Possible errors <contributing-docs-possible_errors>` (if exist)
+*   :ref:`Complexity factors <index-box_complexity-factors>`
+    (for :doc:`CRUD operations </reference/reference_lua/box_space>` and
+    :doc:`index access functions </reference/reference_lua/box_index/>`)
 *   Usage with memtx and vinyl (if differs)
 *   Example(s)
 *   Extra information (if needed)
@@ -82,8 +82,8 @@ See :ref:`class data example <contributing-api-docs_class-example>`.
 
 ..  _documenting_parameters:
 
-Function and class parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Function and method parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 *   :ref:`Since which Tarantool version <contributing-docs-api_version>`
     (if added later)
@@ -93,9 +93,18 @@ Function and class parameters
 
 If the parameter is optional, make sure it is enclosed in square brackets
 in the function declaration (in the "heading").
+Do not mark parameters additionaly as "optional" or "required":
 
-In the "Possible errors" section of the function or class method,
-consider explaining what happens if the parameter hasn't been defined or has the wrong value.
+..  code-block:: rst
+
+    ..  function:: format(URI-components-table[, include-password])
+
+        Construct a URI from components.
+
+        :param URI-components-table: a series of ``name:value`` pairs, one for each component
+        :param include-password: boolean. If this is supplied and is ``true``, then
+                                 the password component is rendered in clear text,
+                                 otherwise it is omitted.
 
 ..  _documenting_confvals:
 
@@ -111,10 +120,18 @@ You can find a list of Tarantool configuration parameters in the :doc:`configura
 *   Type
 *   Corresponding environment variable (if applicable)
 *   Default value
-*   Possible values
+*   Possible values (can be included in the general description, for example, as a list)
 *   Dynamic (yes or no)
 
 See :ref:`configuration parameter example <contributing-api-docs_confval-example>`.
+
+..  _contributing-docs-possible_errors:
+
+Documenting possible errors
+---------------------------
+
+In the "Possible errors" section of a function or class method,
+consider explaining what happens if any parameter hasn't been defined or has the wrong value.
 
 Examples and templates
 ----------------------

--- a/doc/contributing/docs/api.rst
+++ b/doc/contributing/docs/api.rst
@@ -4,15 +4,60 @@ Documenting the API
 This document contains general guidelines for describing the Tarantool API,
 as well as examples and templates.
 
+Style
+-----
+
 Please write as simply as possible. Describe functionality using short sentences in the present simple tense.
 A short sentence consists of no more than two clauses.
 Consider using `LanguageTool <https://languagetool.org/>`_ or `Grammarly <https://www.grammarly.com/>`_
 to check your English.
 For more style-related specifics, consult the :doc:`Language and style </contributing/docs/style>` section.
 
-Use this checklist for documenting a function or a method:
+..  _contributing-docs-api_version:
 
-*   General description (in imperative mood)
+Indicating the version
+----------------------
+
+For every new feature or parameter, please indicate the version it was introduced in.
+
+With Tarantool features and parameters, use one of the following Sphinx directives:
+
+..  code-block:: rst
+
+    Since :tarantool-release:`2.10.0`.
+    This is a link to the release notes on GitHub.
+
+    Since :doc:`2.10.0 </release/2.10.0>`.
+    This is a link to the release notes on the Tarantool documentation website.
+
+The result looks like this:
+
+    Since Tarantool :tarantool-release:`2.10.0`.
+    This is a link to the release notes on GitHub.
+
+    Since Tarantool :doc:`2.10.0 </release/2.10.0>`.
+    This is a link to the release notes on the Tarantool documentation website.
+
+See also the :doc:`guide on writing release notes </contributing/release_notes/>`.
+
+..  _contributing-api-docs_general-description:
+
+Language of the general description
+-----------------------------------
+
+Use one of the two options:
+
+*   Start with a verb in the imperative mood. Example: *Create a fiber.*
+*   Start with a noun. Example: *The directory where memtx stores snapshot files.*
+
+Checklist
+---------
+
+Function or method
+^^^^^^^^^^^^^^^^^^
+
+*   :ref:`Since which Tarantool version <contributing-docs-api_version>`
+*   :ref:`General description <contributing-api-docs_general-description>`
 *   :ref:`Parameters <documenting_parameters>`
 *   What this function returns (if nothing, write 'none')
 *   Return type (if exists)
@@ -22,8 +67,62 @@ Use this checklist for documenting a function or a method:
 *   Example(s)
 *   Extra information (if needed)
 
-Documenting functions
----------------------
+See :ref:`module function example <contributing-api-docs_function-example>`,
+:ref:`class method example <contributing-api-docs_class-example>`.
+
+Data
+^^^^
+
+*   :ref:`Since which Tarantool version <contributing-docs-api_version>`
+*   :ref:`General description <contributing-api-docs_general-description>`
+*   Return type
+*   Example
+
+See :ref:`class data example <contributing-api-docs_class-example>`.
+
+..  _documenting_parameters:
+
+Function and class parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*   :ref:`Since which Tarantool version <contributing-docs-api_version>`
+    (if added later)
+*   :ref:`General description <contributing-api-docs_general-description>`
+*   Type
+*   Default value (if optional), possible values
+
+If the parameter is optional, make sure it is enclosed in square brackets
+in the function declaration (in the "heading").
+
+In the "Possible errors" section of the function or class method,
+consider explaining what happens if the parameter hasn't been defined or has the wrong value.
+
+..  _documenting_confvals:
+
+Configuration parameters
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Configuration parameters are not to be confused with class and method parameters.
+Configuration parameters are passed to Tarantool via the command line or in an initialization file.
+You can find a list of Tarantool configuration parameters in the :doc:`configuration reference </reference/configuration/index>`.
+
+*   :ref:`Since which Tarantool version <contributing-docs-api_version>`
+*   :ref:`General description <contributing-api-docs_general-description>`
+*   Type
+*   Corresponding environment variable (if applicable)
+*   Default value
+*   Possible values
+*   Dynamic (yes or no)
+
+See :ref:`configuration parameter example <contributing-api-docs_confval-example>`.
+
+Examples and templates
+----------------------
+
+..  _contributing-api-docs_function-example:
+
+Module functions
+^^^^^^^^^^^^^^^^
 
 We use the Sphinx directives ``.. module::``
 and ``.. function::`` to describe functions of Tarantool modules:
@@ -35,12 +134,11 @@ The resulting output looks like this:
 
 ..  include:: ./_includes/function_template.rst
 
-..  note::
 
-    The best practices for :ref:`parameter description <documenting_parameters>` are listed below.
+..  _contributing-api-docs_class-example:
 
-Documenting class methods and data
-----------------------------------
+Class methods and data
+^^^^^^^^^^^^^^^^^^^^^^
 
 Methods are described similarly to functions, but the ``.. class::``
 directive, unlike ``.. module::``, requires nesting.
@@ -57,46 +155,12 @@ And the resulting output looks like this:
 
 ..  include:: ./_includes/class_template.rst
 
-..  note::
-
-    The best practices for :ref:`parameter description <documenting_parameters>` are listed below.
-
-..  _documenting_parameters:
-
-Parameters in functions and classes
------------------------------------
-
-This section explains how to document specific function or class method parameters as described above.
-To learn how to document :doc:`configuration parameters </reference/configuration/index>`
-passed to Tarantool via the command line or in an initialization file,
-see the :ref:`next section <documenting_confvals>`.
-
-For every function or class method parameter, list the following details:
-
-*   General description
-*   Type
-*   Default value (if optional), possible values
-
-In the "Possible errors" section of the function or class method,
-consider explaining what happens if the parameter hasn't been defined or has the wrong value.
-
-..  _documenting_confvals:
+..  _contributing-api-docs_confval-example:
 
 Configuration parameters
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-For every configuration parameter, list the following details:
-
-*   Since which Tarantool version
-*   General description (in imperative mood)
-*   Type
-*   Corresponding environment variable (if applicable)
-*   Default value
-*   Possible values
-*   Dynamic (yes or no)
-
-Example
-^^^^^^^
+Example:
 
 ..  literalinclude:: ./_includes/confval_template.rst
     :language: rst

--- a/doc/contributing/docs/api.rst
+++ b/doc/contributing/docs/api.rst
@@ -3,7 +3,12 @@ Documenting the API
 
 This document contains general guidelines for describing the Tarantool API,
 as well as examples and templates.
-For style-related specifics, consult the :doc:`Language and style </contributing/docs/style>` section.
+
+Please write as simply as possible. Describe functionality using short sentences in the present simple tense.
+A short sentence consists of no more than two clauses.
+Consider using `LanguageTool <https://languagetool.org/>`_ or `Grammarly <https://www.grammarly.com/>`_
+to check your English.
+For more style-related specifics, consult the :doc:`Language and style </contributing/docs/style>` section.
 
 Use this checklist for documenting a function or a method:
 

--- a/doc/contributing/docs/api.rst
+++ b/doc/contributing/docs/api.rst
@@ -3,6 +3,7 @@ Documenting the API
 
 This document contains general guidelines for describing the Tarantool API,
 as well as examples and templates.
+For style-related specifics, consult the :doc:`Language and style </contributing/docs/style>` section.
 
 Use this checklist for documenting a function or a method:
 

--- a/doc/contributing/docs/style.rst
+++ b/doc/contributing/docs/style.rst
@@ -213,7 +213,8 @@ Use the US English spelling.
 Check your spelling and punctuation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Consider checking spelling, grammar, and punctuation with special tools.
+Consider checking spelling, grammar, and punctuation with special tools like
+`LanguageTool <https://languagetool.org/>`_ or `Grammarly <https://www.grammarly.com/>`_.
 
 Dashes
 ~~~~~~

--- a/doc/contributing/release_notes.rst
+++ b/doc/contributing/release_notes.rst
@@ -3,6 +3,9 @@ How to write release notes
 
 Below are some best practices to make changelogs consistent, neat, and human-oriented.
 
+Language
+--------
+
 *   Use the past tense to describe changed or fixed behavior.
 
     ..  admonition:: Examples
@@ -23,3 +26,18 @@ Below are some best practices to make changelogs consistent, neat, and human-ori
 
 Note that these guidelines differ from the best practice for commit message titles
 that suggests using the imperative mood.
+
+Formatting
+----------
+
+In release notes, use the following Sphinx syntax when referring to a specific version of Tarantool:
+
+..  code-block:: rst
+
+    Tarantool :tarantool-release:`2.10.0`.
+    This is a link to the release notes on GitHub.
+
+The result looks like this:
+
+    Tarantool :tarantool-release:`2.10.0`.
+    This is a link to the release notes on GitHub.


### PR DESCRIPTION
Deployment: https://docs.d.tarantool.io/en/doc/api-style-guide/contributing/docs/api/