### PR TITLE
ci: fix `delete-deployment` workflow

### DIFF
--- a/.github/workflows/destroy-deployment-manually.yml
+++ b/.github/workflows/destroy-deployment-manually.yml
@@ -31,8 +31,8 @@ jobs:
         id: delete-deployment-webhook
         with:
           command: bash webhooks/delete_deployment.sh
-          timeout_seconds: 15
-          retry_wait_seconds: 15
+          timeout_seconds: 30
+          retry_wait_seconds: 30
           max_attempts: 3
 
       - name: Remove GitHub deployment at ${{env.DEPLOYMENT_NAME}}

--- a/.github/workflows/destroy-deployment.yml
+++ b/.github/workflows/destroy-deployment.yml
@@ -30,8 +30,8 @@ jobs:
         id: delete-deployment-webhook
         with:
           command: bash webhooks/delete_deployment.sh
-          timeout_seconds: 15
-          retry_wait_seconds: 15
+          timeout_seconds: 30
+          retry_wait_seconds: 30
           max_attempts: 3
 
       - name: Remove GitHub deployment at branch-${{env.DEPLOYMENT_NAME}}


### PR DESCRIPTION
This patch fixes retry_wait_seconds for nick-field/retry action so the command has enough time for correct executing. Before this patch, we had this step always failing with the real webhook task finished successfully.

Part of #3390