### PR TITLE
[tt] ci: cancel outdated workflow runs

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -2,6 +2,29 @@ name: Deploy to dev server
 
 on:
   pull_request:
+
+# Cancel workflow runs on PRs when the PR is updated with a newer commit.
+# Such runs will have a concurrency group named
+# `{github.workflow}-{github.ref}`,
+# for example,
+# `deploy-branch/refs/add-concurrency`.
+#
+# Runs on branches `latest`, `tt`, and also tags, will never be canceled,
+# due to having a unique group name
+# `{github.run_id}-{github.run_attempt}`,
+# for example,
+# `3477882280-1`.
+concurrency:
+  group: ${{
+    (
+    github.ref == 'refs/heads/latest' ||
+    github.ref == 'refs/heads/tt' ||
+    startsWith(github.ref, 'refs/tags/')
+    ) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
 jobs:
   deploy-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/destroy-deployment-manually.yml
+++ b/.github/workflows/destroy-deployment-manually.yml
@@ -36,11 +36,14 @@ jobs:
           max_attempts: 3
 
       - name: Remove GitHub deployment at ${{env.DEPLOYMENT_NAME}}
-        uses: strumwolf/delete-deployment-environment@v2
+        uses: bobheadxi/deployments@v1
+        # remove GH deployment even if webhook failed
+        if: always()
         id: remove-github-deployment
         with:
-          token: "${{ secrets.TARANTOOLBOT_TOKEN }}"
-          environment: ${{ env.DEPLOYMENT_NAME }}
+          step: delete-env
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: "${{ env.DEPLOYMENT_NAME }}"
 
       - name: Send VK Teams message on failures
         # bot token won't be accessible in the forks


### PR DESCRIPTION
Same as https://github.com/tarantool/doc/pull/3235 but for branch https://github.com/tarantool/doc/tree/tt.

Test run: https://github.com/tarantool/doc/actions/runs/3532294138

Concurrency:

- [x] concurrency using stable branches from this repo
- [x] commits start with `ci:`
- [x] concurrency commit goes first in the branch
- [x] concurrency commit has the same text as in the action
- [x] concurrency commit links to https://github.com/tarantool/doc/issues/3234
- [x] concurrency workflow checked https://github.com/tarantool/doc/actions/runs/3532294138

Other improvements:

- [ ] actions/checkout updated
- [ ] bobheadxi/deployments updated
- [x] no nodejs12 warnings in the logs
- [x] destroy-deployments action is using `step: delete-env`
- [ ] destroy-deployment workflow tested 
- [ ] create-deployment workflow tested