### PR TITLE
Remove backticks from headers

### DIFF
--- a/doc/how-to/other/libslave.rst
+++ b/doc/how-to/other/libslave.rst
@@ -1,7 +1,7 @@
 .. _libslave:
 
 ================================================================================
-`libslave` tutorial
+libslave tutorial
 ================================================================================
 
 ``libslave`` is a C++ library for reading data changes done by MysQL and,

--- a/locale/ru/LC_MESSAGES/how-to/other/libslave.po
+++ b/locale/ru/LC_MESSAGES/how-to/other/libslave.po
@@ -1,6 +1,6 @@
 
-msgid "`libslave` tutorial"
-msgstr "Практические задания по `libslave`"
+msgid "libslave tutorial"
+msgstr "Практические задания по libslave"
 
 msgid ""
 "``libslave`` is a C++ library for reading data changes done by MysQL and, "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box.po
@@ -1,6 +1,6 @@
 
-msgid "Module `box`"
-msgstr "Модуль `box`"
+msgid "Module box"
+msgstr "Модуль box"
 
 msgid ""
 "As well as executing Lua chunks or defining your own functions, you can "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_backup.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_backup.po
@@ -1,6 +1,6 @@
 
 msgid "Submodule box.backup"
-msgstr "Вложенный модуль `box.backup`"
+msgstr "Вложенный модуль box.backup"
 
 msgid ""
 "The box.backup submodule contains two functions that are helpful for "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_cfg.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_cfg.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.cfg`"
-msgstr "Вложенный модуль `box.cfg`"
+msgid "Submodule box.cfg"
+msgstr "Вложенный модуль box.cfg"
 
 msgid ""
 "The ``box.cfg`` submodule is used for specifying :ref:`server configuration "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_error.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_error.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.error`"
-msgstr "Вложенный модуль `box.error`"
+msgid "Submodule box.error"
+msgstr "Вложенный модуль box.error"
 
 msgid ""
 "The ``box.error`` function is for raising an error. The difference between "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_index.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_index.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.index`"
-msgstr "Вложенный модуль `box.index`"
+msgid "Submodule box.index"
+msgstr "Вложенный модуль box.index"
 
 msgid ""
 "The ``box.index`` submodule provides read-only access for index definitions "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_info.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_info.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.info`"
-msgstr "Вложенный модуль `box.info`"
+msgid "Submodule box.info"
+msgstr "Вложенный модуль box.info"
 
 msgid ""
 "The ``box.info`` submodule provides access to information about server "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_null.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_null.po
@@ -1,6 +1,6 @@
 
-msgid "Constant `box.NULL`"
-msgstr "Константа `box.NULL`"
+msgid "Constant box.NULL"
+msgstr "Константа box.NULL"
 
 msgid ""
 "There are some major problems with using Lua **nil** values in tables. For "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_once.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_once.po
@@ -1,6 +1,6 @@
 
-msgid "Function `box.once`"
-msgstr "Функция `box.once`"
+msgid "Function box.once"
+msgstr "Функция box.once"
 
 msgid ""
 "Execute a function, provided it has not been executed before. A passed value"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_schema.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_schema.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.schema`"
-msgstr "Вложенный модуль `box.schema`"
+msgid "Submodule box.schema"
+msgstr "Вложенный модуль box.schema"
 
 msgid ""
 "The ``box.schema`` submodule has data-definition functions for spaces, "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_session.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_session.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.session`"
-msgstr "Вложенный модуль `box.session`"
+msgid "Submodule box.session"
+msgstr "Вложенный модуль box.session"
 
 msgid ""
 "The ``box.session`` submodule allows querying the session state, writing to "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_slab.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_slab.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.slab`"
-msgstr "Вложенный модуль `box.slab`"
+msgid "Submodule box.slab"
+msgstr "Вложенный модуль box.slab"
 
 msgid ""
 "The ``box.slab`` submodule provides access to slab allocator statistics. The"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_snapshot.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_snapshot.po
@@ -1,6 +1,6 @@
 
-msgid "Function `box.snapshot`"
-msgstr "Функция `box.snapshot`"
+msgid "Function box.snapshot"
+msgstr "Функция box.snapshot"
 
 msgid "**Memtx**"
 msgstr "**Memtx**"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_space.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_space.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.space`"
