### PR TITLE
upload_output: fixed PDF file name

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -78,6 +78,10 @@ jobs:
         id: make-pdf
       - run: make pdf-ru
         id: make-pdf-ru
+      - run: make singlehtml
+        id: make-singlehtml
+      - run: make singlehtml-ru
+        id: make-singlehtml-ru
 
       - run: bash upload_output.sh
         id: upload-output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,10 @@ jobs:
         id: make-pdf
       - run: make pdf-ru
         id: make-pdf-ru
+      - run: make singlehtml
+        id: make-singlehtml
+      - run: make singlehtml-ru
+        id: make-singlehtml-ru
 
       - run: bash upload_output.sh
         id: upload-output

--- a/doc/pdf_toc.rst
+++ b/doc/pdf_toc.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. ifconfig:: builder == 'singlehtml'
+.. ifconfig:: builder == 'pdf'
 
     ---------------------------------------------------------------------------
                            Tarantool - Documentation
@@ -14,7 +14,7 @@
     how-to/index
     concepts/index
     CRUD operations <reference/reference_lua/box_space>
-    Cluster on Cartridge <book/cartridge/index>
+    book/cartridge/index
     book/admin/index
     book/connectors
     reference/index

--- a/pdf/conf.py
+++ b/pdf/conf.py
@@ -1,8 +1,13 @@
 exec(open('../conf.py').read())
 
-master_doc = 'singlehtml'
-
 locale_dirs = ['../locale']
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title, author, documentclass
+# [howto/manual]).
+latex_documents = [
+ ('pdf_toc', 'tarantool.tex', u'Tarantool Community Edition', u'', 'manual'),
+]
 
 extensions = [
     'myst_parser',
@@ -24,3 +29,4 @@ extensions = [
     'ext.ModuleBlock',
     'ext.DownloadPageBlock'
 ]
+

--- a/upload_output.sh
+++ b/upload_output.sh
@@ -17,11 +17,11 @@ aws s3 sync output/json/_build_en/json/_images $S3_PATH/$BRANCH/images_en --endp
 aws s3 sync output/json/_build_ru/json/_images $S3_PATH/$BRANCH/images_ru --endpoint-url=$ENDPOINT_URL --delete --size-only
 
 # upload pdf files
-if [ -f output/_latex_en/Tarantool.pdf ]; then
-  aws s3 cp --acl public-read output/_latex_en/Tarantool.pdf $S3_PATH/$BRANCH/Tarantool-en.pdf --endpoint-url=$ENDPOINT_URL
+if [ -f output/_latex_en/tarantool.pdf ]; then
+  aws s3 cp --acl public-read output/_latex_en/tarantool.pdf $S3_PATH/$BRANCH/Tarantool-en.pdf --endpoint-url=$ENDPOINT_URL
 fi
-if [ -f output/_latex_ru/Tarantool.pdf ]; then
-  aws s3 cp --acl public-read output/_latex_ru/Tarantool.pdf $S3_PATH/$BRANCH/Tarantool-ru.pdf --endpoint-url=$ENDPOINT_URL
+if [ -f output/_latex_ru/tarantool.pdf ]; then
+  aws s3 cp --acl public-read output/_latex_ru/tarantool.pdf $S3_PATH/$BRANCH/Tarantool-ru.pdf --endpoint-url=$ENDPOINT_URL
 fi
 
 # upload singlehtml and assets

--- a/upload_output.sh
+++ b/upload_output.sh
@@ -25,13 +25,13 @@ if [ -f output/_latex_ru/tarantool.pdf ]; then
 fi
 
 # upload singlehtml and assets
-if [ -f output/html/en/singlehtml.html ]; then
-aws s3 sync --acl public-read output/html/en/_static $S3_PATH/$BRANCH/en/_static --endpoint-url=$ENDPOINT_URL --delete --size-only
-aws s3 sync --acl public-read output/html/en/_images $S3_PATH/$BRANCH/en/_images --endpoint-url=$ENDPOINT_URL --delete --size-only
-aws s3 cp --acl public-read output/html/en/singlehtml.html $S3_PATH/$BRANCH/en/singlehtml.html --endpoint-url=$ENDPOINT_URL
-fi
-if [ -f output/html/ru/singlehtml.html ]; then
-aws s3 sync --acl public-read output/html/ru/_static $S3_PATH/$BRANCH/ru/_static --endpoint-url=$ENDPOINT_URL --delete --size-only
-aws s3 sync --acl public-read output/html/ru/_images $S3_PATH/$BRANCH/ru/_images --endpoint-url=$ENDPOINT_URL --delete --size-only
-aws s3 cp --acl public-read output/html/ru/singlehtml.html $S3_PATH/$BRANCH/ru/singlehtml.html --endpoint-url=$ENDPOINT_URL
-fi
+# if [ -f output/html/en/singlehtml.html ]; then
+# aws s3 sync --acl public-read output/html/en/_static $S3_PATH/$BRANCH/en/_static --endpoint-url=$ENDPOINT_URL --delete --size-only
+# aws s3 sync --acl public-read output/html/en/_images $S3_PATH/$BRANCH/en/_images --endpoint-url=$ENDPOINT_URL --delete --size-only
+# aws s3 cp --acl public-read output/html/en/singlehtml.html $S3_PATH/$BRANCH/en/singlehtml.html --endpoint-url=$ENDPOINT_URL
+# fi
+# if [ -f output/html/ru/singlehtml.html ]; then
+# aws s3 sync --acl public-read output/html/ru/_static $S3_PATH/$BRANCH/ru/_static --endpoint-url=$ENDPOINT_URL --delete --size-only
+# aws s3 sync --acl public-read output/html/ru/_images $S3_PATH/$BRANCH/ru/_images --endpoint-url=$ENDPOINT_URL --delete --size-only
+# aws s3 cp --acl public-read output/html/ru/singlehtml.html $S3_PATH/$BRANCH/ru/singlehtml.html --endpoint-url=$ENDPOINT_URL
+# fi


### PR DESCRIPTION
# pdf: fix upload script, fix toctree

Since September 7, 2020 tarantool documentation PDF file doesn't
uploads. For now, command `make pdf` builds file `tarantool.pdf`,
but on upload, we search file `Tarantool.pdf`. This patch fixes
writing of the file.

Also, this patch fixes toctree file to build PDF like website docs.

Known issues:

1. Firs point of the table of content always goes up-leveled. As
the result, the Overview page replaces with 3 top-level points.
2. In the Connectors section, we have some extra pages we shouldn't
have.

Part of #3548

# singlehtml: build singlehtml version for docx doc

Added singlehtml building to CI, but removed singlehtml saving to S3:
for now, we want to build singlehtml version for future DOCX version
building, but don't want to show this version on the website.

Part of #3548