### PR TITLE
Use the same color for single and multiline comments

### DIFF
--- a/_theme/tarantool/_less/pygmentize.less
+++ b/_theme/tarantool/_less/pygmentize.less
@@ -21,16 +21,16 @@
 }
 
 .highlight {
-    .c   { color: #75715e } /* Comment */
+    .c   { color: #8f8a73 } /* Comment */
     .k   { color: #66d9ef } /* Keyword */
     .l   { color: #ae81ff } /* Literal */
     .n   { color: #f8f8f2 } /* Name */
     .o   { color: #f92672 } /* Operator */
     .p   { color: #f8f8f2 } /* Punctuation */
-    .cm  { color: #75715e } /* Comment.Multiline */
-    .cp  { color: #75715e } /* Comment.Preproc */
-    .c1  { color: #33ffff } /* Comment.Single */
-    .cs  { color: #33ffff } /* Comment.Special */
+    .cm  { color: #8f8a73 } /* Comment.Multiline */
+    .cp  { color: #8f8a73 } /* Comment.Preproc */
+    .c1  { color: #8f8a73 } /* Comment.Single */
+    .cs  { color: #8f8a73 } /* Comment.Special */
     .kc  { color: #66d9ef } /* Keyword.Constant */
     .kd  { color: #66d9ef } /* Keyword.Declaration */
     .kn  { color: #f92672 } /* Keyword.Namespace */

--- a/_theme/tarantool/static/design.css
+++ b/_theme/tarantool/static/design.css
@@ -4694,7 +4694,7 @@ dd {
   /* YAML - Punctuation.Indicator*/
 }
 .highlight .c {
-  color: #75715e;
+  color: #8f8a73;
 }
 .highlight .k {
   color: #66d9ef;
@@ -4712,16 +4712,16 @@ dd {
   color: #f8f8f2;
 }
 .highlight .cm {
-  color: #75715e;
+  color: #8f8a73;
 }
 .highlight .cp {
-  color: #75715e;
+  color: #8f8a73;
 }
 .highlight .c1 {
-  color: #33ffff;
+  color: #8f8a73;
 }
 .highlight .cs {
-  color: #33ffff;
+  color: #8f8a73;
 }
 .highlight .kc {
   color: #66d9ef;


### PR DESCRIPTION
See the examples here: 
- Before: https://www.tarantool.io/en/doc/latest/dev_guide/lua_style_guide/
- After: https://docs.d.tarantool.io/en/doc/align-comment-colors/dev_guide/lua_style_guide/

Resolves #3878 