-msgstr "Вложенный модуль `box.space`"
+msgid "Submodule box.space"
+msgstr "Вложенный модуль box.space"
 
 msgid ""
 "**CRUD operations** in Tarantool are implemented by the ``box.space`` "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_stat.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_stat.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.stat`"
-msgstr "Вложенный модуль `box.stat`"
+msgid "Submodule box.stat"
+msgstr "Вложенный модуль box.stat"
 
 msgid ""
 "The ``box.stat`` submodule provides access to request and network "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/box_tuple.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/box_tuple.po
@@ -1,6 +1,6 @@
 
-msgid "Submodule `box.tuple`"
-msgstr "Вложенный модуль `box.tuple`"
+msgid "Submodule box.tuple"
+msgstr "Вложенный модуль box.tuple"
 
 msgid ""
 "The ``box.tuple`` submodule provides read-only access for the ``tuple`` "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/buffer.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/buffer.po
@@ -1,6 +1,6 @@
 
-msgid "Module `buffer`"
-msgstr "Модуль `buffer`"
+msgid "Module buffer"
+msgstr "Модуль buffer"
 
 msgid ""
 "The ``buffer`` module returns a dynamically resizable buffer which is solely"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/clock.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/clock.po
@@ -1,6 +1,6 @@
 
-msgid "Module `clock`"
-msgstr "Модуль `clock`"
+msgid "Module clock"
+msgstr "Модуль clock"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/console.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/console.po
@@ -1,6 +1,6 @@
 
-msgid "Module `console`"
-msgstr "Модуль `console`"
+msgid "Module console"
+msgstr "Модуль console"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/crypto.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/crypto.po
@@ -1,6 +1,6 @@
 
-msgid "Module `crypto`"
-msgstr "Модуль `crypto`"
+msgid "Module crypto"
+msgstr "Модуль crypto"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/csv.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/csv.po
@@ -1,6 +1,6 @@
 
-msgid "Module `csv`"
-msgstr "Модуль `csv`"
+msgid "Module csv"
+msgstr "Модуль csv"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/decimal.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/decimal.po
@@ -1,6 +1,6 @@
 
-msgid "Module `decimal`"
-msgstr ""
+msgid "Module decimal"
+msgstr "Модуль decimal"
 
 msgid ""
 "The ``decimal`` module has functions for working with exact numbers. This is"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/digest.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/digest.po
@@ -1,6 +1,6 @@
 
-msgid "Module `digest`"
-msgstr "Модуль `digest`"
+msgid "Module digest"
+msgstr "Модуль digest"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/errno.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/errno.po
@@ -1,6 +1,6 @@
 
-msgid "Module `errno`"
-msgstr "Модуль `errno`"
+msgid "Module errno"
+msgstr "Модуль errno"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/fiber.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/fiber.po
@@ -1,7 +1,7 @@
 
 #, fuzzy
 msgid "Module fiber"
-msgstr "Модуль `fiber`"
+msgstr "Модуль fiber"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/fio.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/fio.po
@@ -1,6 +1,6 @@
 
-msgid "Module `fio`"
-msgstr "Модуль `fio`"
+msgid "Module fio"
+msgstr "Модуль fio"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/fun.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/fun.po
@@ -1,6 +1,6 @@
 
-msgid "Module `fun`"
-msgstr "Модуль `fun`"
+msgid "Module fun"
+msgstr "Модуль fun"
 
 msgid ""
 "Luafun, also known as the Lua Functional Library, takes advantage of the "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/http.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/http.po
@@ -1,6 +1,6 @@
 
-msgid "Module `http`"
-msgstr "Модуль `http`"
+msgid "Module http"
+msgstr "Модуль http"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/iconv.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/iconv.po
@@ -1,6 +1,6 @@
 
-msgid "Module `iconv`"
-msgstr "Модуль `iconv`"
+msgid "Module iconv"
+msgstr "Модуль iconv"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/json.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/json.po
@@ -1,6 +1,6 @@
 
-msgid "Module `json`"
-msgstr "Модуль `json`"
+msgid "Module json"
+msgstr "Модуль json"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/json_paths.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/json_paths.po
@@ -1,6 +1,6 @@
 
 msgid "JSON paths"
-msgstr ""
+msgstr "JSON-пути"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/key_def.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/key_def.po
@@ -1,6 +1,6 @@
 
-msgid "Module `key_def`"
-msgstr "Модуль `key_def`"
+msgid "Module key_def"
+msgstr "Модуль key_def"
 
 msgid ""
 "The `key_def` module has a function for defining the field numbers and types"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/log.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/log.po
@@ -1,6 +1,6 @@
 
-msgid "Module `log`"
-msgstr "Модуль `log`"
+msgid "Module log"
+msgstr "Модуль log"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/merger.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/merger.po
@@ -1,6 +1,6 @@
 
-msgid "Module `merger`"
-msgstr ""
+msgid "Module merger"
+msgstr "Модуль merger"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/msgpack.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/msgpack.po
@@ -1,6 +1,6 @@
 
-msgid "Module `msgpack`"
-msgstr "Модуль `msgpack`"
+msgid "Module msgpack"
+msgstr "Модуль msgpack"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/net_box.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/net_box.po
@@ -1,6 +1,6 @@
 
-msgid "Module `net.box`"
-msgstr "Модуль `net.box`"
+msgid "Module net.box"
+msgstr "Модуль net.box"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/osmodule.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/osmodule.po
@@ -1,6 +1,6 @@
 
-msgid "Module `os`"
-msgstr "Модуль `os`"
+msgid "Module os"
+msgstr "Модуль os"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/other.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/other.po
@@ -1,6 +1,6 @@
 
 msgid "Other package components"
-msgstr ""
+msgstr "Прочие компоненты пакета"
 
 msgid ""
 "All the Tarantool modules are, at some level, inside a package which, "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/pickle.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/pickle.po
@@ -1,6 +1,6 @@
 
-msgid "Module `pickle`"
-msgstr "Модуль `pickle`"
+msgid "Module pickle"
+msgstr "Модуль pickle"
 
 msgid "Index"
 msgstr "Указатель"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/popen.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/popen.po
@@ -1,6 +1,6 @@
 
-msgid "Module `popen`"
-msgstr "Модуль `popen`"
+msgid "Module popen"
+msgstr "Модуль popen"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/socket.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/socket.po
@@ -1,6 +1,6 @@
 
-msgid "Module `socket`"
-msgstr "Модуль `socket`"
+msgid "Module socket"
+msgstr "Модуль socket"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/strict.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/strict.po
@@ -1,6 +1,6 @@
 
-msgid "Module `strict`"
-msgstr "Модуль `strict`"
+msgid "Module strict"
+msgstr "Модуль strict"
 
 msgid ""
 "The :code:`strict` module has functions for turning \"strict mode\" on or "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/string.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/string.po
@@ -1,6 +1,6 @@
 
-msgid "Module `string`"
-msgstr "Модуль `string`"
+msgid "Module string"
+msgstr "Модуль string"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/swim.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/swim.po
@@ -1,6 +1,6 @@
 
-msgid "Module `swim`"
-msgstr ""
+msgid "Module swim"
+msgstr "Модуль swim"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/table.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/table.po
@@ -1,6 +1,6 @@
 
-msgid "Module `table`"
-msgstr "Модуль `table`"
+msgid "Module table"
+msgstr "Модуль table"
 
 msgid ""
 "The :code:`table` module has everything in the `standard Lua table library "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/tap.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/tap.po
