### PR TITLE
Deprecated fiber APIs

### DIFF
--- a/doc/dev_guide/reference_capi/fiber.rst
+++ b/doc/dev_guide/reference_capi/fiber.rst
@@ -81,7 +81,7 @@
 
 .. c:function:: bool fiber_set_cancellable(bool yesno)
 
-    Make it possible or not possible to wakeup the current fiber immediately
+    Deprecated since :doc:`2.11.0 </release/2.11.0>`. Make it possible or not possible to wakeup the current fiber immediately
     when it's cancelled.
 
     :param struct fiber* f: fiber

--- a/doc/reference/reference_lua/fiber.rst
+++ b/doc/reference/reference_lua/fiber.rst
@@ -670,6 +670,10 @@ API reference
     zero for the latest measurement. This lowers the precision of our computations,
     so the bigger ``cpu misses`` value the lower the precision of ``fiber.top()`` results.
 
+    .. NOTE::
+
+        With :doc:`2.11.0 </release/2.11.0>`, ``cpu_misses`` is deprecated and always returns 0.
+
     **Example:**
 
     ..  code-block:: tarantoolsession


### PR DESCRIPTION
Marked `cpu_misses` and `fiber_set_cancellable` as deprecated and removed the description for `cpu_misses`.