### PR TITLE
Add the rule against forks

### DIFF
--- a/doc/contributing/docs/git.rst
+++ b/doc/contributing/docs/git.rst
@@ -17,6 +17,15 @@ Name your branch so it's clear what you're doing. Examples:
 *   ``gh-1234-short-issue-description``
 *   ``your-github-handle/short-issue-description``
 
+..  important::
+
+    It is not recommended to submit PRs to the `documentation repository <https://github.com/tarantool/doc>`__
+    from forks.
+    Because of a GitHub failsafe mechanism, it is impossible to view changes from a fork
+    on the development website.
+    
+    Creating branches directly in the repository results in a more convenient workflow.
+
 Linking issues and PRs
 ----------------------
 

--- a/doc/contributing/docs/localization/guide.rst
+++ b/doc/contributing/docs/localization/guide.rst
@@ -1,5 +1,5 @@
-Tarantool Translation Guidelines
-================================
+Localization guidelines
+=======================
 
 Use this guide when localizing Tarantool into Russian.
 


### PR DESCRIPTION
Submitting PR from forks is discouraged because of deployment specifics.