### PR TITLE
Document deprecation of 'GT' iterator type for the 'HASH' index

### DIFF
--- a/doc/concepts/data_model/indexes.rst
+++ b/doc/concepts/data_model/indexes.rst
@@ -197,9 +197,13 @@ We give an overview of index features in the following table:
 
         *   - :doc:`iterator types </reference/reference_lua/box_index/pairs>`
             - ALL, EQ, REQ, GT, GE, LT, LE
-            - ALL, EQ, GT
+            - ALL, EQ
             - ALL, EQ, GT, GE, LT, LE, OVERLAPS, NEIGHBOR
             - ALL, EQ, BITS_ALL_SET, BITS_ANY_SET, BITS_ALL_NOT_SET
+
+.. NOTE::
+
+    In :doc:`2.11.0 </release/2.11.0>`, the ``GT`` index type is deprecated for HASH indexes.
 
 .. _indexes-tree:
 

--- a/doc/reference/reference_lua/box_index/pairs.rst
+++ b/doc/reference/reference_lua/box_index/pairs.rst
@@ -202,19 +202,6 @@ index_object:pairs()
             |               |           | The number of returned tuples will be 0 or 1.  |
             |               |           | This is the default.                           |
             +---------------+-----------+------------------------------------------------+
-            | box.index.GT  | search    | The comparison operator is '>' (greater than). |
-            | or 'GT'       | value     | If a hash of an index key is greater than a    |
-            |               |           | hash of a search value, it matches.            |
-            |               |           | Tuples are returned in ascending order by hash |
-            |               |           | of index key, which will appear to be random.  |
-            |               |           | Provided that the space is not being updated,  |
-            |               |           | one can retrieve all the tuples in a space,    |
-            |               |           | N tuples at a time, by using                   |
-            |               |           | {iterator='GT', limit=N}                       |
-            |               |           | in each search, and using the last returned    |
-            |               |           | value from the previous result as the start    |
-            |               |           | search value for the next search.              |
-            +---------------+-----------+------------------------------------------------+
 
             **Iterator types for BITSET indexes**
 


### PR DESCRIPTION
- Removed `GT` mention for HASH from the [Index types](https://docs.d.tarantool.io/en/doc/2.11-deprecate-gt-hash/concepts/data_model/indexes/#index-types) section and added a note about deprecation.
- Removed `GT` mention from the [index_object:pairs()](https://docs.d.tarantool.io/en/doc/2.11-deprecate-gt-hash/reference/reference_lua/box_index/pairs/) description.