### PR TITLE
ci: deploy branch tt without opening PRs

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -2,6 +2,9 @@ name: Deploy to dev server
 
 on:
   pull_request:
+  push:
+    branches:
+      - tt
 jobs:
   deploy-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Branch `tt` holds the documentation for the `tt` CLI tool
which is currently in active development.

New PRs with `tt` CLI documentation will be opened against
branch `tt`. The change in deploy-branch.yml enables
deploying this branch to the test server without opening
PRs against `latest`.

Remove this after merging `tt` to `latest`.

---

Alongside this change, I've set up protection rules for branch `tt` in https://github.com/tarantool/doc/settings/branch_protection_rules/31254572.