### PR TITLE
[tt] Remove kubernetes-operator docs

### DIFF
--- a/.github/workflows/deploy-custom.yml
+++ b/.github/workflows/deploy-custom.yml
@@ -21,9 +21,6 @@ on:
       metrics:
         description: "Metrics branch or commit"
         required: false
-      k8s_operator:
-        description: "Kubernetes branch or commit"
-        required: false
       cpp_driver:
         description: "Cpp driver branch or commit"
         required: false
@@ -63,7 +60,6 @@ jobs:
           echo "INPUT_GRAFANA=${{github.event.inputs.grafana}}" >> $GITHUB_ENV
           echo "INPUT_LUATEST=${{github.event.inputs.luatest}}" >> $GITHUB_ENV
           echo "INPUT_METRICS=${{github.event.inputs.metrics}}" >> $GITHUB_ENV
-          echo "INPUT_K8S_OPERATOR=${{github.event.inputs.k8s_operator}}" >> $GITHUB_ENV
           echo "INPUT_CPP_DRIVER=${{github.event.inputs.cpp_driver}}" >> $GITHUB_ENV
 
       - name: Start dev server deployment

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "modules/luatest"]
 	path = modules/luatest
 	url = https://github.com/tarantool/luatest
-[submodule "modules/tarantool-operator"]
-	path = modules/tarantool-operator
-	url = https://github.com/tarantool/tarantool-operator.git
 [submodule "modules/grafana-dashboard"]
 	path = modules/grafana-dashboard
 	url = https://github.com/tarantool/grafana-dashboard

--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -56,10 +56,6 @@ mkdir -p "${cartridge_cli_po_dest}"
 cd "${cartridge_cli_root}/locale/ru/LC_MESSAGES/doc/" || exit
 find . -name '*.po' -exec cp -rv --parents {} "${cartridge_cli_po_dest}" \;
 
-# Add Cartridge Kubernetes guide to the Cartridge toctree right after Cartridge CLI
-sed -i -e '/Cartridge CLI <cartridge_cli\/index>/a\' -e '\ \ \ Cartridge Kubernetes guide <cartridge_kubernetes_guide/index>' "${cartridge_rst_dest}/index.rst"
-
-
 # Monitoring
 monitoring_root="${project_root}/modules/metrics/doc/monitoring"
 monitoring_dest="${project_root}/doc/book"
@@ -85,16 +81,6 @@ cp -fa "${luatest_root}/rst/." "${luatest_dest}"
 cp "${luatest_root}/README.rst" "${luatest_dest}"
 mkdir -p "${luatest_dest}/_includes/"
 mv -fv "${luatest_dest}/index.rst" "${luatest_dest}/_includes/"
-
-
-# Kubernetes operator
-cartridge_kubernetes_root="${project_root}/modules/tarantool-operator/doc/cartridge_kubernetes_guide"
-cartridge_kubernetes_dest="${cartridge_rst_dest}/"
-
-# Copy Kubernetes operator docs to the right place
-mkdir -p "${cartridge_kubernetes_dest}"
-cp -rfv "${cartridge_kubernetes_root}" "${cartridge_kubernetes_dest}"
-
 
 # Tarantool C++ connector
 tntcxx_root="${project_root}/modules/tntcxx"

--- a/pull_submodules.py
+++ b/pull_submodules.py
@@ -11,7 +11,6 @@ modules = {
     'grafana-dashboard': 'INPUT_GRAFANA',
     'luatest': 'INPUT_LUATEST',
     'metrics': 'INPUT_METRICS',
-    'tarantool-operator': 'INPUT_K8S_OPERATOR',
     'tntcxx': 'INPUT_CPP_DRIVER',
 }
 workdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules')


### PR DESCRIPTION
tarantool/kubernetes-operator has had a major release recently. Now it doesn't have the documentation sources which could be included in the documentation project. Until we set up a new doc project for kubernetes-operator, the submodule will be removed from the docs.

Resolve https://github.com/tarantool/doc/issues/3248