### PR TITLE
ci: add myst-parser

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   deploy-branch:
     runs-on: ubuntu-latest
-    container: tarantool/doc-builder:fat-4.1
+    container: tarantool/doc-builder:fat-4.3
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -38,6 +38,10 @@ jobs:
       TARANTOOL_UPDATE_URL: ${{secrets.TARANTOOL_DEVELOP_UPDATE_URL}}
       VKTEAMS_BOT_TOKEN: ${{secrets.VKTEAMS_TARANTOOLBOT_TOKEN}}
     steps:
+      - name: Prevent dubious ownership
+        id: add-safe-directory
+        run: git config --global --add safe.directory '*'
+
       - uses: actions/checkout@v3
         id: checkout
         with:

--- a/.github/workflows/deploy-custom.yml
+++ b/.github/workflows/deploy-custom.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   custom-deploy-branch:
     runs-on: ubuntu-latest
-    container: tarantool/doc-builder:fat-4.1
+    container: tarantool/doc-builder:fat-4.3
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -39,6 +39,10 @@ jobs:
       TARANTOOL_UPDATE_URL: ${{secrets.TARANTOOL_DEVELOP_UPDATE_URL}}
       VKTEAMS_BOT_TOKEN: ${{secrets.VKTEAMS_TARANTOOLBOT_TOKEN}}
     steps:
+      - name: Prevent dubious ownership
+        id: add-safe-directory
+        run: git config --global --add safe.directory '*'
+
       - uses: actions/checkout@v3
         id: checkout
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    container: tarantool/doc-builder:fat-4.1
+    container: tarantool/doc-builder:fat-4.3
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -22,6 +22,10 @@ jobs:
       DEPLOYMENT_NAME: latest
       VKTEAMS_BOT_TOKEN: ${{secrets.VKTEAMS_TARANTOOLBOT_TOKEN}}
     steps:
+      - name: Prevent dubious ownership
+        id: add-safe-directory
+        run: git config --global --add safe.directory '*'
+
       - uses: actions/checkout@v3
         id: checkout
         with:

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ and refresh the browser page.
 
 ..  code-block:: bash
 
-    docker run --rm -it -p 8000:8000 -v $(pwd):/doc tarantool/doc-builder:fat-4.1 sh -c "make autobuild"
+    docker run --rm -it -p 8000:8000 -v $(pwd):/doc tarantool/doc-builder:fat-4.3 sh -c "make autobuild"
 
 First build will take some time.
 When it's done, open `127.0.0.1:8000 <http://127.0.0.1:8000>`_ in the browser.

--- a/conf.py
+++ b/conf.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.abspath('..'))
 master_doc = 'index'
 
 extensions = [
+    'myst_parser',
     'sphinx.ext.todo',
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
@@ -50,7 +51,10 @@ plantuml_output_format = 'svg_img'
 imgmath_image_format = 'svg'
 
 primary_domain = 'lua'
-source_suffix = '.rst'
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 project = u'Tarantool'
 


### PR DESCRIPTION
* Updated doc-builder version to 4.3 with myst-parser
* Added myst_parser to config
* Ignored dubious ownership error with `git config --add safe.directory`

Before the ignor, new build had the following error:
```
fatal: detected dubious ownership in repository at '/__w/doc/doc'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/doc/doc
Error: Process completed with exit code 128.
```


Part of https://github.com/tarantool/doc-builder/issues/21