### PR TITLE
[tt] ci: remove wakeup request

### DIFF
--- a/.github/workflows/deploy-custom.yml
+++ b/.github/workflows/deploy-custom.yml
@@ -82,9 +82,6 @@ jobs:
       - run: make json-ru
         id: make-json-ru
 
-      - run: curl ${{secrets.WAKEUP_URL}} --connect-timeout 300 --retry 3 --retry-delay 30 >> /dev/null
-        id: wake-up-server
-
       - run: bash upload_output.sh
         id: upload-output
 


### PR DESCRIPTION
Request on WAKEUP_URL was added in the time when we deployed Heroku, and a server on Heroku used to 'sleep' sometimes, failing to receive deployment webhooks. After such request it came to a working state. This request was initially added in #1978.
