### PR TITLE
BITSET and RTREE indexes isolation level in MVCC transaction mode is 'read-committed' (not 'serializable')

### DIFF
--- a/doc/concepts/atomic/transaction_model.rst
+++ b/doc/concepts/atomic/transaction_model.rst
@@ -40,7 +40,7 @@ when the disk space is over. In this case, the isolation level of the concurrent
 would be *read committed*.
 
 
-The :ref:`MVСС mode <txn_mode_transaction-manager>` provides several options that allows you to tune 
+The :ref:`MVСС mode <txn_mode_transaction-manager>` provides several options that allow you to tune
 the visibility behavior during transaction execution. To achieve *serializable*, any write transaction 
 should read all data that has already been committed (otherwise it may conflict 
 when it reaches its commit). For read transactions, however, it is sufficient 
@@ -48,7 +48,7 @@ and safe to *read confirmed* data that is on disk (for asynchronous replication)
 (for synchronous replication).
 
 
-So, during transaction execution, the MVCC must choose between *read-commited* or *read-confirmed* visibility, 
+So, during transaction execution, the MVCC must choose between *read-committed* or *read-confirmed* visibility,
 which inevitably leads to the *serializable* isolation level.
 
 
@@ -66,16 +66,16 @@ and can no longer be committed.
 
 
 To minimize the possibility of conflicts, MVCC uses what is called *best-effort* visibility: 
-for write transactions it chooses *read-commited*, for read transactions it chooses *read-confirmed*. 
+for write transactions it chooses *read-committed*, for read transactions it chooses *read-confirmed*.
 Since there is no option for MVCC to analyze the whole transaction to make a decision, it makes the choice on 
 the first operation. The author of the transaction has more knowledge about the whole transaction and could give 
 a hint to minimize conflicts.
 
-Manual usage of *read-commited* for write transactions with reads is completely safe, as this 
+Manual usage of *read-committed* for write transactions with reads is completely safe, as this
 transaction will eventually result in a commit. And if some previous transactions fail, this 
 transaction will inevitably fail as well due to the *serializable* isolation level.
 
-Manual usage of *read-commited* for pure read transactions may be unsafe, as it may lead to phantom reads.
+Manual usage of *read-committed* for pure read transactions may be unsafe, as it may lead to phantom reads.
 
 
 

--- a/doc/concepts/atomic/txn_mode_mvcc.rst
+++ b/doc/concepts/atomic/txn_mode_mvcc.rst
@@ -42,10 +42,17 @@ It consists of two parts:
     in the conflicted transaction will result in errors until the transaction is
     rolled back.
 
-The transaction manager also provides a non-classical snapshot isolation level -- this snapshot is not 
+The transaction manager also provides a non-classical *snapshot* isolation level -- this snapshot is not
 necessarily tied to the start time of the transaction, like the classical snapshot where a transaction 
 can get a consistent snapshot of the database. The conflict manager decides if and when each transaction 
 gets which snapshot. This avoids some conflicts compared to the classic snapshot isolation approach.
+
+..  warning::
+
+    Currently, the :ref:`isolation level <transaction_model_levels>` of BITSET and RTREE indexes
+    in MVCC transaction mode is *read-committed* (not *serializable*, as stated).
+    If a transaction uses these indexes, it can read committed or confirmed data (depending on the isolation level).
+    However, the indexes are subject to different anomalies that can make them unserializable.
 
 ..  _txn_mode_mvcc-enabling:
 
@@ -101,11 +108,9 @@ to the one set in ``box.cfg``.
 You can also set the isolation level in the net.box :ref:`stream:begin() <net_box-stream_begin>` method
 and :ref:`IPROTO_BEGIN <box_protocol-begin>` binary protocol request.
 
-
 Choosing the better option depends on whether you have conflicts or not. 
 If you have many conflicts, you should set a different option or use 
 the :ref:`default transaction mode <txn_mode-default>`.
-
 
 ..  _txn_mode_mvcc-examples:
 

--- a/doc/concepts/data_model/indexes.rst
+++ b/doc/concepts/data_model/indexes.rst
@@ -248,6 +248,13 @@ The option list of this type of index may contain ``dimension`` and ``distance``
 The ``parts`` definition must contain the one and only part with type ``array``.
 RTREE index can accept two types of ``distance`` functions: ``euclid`` and ``manhattan``.
 
+..  warning::
+
+    Currently, the :ref:`isolation level <transaction_model_levels>` of RTREE indexes
+    in :ref:`MVCC transaction mode <txn_mode_mvcc-tnx-manager>` is *read-committed* (not *serializable*, as stated).
+    If a transaction uses these indexes, it can read committed or confirmed data (depending on the isolation level).
+    However, the indexes are subject to different anomalies that can make them unserializable.
+
 **Example 1:**
 
 ..  code-block:: lua
@@ -423,6 +430,13 @@ BITSET indexes
 Bitset is a bit mask. You should use it when you need to search by bit masks.
 This can be, for example, storing a vector of attributes and searching by these
 attributes.
+
+..  warning::
+
+    Currently, the :ref:`isolation level <transaction_model_levels>` of BITSET indexes
+    in :ref:`MVCC transaction mode <txn_mode_mvcc-tnx-manager>` is *read-committed* (not *serializable*, as stated).
+    If a transaction uses these indexes, it can read committed or confirmed data (depending on the isolation level).
+    However, the indexes are subject to different anomalies that can make them unserializable.
 
 **Example 1:**
 


### PR DESCRIPTION
Fixes #3172 