### PR TITLE
Fix IPROTO_EVENT_KEY and IPROTO_EVENT_DATA values

### DIFF
--- a/doc/reference/internals/iproto/keys.rst
+++ b/doc/reference/internals/iproto/keys.rst
@@ -338,11 +338,11 @@ Events and subscriptions
             -   Description
 
         *   -   IPROTO_EVENT_KEY
-            -   0x56 |br| MP_STR
+            -   0x57 |br| MP_STR
             -   :ref:`Event <box-protocol-watchers>` key name
 
         *   -   IPROTO_EVENT_DATA
-            -   0x57 |br| MP_OBJECT
+            -   0x58 |br| MP_OBJECT
             -   :ref:`Event <box-protocol-watchers>` data sent to a remote watcher
 
 :ref:`Learn more about events and subscriptions in iproto <box-protocol-watchers>`.


### PR DESCRIPTION
The patch fixes values of IPROTO_EVENT_KEY and IPROTO_EVENT_DATA [1].

1. https://github.com/tarantool/tarantool/blob/e00f9dad385d02417ea0ddfedb7c668c20b420db/src/box/iproto_constants.h#L152-L154

Staging: https://docs.d.tarantool.io/en/doc/fix-event-keys/reference/internals/iproto/keys/#events-and-subscriptions