### PR TITLE
[1.10] Put only document titles in the left navigation bar

### DIFF
--- a/doc/toctree.rst
+++ b/doc/toctree.rst
@@ -1,5 +1,6 @@
 
-.. toctree::
+..  toctree::
+    :titlesonly:
     :maxdepth: 7
     :includehidden:
 


### PR DESCRIPTION
See https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=toctree#directive-toctree

Part of tarantool/tarantool.io#1275