@@ -1,7 +1,6 @@
 
-#, fuzzy
 msgid "Module tap"
-msgstr "Модуль `tap`"
+msgstr "Модуль tap"
 
 msgid "Overview"
 msgstr "Общие сведения"
@@ -454,15 +453,3 @@ msgstr ""
 "    # Some subtests for test2: end\n"
 "ok - some subtests for test2"
 
-#~ msgid ""
-#~ "Set ``taptest.strict=true`` if :ref:`taptest:is() <taptest-is>` and "
-#~ ":ref:`taptest:isnt() <taptest-isnt>` and :ref:`taptest:is_deeply() <taptest-"
-#~ "is_deeply>` must be compared strictly with ``nil``. Set "
-#~ "``taptest.strict=false`` if ``nil`` and ``box.NULL`` both have the same "
-#~ "effect. The default is false. For example, if and only if "
-#~ "``taptest.strict=true`` has happened, then ``taptest:is_deeply({a = "
-#~ "box.NULL}, {})`` will return ``false``."
-#~ msgstr ""
-
-#~ msgid "Note that ``taptest.strict`` is the same for subtests:"
-#~ msgstr ""

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/tarantool.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/tarantool.po
@@ -1,6 +1,6 @@
 
-msgid "Module `tarantool`"
-msgstr "Модуль `tarantool`"
+msgid "Module tarantool"
+msgstr "Модуль tarantool"
 
 msgid ""
 "By saying ``require('tarantool')``, one can answer some questions about how "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/uri.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/uri.po
