### PR TITLE
Update tt install doc to the new syntax

### DIFF
--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -29,6 +29,8 @@ Flags
         :widths: 20 80
         :header-rows: 0
 
+        *   -   ``--dynamic``
+            -   (``tarantool`` and ``tarantool-ee``) Use dynamic linking for building Tarantool
         *   -   ``-f``
 
                 ``--force``
@@ -42,7 +44,7 @@ Flags
         *   -   ``--reinstall``
             -   Reinstall a previously installed program
         *   -   ``--use-docker``
-            -   Build Tarantool in an Ubuntu 16.04 Docker container
+            -   (``tarantool`` and ``tarantool-ee``) Build Tarantool in an Ubuntu 18.04 Docker container
 
 Details
 -------

--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -5,7 +5,7 @@ Installing Tarantool software
 
 ..  code-block:: bash
 
-    tt install PROGRAM_NAME[=version] [flags]
+    tt install PROGRAM_NAME [version] [flags]
 
 ``tt install`` installs the latest or an explicitly specified version of Tarantool
 or ``tt``. The possible values of ``PROGRAM_NAME`` are:
@@ -72,14 +72,14 @@ Example
 
         tt install tarantool
 
-*   Install Tarantool 2.10.5 from the local repository:
+*   Install Tarantool 2.11.0 from the local repository:
 
     ..  code-block:: bash
 
-        tt install tarantool=2.10.5 --local-repo
+        tt install tarantool 2.11.0 --local-repo
 
-*   Reinstall Tarantool 2.10.5:
+*   Reinstall Tarantool 2.10.7:
 
     ..  code-block:: bash
 
-        tt install tarantool=2.10.5 --reinstall
+        tt install tarantool 2.10.7 --reinstall

--- a/doc/reference/tooling/tt_cli/search.rst
+++ b/doc/reference/tooling/tt_cli/search.rst
@@ -29,10 +29,14 @@ Flags
         :widths: 20 80
         :header-rows: 0
 
+        *   -   ``--debug``
+            -   (``tarantool-ee`` only) Search for debug builds of Tarantool Enterprise SDK
         *   -   ``--local-repo``
             -   Search in the local repository, which is specified in the
                 :ref:`repo section <tt-config_file_repo>` of the ``tt``
-                configuration file.
+                configuration file
+        *   -   ``--version``
+            -   (``tarantool-ee`` only) Tarantool Enterprise version
 
 Example
 --------

--- a/doc/reference/tooling/tt_cli/uninstall.rst
+++ b/doc/reference/tooling/tt_cli/uninstall.rst
@@ -5,7 +5,7 @@ Uninstalling Tarantool software
 
 ..  code-block:: bash
 
-    tt uninstall PROGRAM_NAME
+    tt uninstall PROGRAM_NAME [version]
 
 ``tt uninstall`` uninstalls a previously :doc:`installed <install>` Tarantool version.
 
@@ -16,4 +16,4 @@ Uninstall Tarantool 2.10.4:
 
 ..  code-block:: bash
 
-    tt uninstall tarantool=2.10.4
+    tt uninstall tarantool 2.10.4


### PR DESCRIPTION
Resolves #3514 

* Update the `tt install/uninstall` version syntax from `tt install <product>=<version>`` to `tt install <product> <version> (without the `equals` sign).
* Add new flags for `tt search` and `tt install`

Deployment: 
- https://docs.d.tarantool.io/en/doc/gh-3514-tt-install-fix/reference/tooling/tt_cli/install/
- https://docs.d.tarantool.io/en/doc/gh-3514-tt-install-fix/reference/tooling/tt_cli/uninstall/
