### PR TITLE
Add msgpack.v5 support for go-tarantool

### DIFF
--- a/doc/book/connectors/__go.rst
+++ b/doc/book/connectors/__go.rst
@@ -66,7 +66,7 @@ Last update: August 2022
         -   No
 
     *   -   msgpack driver
-        -   `vmihailenco/msgpack/v2 <https://github.com/vmihailenco/msgpack/tree/v2>`_ (`#124 <https://github.com/tarantool/go-tarantool/issues/124>`_)
+        -   `vmihailenco/msgpack/v2 <https://github.com/vmihailenco/msgpack/tree/v2>`_ or `vmihailenco/msgpack/v5 <https://github.com/vmihailenco/msgpack/tree/v5>`_
         -   `tinylib/msgp <https://github.com/tinylib/msgp>`_
         -   `vmihailenco/msgpack/v5 <https://github.com/vmihailenco/msgpack/tree/v5>`_
 


### PR DESCRIPTION
The patch adds msgpack.v5 support for go-tarantool in Go-connectors
comparison table. The feature has been introduced in go-tarantool
1.8.0.

Follows up https://github.com/tarantool/go-tarantool/issues/124