### PR TITLE
Add Homebrew installation for tt

### DIFF
--- a/doc/dev_guide/building_from_source.rst
+++ b/doc/dev_guide/building_from_source.rst
@@ -276,7 +276,7 @@ See also
 
 *   `Tarantool README.md <https://github.com/tarantool/tarantool/blob/master/README.md>`_
 
-*   `Building Tarantool on MacOS <https://github.com/tarantool/tarantool/blob/master/README.MacOSX>`_
+*   `Building Tarantool on macOS <https://github.com/tarantool/tarantool/blob/master/README.MacOSX>`_
 
 *   `Building Tarantool on FreeBSD <https://github.com/tarantool/tarantool/blob/master/README.FreeBSD>`_
 

--- a/doc/reference/tooling/luajit_memprof.rst
+++ b/doc/reference/tooling/luajit_memprof.rst
@@ -184,8 +184,8 @@ the session:
 
 ..  note::
 
-    On MacOS, a report will be different for the same chunk of code because
-    Tarantool and LuaJIT are built with the GC64 mode enabled for MacOS.
+    On macOS, a report will be different for the same chunk of code because
+    Tarantool and LuaJIT are built with the GC64 mode enabled for macOS.
 
 
 Let's examine the report structure. A report has four sections:

--- a/doc/reference/tooling/tt_cli/installation.rst
+++ b/doc/reference/tooling/tt_cli/installation.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 To install the ``tt`` command-line utility, use a package manager -- Yum or
-APT on Linux, or Homebrew on MacOS. If you need a specific build, you can build
+APT on Linux, or Homebrew on macOS. If you need a specific build, you can build
 ``tt`` from sources.
 
 Using Linux package managers
@@ -26,10 +26,10 @@ The installation command looks like this:
 
       $ sudo yum install tt
 
-Using Homebrew on MacOS
+Using Homebrew on macOS
 -----------------------
 
-On MacOS, use Homebrew to install ``tt``:
+On macOS, use Homebrew to install ``tt``:
 
 .. code-block:: console
 

--- a/doc/reference/tooling/tt_cli/installation.rst
+++ b/doc/reference/tooling/tt_cli/installation.rst
@@ -1,15 +1,15 @@
 Installation
 ============
 
-To install the ``tt`` command-line utility, use a package manager -- ``yum``
-or ``apt``. If you need a specific ``tt`` build or use MacOS, you can build
+To install the ``tt`` command-line utility, use a package manager -- Yum or
+APT on Linux, or Homebrew on MacOS. If you need a specific build, you can build
 ``tt`` from sources.
 
-Using package managers
-----------------------
+Using Linux package managers
+----------------------------
 
-On Linux systems, you can install with ``yum`` or ``apt`` package managers from
-the ``tarantool/modules`` repository. Learn how to `add this repository
+On Linux systems, you can install ``tt`` with ``yum`` or ``apt`` package managers
+from the ``tarantool/modules`` repository. Learn how to `add this repository
 <https://www.tarantool.io/en/download/os-installation/>`_.
 
 The installation command looks like this:
@@ -26,13 +26,19 @@ The installation command looks like this:
 
       $ sudo yum install tt
 
+Using Homebrew on MacOS
+-----------------------
+
+On MacOS, use Homebrew to install ``tt``:
+
+.. code-block:: console
+
+  $ brew install tt
+
 Building from sources
 ---------------------
 
-.. note::
-
-    As of ``tt`` 1.0.0, there is no pre-built version for MacOS, so building
-    from sources is the only supported way to install ``tt`` on it.
+To build ``tt`` from sources:
 
 1.  Install third-party software required for building ``tt``:
 

--- a/doc/release/2.10.0.rst
+++ b/doc/release/2.10.0.rst
@@ -281,7 +281,7 @@ LuaJIT
 -   Introduced support for ``LJ_DUALNUM`` mode in ``luajit-gdb.py``
     (:tarantool-issue:`6224`).
 
--   Introduced preliminary support of GNU/Linux ARM64 and MacOS M1. In
+-   Introduced preliminary support of GNU/Linux ARM64 and macOS M1. In
     the scope of this activity, the following issues have been resolved:
 
     -   Introduced support for a full 64-bit range of lightuserdata values


### PR DESCRIPTION
Resolves #3423 

Additionally, fixes `macOS` spelling across doc pages (lowercase `m`).

Deployment: https://docs.d.tarantool.io/en/doc/gh-3423-tt-homebrew/reference/tooling/tt_cli/installation/