### PR TITLE
Document bootstrap_strategy

### DIFF
--- a/doc/concepts/replication/repl_architecture.rst
+++ b/doc/concepts/replication/repl_architecture.rst
@@ -242,9 +242,8 @@ The maximal number of replicas in a mesh is 32.
 Orphan status
 -------------
 
-During ``box.cfg()``, an instance will try to join all masters listed
+During ``box.cfg()``, an instance tries to join all nodes listed
 in :ref:`box.cfg.replication <cfg_replication-replication>`.
-If the instance does not succeed with at least
-the number of masters specified in
-:ref:`replication_connect_quorum <cfg_replication-replication_connect_quorum>`,
-then it will switch to :ref:`orphan status <internals-replication-orphan_status>`.
+If the instance does not succeed with connecting to the required number of nodes
+(see :ref:`bootstrap_strategy <cfg_replication-bootstrap_strategy>`),
+it switches to the :ref:`orphan status <internals-replication-orphan_status>`.

--- a/doc/how-to/replication/repl_leader_elect.rst
+++ b/doc/how-to/replication/repl_leader_elect.rst
@@ -44,13 +44,12 @@ Configuration
 *   ``election_fencing_enabled`` -- switches the :ref:`leader fencing mode <repl_leader_elect_fencing>` on and off.
     For the details, refer to the :ref:`option description <cfg_replication-election_fencing_enabled>` in the configuration reference.
 
-Besides, it is important to know that
-being a leader is not the only requirement for a node to be writable.
-A leader node should have its :ref:`read_only <cfg_basic-read_only>` option set
-to ``false`` (``box.cfg{read_only = false}``),
-and its :ref:`connectivity quorum <cfg_replication-replication_connect_quorum>`
-should be satisfied (``box.cfg{replication_connect_quorum = <count>}``)
-or disabled (``box.cfg{replication_connect_quorum = 0}``).
+It is important to know that being a leader is not the only requirement for a node to be writable.
+The leader should also satisfy the following requirements:
+
+*   The :ref:`read_only <cfg_basic-read_only>` option is to ``false``.
+
+*   The leader shouldn't be in the orphan state.
 
 Nothing prevents from setting the ``read_only`` option to ``true``,
 but the leader just won't be writable then. The option doesn't affect the

--- a/doc/how-to/replication/repl_leader_elect.rst
+++ b/doc/how-to/replication/repl_leader_elect.rst
@@ -47,7 +47,7 @@ Configuration
 It is important to know that being a leader is not the only requirement for a node to be writable.
 The leader should also satisfy the following requirements:
 
-*   The :ref:`read_only <cfg_basic-read_only>` option is to ``false``.
+*   The :ref:`read_only <cfg_basic-read_only>` option is set to ``false``.
 
 *   The leader shouldn't be in the orphan state.
 

--- a/doc/how-to/vshard_quick.rst
+++ b/doc/how-to/vshard_quick.rst
@@ -131,7 +131,6 @@ The configuration of a simple sharded cluster can look like this:
 
     local cfg = {
         memtx_memory = 100 * 1024 * 1024,
-        replication_connect_quorum = 0,
         bucket_count = 10000,
         rebalancer_disbalance_threshold = 10,
         rebalancer_max_receiving = 100,

--- a/doc/reference/configuration/cfg_replication.rst
+++ b/doc/reference/configuration/cfg_replication.rst
@@ -217,7 +217,7 @@
     *   ``auto``: in this case, a node doesn't boot if a half or more of other nodes in a replica set are not connected.
         For example, if the :ref:`replication <cfg_replication-replication>` parameter contains 2 or 3 nodes,
         a node requires 2 connected instances.
-        In case of 4 or 5 nodes, at least 3 connected instances are required.
+        In the case of 4 or 5 nodes, at least 3 connected instances are required.
         Moreover, a bootstrap leader fails to boot unless every connected node has chosen it as a bootstrap leader.
 
     *   ``legacy``: in this case, a node requires the :ref:`replication_connect_quorum <cfg_replication-replication_connect_quorum>` number of other nodes to be connected.

--- a/doc/reference/configuration/cfg_replication.rst
+++ b/doc/reference/configuration/cfg_replication.rst
@@ -211,16 +211,16 @@
 .. confval:: bootstrap_strategy
 
     Since version 2.11.
-    Allows you to specify a strategy used to bootstrap a :ref:`replica set <replication-bootstrap>`.
+    Specifies a strategy used to bootstrap a :ref:`replica set <replication-bootstrap>`.
     The following strategies are available:
 
-    *   ``auto``: in this case, a node doesn't boot if a half or more of other nodes in a replica set are not connected.
+    *   ``auto``: a node doesn't boot if a half or more of other nodes in a replica set are not connected.
         For example, if the :ref:`replication <cfg_replication-replication>` parameter contains 2 or 3 nodes,
         a node requires 2 connected instances.
         In the case of 4 or 5 nodes, at least 3 connected instances are required.
         Moreover, a bootstrap leader fails to boot unless every connected node has chosen it as a bootstrap leader.
 
-    *   ``legacy``: in this case, a node requires the :ref:`replication_connect_quorum <cfg_replication-replication_connect_quorum>` number of other nodes to be connected.
+    *   ``legacy``: a node requires the :ref:`replication_connect_quorum <cfg_replication-replication_connect_quorum>` number of other nodes to be connected.
 
     | Type: string
     | Default: auto
@@ -253,7 +253,7 @@
 
     Since version 1.9.0.
     Specifies the number of nodes to be up and running to start a replica set.
-    This option is in effect if :ref:`bootstrap_strategy <cfg_replication-bootstrap_strategy>`
+    Since version 2.11, this option is in effect if :ref:`bootstrap_strategy <cfg_replication-bootstrap_strategy>`
     is set to ``legacy``.
 
     This parameter has effect during :ref:`bootstrap <replication-leader>` or

--- a/doc/reference/reference_lua/box_cfg.rst
+++ b/doc/reference/reference_lua/box_cfg.rst
@@ -73,7 +73,6 @@ default settings to all the parameters:
       replicaset_uuid              = nil -- generated automatically
       replication                  = nil
       replication_anon             = false
-      replication_connect_quorum   = nil
       replication_connect_timeout  = 30
       replication_skip_conflict    = false
       replication_sync_lag         = 10


### PR DESCRIPTION
- Added the [bootstrap_strategy](https://docs.d.tarantool.io/en/doc/2.11-bootstrap-strategy/reference/configuration/#confval-bootstrap_strategy) property description to reference.
- Updated [replication_connect_quorum](https://docs.d.tarantool.io/en/doc/2.11-bootstrap-strategy/reference/configuration/#confval-replication_connect_quorum) description.
- Updated the [Orphan status](https://docs.d.tarantool.io/en/doc/2.11-bootstrap-strategy/concepts/replication/repl_architecture/#orphan-status) paragraph.
- Added info about the bootstrap strategy to the [Orphan status](https://docs.d.tarantool.io/en/doc/2.11-bootstrap-strategy/dev_guide/internals/replication/orphan/) topic.
- Updated [Managing leader elections](https://docs.d.tarantool.io/en/doc/2.11-bootstrap-strategy/how-to/replication/repl_leader_elect/#configuration).
- Removed the `replication_connect_quorum` property from the `box.cfg` reference and from the vshard code sample.