### PR TITLE
ci: use bobheadxi/deployments@v1.3.0

### DIFF
--- a/.github/workflows/destroy-deployment-manually.yml
+++ b/.github/workflows/destroy-deployment-manually.yml
@@ -31,8 +31,8 @@ jobs:
         id: delete-deployment-webhook
         with:
           command: bash webhooks/delete_deployment.sh
-          timeout_seconds: 15
-          retry_wait_seconds: 15
+          timeout_seconds: 30
+          retry_wait_seconds: 30
           max_attempts: 3
 
       - name: Remove GitHub deployment at ${{env.DEPLOYMENT_NAME}}

--- a/.github/workflows/destroy-deployment-manually.yml
+++ b/.github/workflows/destroy-deployment-manually.yml
@@ -36,7 +36,7 @@ jobs:
           max_attempts: 3
 
       - name: Remove GitHub deployment at ${{env.DEPLOYMENT_NAME}}
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@v1.3.0
         # remove GH deployment even if webhook failed
         if: always()
         id: remove-github-deployment

--- a/.github/workflows/destroy-deployment.yml
+++ b/.github/workflows/destroy-deployment.yml
@@ -35,7 +35,7 @@ jobs:
           max_attempts: 3
 
       - name: Remove GitHub deployment at branch-${{env.DEPLOYMENT_NAME}}
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@v1.3.0
         # remove GH deployment even if webhook failed
         if: always()
         id: remove-github-deployment

--- a/.github/workflows/destroy-deployment.yml
+++ b/.github/workflows/destroy-deployment.yml
@@ -30,8 +30,8 @@ jobs:
         id: delete-deployment-webhook
         with:
           command: bash webhooks/delete_deployment.sh
-          timeout_seconds: 15
-          retry_wait_seconds: 15
+          timeout_seconds: 30
+          retry_wait_seconds: 30
           max_attempts: 3
 
       - name: Remove GitHub deployment at branch-${{env.DEPLOYMENT_NAME}}


### PR DESCRIPTION
This patch fixes retry_wait_seconds for nick-field/retry action
so the command has enough time for correct executing. Before this patch,
we had this step always failing with the real webhook task finished
successfully.

Part of https://github.com/tarantool/doc/issues/3390

_______

Since bobheadxi/deployments@v1.4.0 we had a CI failure with the 
following error in `destroy-deployments` and  
`destroy-deployments-manually`, step `remove-github-deployment`:                                                                                                        
```                                                                                                                     
unexpected error encountered: HttpError: Resource not accessible by integration                                         
Error: unexpected error encountered: HttpError: Resource not accessible by integration - see logs for more information  
```                                                                                                                     
                                                                                                                        
This patch returns version 1.3.0 that worked OK.                                                                        
                                                                                                                        
Part of #3390
______

Closes #3390 