### PR TITLE
Add information about supplementary Tarantool threads

### DIFF
--- a/doc/concepts/atomic/thread_model.rst
+++ b/doc/concepts/atomic/thread_model.rst
@@ -3,96 +3,80 @@
 Thread model
 ============
 
+..  _main_threads:
+
+Main threads
+-------
+
 The thread model assumes that a query received by Tarantool via network 
 is processed with three operating system **threads**:
 
-1.  The **network thread** on the server side receives the query, parses
+1.  The **network thread** (or :ref:`threads <cfg_networking-iproto_threads>`)
+    on the server side receives the query, parses
     the statement, checks if it is correct, and then transforms it into a special
     structure -- a message containing an executable statement and its options.
 
-2.  The network thread ships this message to the instance's
-    **transaction processor thread** (*tx thread*) using a lock-free message bus.
+2.  The network thread sends this message to the instance's
+    **transaction processor thread** (*TX thread*) via a lock-free message bus.
     Lua programs are executed directly in the transaction processor thread,
     and do not need to be parsed and prepared.
 
-    The tx thread either use space index to find and update the tuple, 
-    or executes stored function, that will perform some data operations.
+    The TX thread either uses a space index to find and update the tuple,
+    or executes a stored function that performs a data operation.
 
-3.  The execution of operation will result in a message to the 
-    :ref:`write-ahead logging (WAL) <internals-wal>` thread to commit 
-    the transaction and the fiber executing the transaction will be suspended. 
-    When the transaction will result in a COMMIT or ROLLBACK, :ref:`WAL <internals-wal>` thread will 
-    reply with a message to the TX, fiber will be resumed to have an ability 
-    to process the result of transaction and the result of fiber execution 
-    will be passed to the network thread, and the network thread returns 
-    the result to the client.
+3.  The execution of the operation results in a message to the
+    :ref:`write-ahead logging (WAL) <internals-wal>` thread used to commit
+    the transaction and the fiber executing the transaction is suspended.
+    When the transaction results in a COMMIT or ROLLBACK, the following actions are taken:
+
+    * The WAL thread responds with a message to the TX thread.
+
+    * The fiber executing the transaction is resumed to process the result of the transaction.
+
+    * The result of the fiber execution is passed to the network thread,
+      and the network thread returns the result to the client.
 
 
 ..  note::
 
-    There is only one tx thread in Tarantool. 
+    There is only one TX thread in Tarantool.
     Some users are used to the idea that there can be multiple threads 
-    working on the database. For example, thread #1 reads row #x while 
-    thread #2 writes row #y. With Tarantool, this never happens. 
-    Only the tx thread can access the database, 
-    and there is only one tx thread for each Tarantool instance.
+    working on the database. For example, thread #1 reads a row #x while
+    thread #2 writes a row #y. With Tarantool this does not happen.
+    Only the TX thread can access the database,
+    and there is only one TX thread for each Tarantool instance.
 
 
-The tx thread can handle many :ref:`fibers <fiber-fibers>` -- 
-a set of computer instructions that may contain "**yield**" signals. 
-The tx thread executes all computer instructions up to a 
+The TX thread can handle many :ref:`fibers <fiber-fibers>` --
+a set of computer instructions that can contain "**yield**" signals.
+The TX thread executes all computer instructions up to a
 yield signal, and then switches to execute the instructions of another fiber.
 
 
-:ref:`Yields <app-yields>` must happen, otherwise the tx thread would 
+:ref:`Yields <app-yields>` must happen, otherwise the TX thread would
 be permanently stuck on the same fiber.
 
-..  _thread_model-example:
 
-Example
+..  _supplementary_threads:
+
+Supplementary threads
 -------
 
-Create space ``tester``: 
+There are also several auxiliary threads that serve additional capabilities:
 
-..  code-block:: tarantoolsession
+* For :ref:`replication <replication-architecture>`, Tarantool creates a separate thread for each connected replica.
+  This thread reads a write-ahead log and sends it to the replica, following its position in the log.
+  Separate threads are required because each replica can point to a different position in the log and can run at different speeds.
 
-    box.schema.create_space('tester',{ if_not_exists = true; })
-    
-    box.space.tester:format( {
-        { name = 'id';     type = 'number' },
-        { name = 'name';   type = 'string' },
-        { name = 'data';   type = '*'      },
-    } );
+* There is a thread pool for ad hoc asynchronous tasks,
+  such as a DNS resolver or :ref:`fsync <cfg_binary_logging_snapshots-wal_mode>`.
 
-    box.space.tester:create_index('primary', {
-       parts = {{ 'id','number' }};
-       if_not_exists = true;
-    })
+* There are OpenMP threads used to parallelize sorting
+  (hence, to parallelize building :ref:`indexes <concepts-data_model_indexes>`).
+  For example, this is applicable when Tarantool is restoring from a
+  :ref:`snapshot <internals-snapshot>` with a large amount of data
+  and needs to sort a secondary index if it is ordered by something other than the primary order.
 
-    box.space.tester:update({3}, {{'=', 'name, 'size'}, {'=', 'data', 0}})
+  ..  note::
 
-
-Perform a basic operation with this query: 
-
-..  code-block:: tarantoolsession
-
-    box.space.tester:update({3}, {{'=', 'name, 'size'}, {'=', 'data', 0}})   
-
-
-This is equivalent to the following SQL statement:
-
-..  code-block:: SQL
-
-    UPDATE tester SET "name" = 'size', "data" = 0 WHERE "id" = 3
-    
-..  note::
-
-    It is better to follow best practice and use SQL with placeholders:
-    
-    ``box.execute([[ UPDATE tester SET "name" = ?, "data" = ? WHERE "id" = ? ]], 'size', 0, 123)``
-    
-
-
-
-
-
+    The maximum number of OpenMP threads can be controlled by the ``OMP_NUM_THREADS`` environment variable.

--- a/doc/concepts/atomic/thread_model.rst
+++ b/doc/concepts/atomic/thread_model.rst
@@ -6,9 +6,9 @@ Thread model
 ..  _main_threads:
 
 Main threads
--------
+------------
 
-The thread model assumes that a query received by Tarantool via network 
+The thread model assumes that a :ref:`query <index-box_operations>` received by Tarantool via network
 is processed with three operating system **threads**:
 
 1.  The **network thread** (or :ref:`threads <cfg_networking-iproto_threads>`)
@@ -60,9 +60,9 @@ be permanently stuck on the same fiber.
 ..  _supplementary_threads:
 
 Supplementary threads
--------
+---------------------
 
-There are also several auxiliary threads that serve additional capabilities:
+There are also several supplementary threads that serve additional capabilities:
 
 * For :ref:`replication <replication-architecture>`, Tarantool creates a separate thread for each connected replica.
   This thread reads a write-ahead log and sends it to the replica, following its position in the log.


### PR DESCRIPTION
Added information about OpenMP threads to the `Thread model` topic inside the `Transactions` section. It's not the best place for this information - IMO, `Thread model` should be placed outside of `Transactions` and should cover all thread types used in Tarantool (with links to corresponding topics and configuration properties). Given that this task requires deep investigation and restructuring docs, I've decided to place info about OpenMP threads inside the a `Supplementary threads` chapter. Here is the summary of the changes:
- Improved the part about the main threads: fixed grammar and wording.
- Added the new `Supplementary threads` chapter with the information OpenMP threads.
- Removed the [Example](https://www.tarantool.io/en/doc/latest/concepts/atomic/thread_model/#example) chapter as I don't understand how it's related to Thread model.

Resolves #3293