@@ -1,6 +1,6 @@
 
-msgid "Module `uri`"
-msgstr "Модуль `uri`"
+msgid "Module uri"
+msgstr "Модуль uri"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/utf8.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/utf8.po
@@ -1,6 +1,6 @@
 
-msgid "Module `utf8`"
-msgstr "Модуль `utf8`"
+msgid "Module utf8"
+msgstr "Модуль utf8"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/uuid.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/uuid.po
@@ -1,6 +1,6 @@
 
-msgid "Module `uuid`"
-msgstr "Модуль `uuid`"
+msgid "Module uuid"
+msgstr "Модуль uuid"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/xlog.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/xlog.po
@@ -1,6 +1,6 @@
 
-msgid "Module `xlog`"
-msgstr "Модуль `xlog`"
+msgid "Module xlog"
+msgstr "Модуль xlog"
 
 msgid ""
 "The xlog module contains one function: ``pairs()``. It can be used to read "

--- a/locale/ru/LC_MESSAGES/reference/reference_lua/yaml.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_lua/yaml.po
@@ -1,6 +1,6 @@
 
-msgid "Module `yaml`"
-msgstr "Модуль `yaml`"
+msgid "Module yaml"
+msgstr "Модуль yaml"
 
 msgid "Overview"
 msgstr "Общие сведения"

--- a/locale/ru/LC_MESSAGES/reference/reference_rock/expirationd.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_rock/expirationd.po
@@ -1,6 +1,6 @@
 
-msgid "Module `expirationd`"
-msgstr "Модуль `expirationd`"
+msgid "Module expirationd"
+msgstr "Модуль expirationd"
 
 msgid ""
 "For a commercial-grade example of a Lua `rock "

--- a/locale/ru/LC_MESSAGES/reference/reference_rock/membership.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_rock/membership.po
@@ -1,6 +1,6 @@
 
-msgid "Module `membership`"
-msgstr "Модуль `membership`"
+msgid "Module membership"
+msgstr "Модуль membership"
 
 msgid ""
 "This module is a ``membership`` library for Tarantool based on a gossip "

--- a/locale/ru/LC_MESSAGES/reference/reference_rock/vshard/index.po
+++ b/locale/ru/LC_MESSAGES/reference/reference_rock/vshard/index.po
@@ -1,6 +1,6 @@
 
-msgid "Module `vshard`"
-msgstr "Модуль `vshard`"
+msgid "Module vshard"
+msgstr "Модуль vshard"
 
 msgid ""
 "The ``vshard`` module introduces an advanced sharding feature based on the "

--- a/locale/ru/LC_MESSAGES/reference/tarantoolctl.po
+++ b/locale/ru/LC_MESSAGES/reference/tarantoolctl.po
@@ -1,6 +1,6 @@
 
-msgid "Utility `tarantoolctl`"
-msgstr "Утилита `tarantoolctl`"
+msgid "Utility tarantoolctl"
+msgstr "Утилита tarantoolctl"
 
 msgid ""
 "``tarantoolctl`` is a utility for administering Tarantool :ref:`instances "


### PR DESCRIPTION
Follow-up to https://github.com/tarantool/doc/pull/2767

Main culprit: https://www.tarantool.io/en/doc/latest/how-to/other/libslave/
Also removing backticks from translated code headers.