### PR TITLE
Update constraints and foreign keys docs

### DIFF
--- a/doc/code_snippets/test/constraints/constraint_test.lua
+++ b/doc/code_snippets/test/constraints/constraint_test.lua
@@ -1,0 +1,60 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+    cg.server:drop()
+end)
+
+g.test_constraints = function(cg)
+    cg.server:exec(function()
+
+        -- Tuple constraint function --
+        box.schema.func.create('check_person',
+            {language = 'LUA', is_deterministic = true, body = 'function(t, c) return (t.age >= 0 and #(t.name) > 3) end'})
+
+        -- Field constraint function --
+        box.schema.func.create('check_age',
+            {language = 'LUA', is_deterministic = true, body = 'function(f, c) return (f >= 0 and f < 150) end'})
+
+        -- Create a space with tuple constraint --
+        customers = box.schema.space.create('customers', { engine = 'memtx', constraint = 'check_person'})
+
+        -- Specify format with a field constraint --
+        box.space.customers:format({
+            {name = 'id',   type = 'number'},
+            {name = 'name', type = 'string'},
+            {name = 'age',  type = 'number', constraint = 'check_age'},
+        })
+
+
+        box.space.customers:create_index('primary', { parts = { 1 } })
+
+        box.space.customers:insert{1, "Alice", 30}
+
+        -- Tests --
+        t.assert_equals(customers:count(), 1)
+        t.assert_equals(customers:get(1), {1, "Alice", 30})
+
+        -- Failed contstraint --
+        t.assert_error_msg_contains("Check constraint 'check_person' failed for tuple",
+                function() customers:insert{2, "Bob", 230} end)
+
+        box.schema.func.create('another_constraint',
+            {language = 'LUA', is_deterministic = true, body = 'function(t, c) return (t.age >= 0 and #(t.name) > 3) end'})
+
+        -- Set two constraints with optional names --
+        box.space.customers:alter{
+            constraint = { check1 = 'check_person', check2 = 'another_constraint'}
+        }
+    end)
+end

--- a/doc/code_snippets/test/constraints/constraint_test.lua
+++ b/doc/code_snippets/test/constraints/constraint_test.lua
@@ -31,7 +31,7 @@ g.test_constraints = function(cg)
 
         -- Specify format with a field constraint --
         box.space.customers:format({
-            {name = 'id',   type = 'number'},
+            {name = 'id', type = 'number'},
             {name = 'name', type = 'string'},
             {name = 'age',  type = 'number', constraint = 'check_age'},
         })

--- a/doc/code_snippets/test/constraints/constraint_test.lua
+++ b/doc/code_snippets/test/constraints/constraint_test.lua
@@ -18,16 +18,16 @@ end)
 g.test_constraints = function(cg)
     cg.server:exec(function()
 
-        -- Tuple constraint function --
+        -- Define a tuple constraint function --
         box.schema.func.create('check_person',
             {language = 'LUA', is_deterministic = true, body = 'function(t, c) return (t.age >= 0 and #(t.name) > 3) end'})
 
-        -- Field constraint function --
+        -- Create a space with tuple constraint --
+        customers = box.schema.space.create('customers', {constraint = 'check_person'})
+
+        -- Define a field constraint function --
         box.schema.func.create('check_age',
             {language = 'LUA', is_deterministic = true, body = 'function(f, c) return (f >= 0 and f < 150) end'})
-
-        -- Create a space with tuple constraint --
-        customers = box.schema.space.create('customers', { engine = 'memtx', constraint = 'check_person'})
 
         -- Specify format with a field constraint --
         box.space.customers:format({
@@ -35,7 +35,6 @@ g.test_constraints = function(cg)
             {name = 'name', type = 'string'},
             {name = 'age',  type = 'number', constraint = 'check_age'},
         })
-
 
         box.space.customers:create_index('primary', { parts = { 1 } })
 

--- a/doc/code_snippets/test/constraints/constraint_test.lua
+++ b/doc/code_snippets/test/constraints/constraint_test.lua
@@ -19,15 +19,21 @@ g.test_constraints = function(cg)
     cg.server:exec(function()
 
         -- Define a tuple constraint function --
-        box.schema.func.create('check_person',
-            {language = 'LUA', is_deterministic = true, body = 'function(t, c) return (t.age >= 0 and #(t.name) > 3) end'})
+        box.schema.func.create('check_person', {
+            language = 'LUA',
+            is_deterministic = true,
+            body = 'function(t, c) return (t.age >= 0 and #(t.name) > 3) end'
+        })
 
-        -- Create a space with tuple constraint --
+        -- Create a space with a tuple constraint --
         customers = box.schema.space.create('customers', {constraint = 'check_person'})
 
         -- Define a field constraint function --
-        box.schema.func.create('check_age',
-            {language = 'LUA', is_deterministic = true, body = 'function(f, c) return (f >= 0 and f < 150) end'})
+        box.schema.func.create('check_age', {
+            language = 'LUA',
+            is_deterministic = true,
+            body = 'function(f, c) return (f >= 0 and f < 150) end'
+        })
 
         -- Specify format with a field constraint --
         box.space.customers:format({
@@ -48,8 +54,9 @@ g.test_constraints = function(cg)
         t.assert_error_msg_contains("Check constraint 'check_person' failed for tuple",
                 function() customers:insert{2, "Bob", 230} end)
 
+        -- Create one more tuple constraint --
         box.schema.func.create('another_constraint',
-            {language = 'LUA', is_deterministic = true, body = 'function(t, c) return (t.age >= 0 and #(t.name) > 3) end'})
+            {language = 'LUA', is_deterministic = true, body = 'function(t, c) return true end'})
 
         -- Set two constraints with optional names --
         box.space.customers:alter{

--- a/doc/code_snippets/test/foreign_keys/field_foreign_key_test.lua
+++ b/doc/code_snippets/test/foreign_keys/field_foreign_key_test.lua
@@ -37,7 +37,7 @@ g.test_foreign_keys = function(cg)
         box.space.orders:format({
             {name = 'id',   type = 'number'},
             {name = 'customer_id', foreign_key = {space = 'customers', field = 'id'}},
-            {name = 'price_total',  type = 'number'},
+            {name = 'price_total', type = 'number'},
         })
 
         orders = box.space.orders

--- a/doc/code_snippets/test/foreign_keys/field_foreign_key_test.lua
+++ b/doc/code_snippets/test/foreign_keys/field_foreign_key_test.lua
@@ -1,0 +1,56 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+    cg.server:drop()
+end)
+
+g.test_foreign_keys = function(cg)
+    cg.server:exec(function()
+
+        -- Parent space --
+        customers = box.schema.space.create('customers')
+        customers:format{
+            {name = 'id', type = 'number'},
+            {name = 'name', type = 'string'}
+        }
+
+        customers:create_index('primary', { parts = { 1 } })
+        customers:create_index('name', { parts = { 2 } })
+        customers:create_index('id_name', { parts = { 1, 2 } })
+
+        customers:insert({1, 'Alice'})
+
+        -- Create a space with a field foreign key --
+        box.schema.space.create('orders')
+
+        box.space.orders:format({
+            {name = 'id',   type = 'number'},
+            {name = 'customer_id', foreign_key = {space = 'customers', field = 'id'}},
+            {name = 'price_total',  type = 'number'},
+        })
+
+        orders = box.space.orders
+        orders:create_index('primary', { parts = { 1 } })
+
+        orders:insert({1, 1, 100})
+
+        t.assert_equals(orders:count(), 1)
+        t.assert_equals(orders:get(1), {1, 1, 100})
+
+        -- Failed foreign key check --
+        t.assert_error_msg_contains("Foreign key constraint 'customers' failed for field '2 (customer_id)': foreign tuple was not found",
+                function() orders:insert{2, 10, 200} end)
+
+    end)
+end

--- a/doc/code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
+++ b/doc/code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
@@ -32,11 +32,12 @@ g.test_foreign_keys = function(cg)
         customers:insert({1, 'Alice'})
 
         -- Create a space with a tuple foreign key --
-        box.schema.space.create("orders",
-                {foreign_key = { space = 'customers',
-                                 field = {customer_id = 'id', customer_name = 'name'}}
-                }
-        )
+        box.schema.space.create("orders", {
+            foreign_key = {
+                space = 'customers',
+                field = {customer_id = 'id', customer_name = 'name'}
+            }
+        })
 
         box.space.orders:format({
             {name = "id", type = "number"},
@@ -59,7 +60,12 @@ g.test_foreign_keys = function(cg)
 
         -- Set a foreign key with an optional name --
         box.space.orders:alter{
-            foreign_key = {customer = {space = 'customers', field = { customer_id = 'id', customer_name = 'name'}}}
+            foreign_key = {
+                customer = {
+                    space = 'customers',
+                    field = { customer_id = 'id', customer_name = 'name'}
+                }
+            }
         }
 
         items = box.schema.space.create('items')
@@ -77,8 +83,16 @@ g.test_foreign_keys = function(cg)
 
         -- Set two foreign keys: names are mandatory --
         box.space.orders:alter{
-            foreign_key = {customer = {space = 'customers', field = {customer_id = 'id', customer_name = 'name'}},
-                           item = {space = 'items', field = {item_id = 'id'}}}
+            foreign_key = {
+                customer = {
+                    space = 'customers',
+                    field = {customer_id = 'id', customer_name = 'name'}
+                },
+                item = {
+                    space = 'items',
+                    field = {item_id = 'id'}
+                }
+            }
         }
     end)
 end

--- a/doc/code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
+++ b/doc/code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
@@ -1,0 +1,80 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+    cg.server:drop()
+end)
+
+g.test_foreign_keys = function(cg)
+    cg.server:exec(function()
+
+        -- Parent space --
+        customers = box.schema.space.create('customers')
+        customers:format{
+            {name = 'id', type = 'number'},
+            {name = 'name', type = 'string'}
+        }
+
+        customers:create_index('primary', { parts = { 1 } })
+        customers:create_index('name', { parts = { 2 } })
+        customers:create_index('id_name', { parts = { 1, 2 } })
+
+        customers:insert({1, 'Alice'})
+
+        -- Create a space with a tuple foreign key --
+        box.schema.space.create("orders", {foreign_key={space='customers', field={customer_id='id', customer_name='name'}}})
+
+        box.space.orders:format({
+            {name = "id", type = "number"},
+            {name = "customer_id" },
+            {name = "customer_name"},
+            {name = "price_total", type = "number"},
+        })
+
+        orders = box.space.orders
+        orders:create_index('primary', { parts = { 1 } })
+
+        orders:insert({1, 1, 'Alice', 100})
+
+        t.assert_equals(orders:count(), 1)
+        t.assert_equals(orders:get(1), {1, 1, 'Alice', 100})
+
+        -- Failed foreign key check --
+        t.assert_error_msg_contains("Foreign key constraint 'customers' failed: foreign tuple was not found",
+                function() orders:insert{2, 10, 'Bob', 200} end)
+
+        -- Set a foreign key with an optional name --
+        box.space.orders:alter{
+            foreign_key = {customer = {space = 'customers', field={customer_id='id', customer_name='name'}}}
+        }
+
+        items = box.schema.space.create('items')
+        items:format{{name = 'id', type = 'number'}}
+        items:create_index('primary', { parts = { 1 } })
+
+        orders:delete{1}
+        orders:format({
+            {name = "id", type = "number"},
+            {name = "customer_id" },
+            {name = "customer_name"},
+            {name = "item_id", type = "number"},
+            {name = "price_total", type = "number"},
+        })
+
+        -- Set two foreign keys: names are mandatory --
+        box.space.orders:alter{
+            foreign_key = {customer = {space = 'customers', field = {customer_id = 'id', customer_name = 'name'}},
+                           item = {space = 'items', field = {item_id = 'id'}}}
+        }
+    end)
+end

--- a/doc/code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
+++ b/doc/code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
@@ -32,7 +32,11 @@ g.test_foreign_keys = function(cg)
         customers:insert({1, 'Alice'})
 
         -- Create a space with a tuple foreign key --
-        box.schema.space.create("orders", {foreign_key={space='customers', field={customer_id='id', customer_name='name'}}})
+        box.schema.space.create("orders",
+                {foreign_key = { space = 'customers',
+                                 field = {customer_id = 'id', customer_name = 'name'}}
+                }
+        )
 
         box.space.orders:format({
             {name = "id", type = "number"},
@@ -55,7 +59,7 @@ g.test_foreign_keys = function(cg)
 
         -- Set a foreign key with an optional name --
         box.space.orders:alter{
-            foreign_key = {customer = {space = 'customers', field={customer_id='id', customer_name='name'}}}
+            foreign_key = {customer = {space = 'customers', field = { customer_id = 'id', customer_name = 'name'}}}
         }
 
         items = box.schema.space.create('items')

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -673,21 +673,25 @@ Each constraint can have an optional name:
 Foreign keys
 ------------
 
-**Foreign keys** provide links between related spaces, therefore maintaining the
+**Foreign keys** provide links between related fields, therefore maintaining the
 `referential integrity <https://en.wikipedia.org/wiki/Referential_integrity>`_
 of the database.
 
-Some fields can only contain values present in other spaces. For example,
-shop orders always belong to existing customers. Hence, all values of the ``customer``
-field of the ``orders`` space must exist in the ``customers`` space. In this case,
-``customers`` is a **parent space** for ``orders`` (its **child space**). When two
-spaces are linked with a foreign key, each time a tuple is inserted or modified
-in the child space, Tarantool checks that a corresponding value is present in
-the parent space.
-
+Some fields can only contain values that exist in other fields. For example,
+a shop order always belongs to a customer. Hence, all values of the ``customer``
+field of the ``orders`` space must also exist in the ``id`` field of the ``customers``
+space. In this case, ``customers`` is a **parent space** for ``orders`` (its **child space**).
+When two spaces are linked with a foreign key, each time a tuple is inserted or
+modified in the child space, Tarantool checks that a corresponding value is present
+in the parent space.
 
 ..  image:: foreign_key.svg
     :align: center
+
+.. note::
+
+    A foreign key can link a field to another field in the same space. In this
+    case, the space is its own parent and child.
 
 Foreign key types
 ~~~~~~~~~~~~~~~~~
@@ -714,6 +718,7 @@ Creating foreign keys
     For each foreign key, there must exist an index that includes all its fields.
 
 To create a foreign key in a space, specify the parent space and linked fields in the ``foreign_key`` parameter.
+Parent spaces can be referenced by name or by id. When linking to the same space, the space can be omitted.
 Fields can be referenced by name or by number:
 
 *   Field foreign keys: when setting up the space format.

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -710,6 +710,7 @@ more strict references.
 Creating foreign keys
 ~~~~~~~~~~~~~~~~~~~~~
 
+
 ..  important::
 
     For each foreign key, there must exist a parent space index that includes

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -617,7 +617,7 @@ Constraint functions take two parameters:
 
     ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
         :language: lua
-        :lines: 25-27
+        :lines: 28-30
         :dedent:
 
 
@@ -639,7 +639,7 @@ in the ``constraint`` parameter:
 
     ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
         :language: lua
-        :lines: 29-30
+        :lines: 25-26
         :dedent:
 
 *   Field constraints: when setting up the space format:
@@ -654,7 +654,7 @@ Each constraint can have an optional name:
 
 ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
     :language: lua
-    :lines: 55-58
+    :lines: 54-57
     :dedent:
 
 ..  note::
@@ -731,7 +731,7 @@ Fields can be referenced by name or by number:
 
     ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
         :language: lua
-        :lines: 34-42
+        :lines: 34-46
         :dedent:
 
 ..  note::
@@ -743,14 +743,14 @@ Foreign keys can have an optional name.
 
     ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
         :language: lua
-        :lines: 56-59
+        :lines: 60-63
         :dedent:
 
 A space can have multiple tuple foreign keys. In this case, they all must have names.
 
     ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
         :language: lua
-        :lines: 74-78
+        :lines: 78-82
         :dedent:
 
 Tarantool performs integrity checks upon data modifications in parent spaces.

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -673,7 +673,7 @@ Foreign keys
 `referential integrity <https://en.wikipedia.org/wiki/Referential_integrity>`_
 of the database.
 
-Some fields can only contain values that exist in other fields. For example,
+Fields can contain values that exist only in other fields. For example,
 a shop order always belongs to a customer. Hence, all values of the ``customer``
 field of the ``orders`` space must also exist in the ``id`` field of the ``customers``
 space. In this case, ``customers`` is a **parent space** for ``orders`` (its **child space**).
@@ -687,7 +687,7 @@ in the parent space.
 .. note::
 
     A foreign key can link a field to another field in the same space. In this case,
-    the child field must be nullable. Otherwise, it will be impossible to insert
+    the child field must be nullable. Otherwise, it is impossible to insert
     the first tuple in such a space because there is no parent tuple to which
     it can link.
 

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -613,19 +613,18 @@ Constraint functions take two parameters:
         :lines: 21-26
         :dedent:
 
+    ..  warning::
+
+        Tarantool doesn't check field names used in tuple constraint functions.
+        If a field referenced in a tuple constraint gets renamed, this constraint will break
+        and prevent further insertions and modifications in the space.
+
 *   The field value and the constraint name for field constraints.
 
     ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
         :language: lua
         :lines: 31-36
         :dedent:
-
-
-..  warning::
-
-    Tarantool doesn't check field names used in tuple constraint functions.
-    If a field referenced in a tuple constraint gets renamed, this constraint will break
-    and prevent further insertions and modifications in the space.
 
 ..  _index-constraint_apply:
 
@@ -635,14 +634,14 @@ Creating constraints
 To create a constraint in a space, specify the corresponding function's name
 in the ``constraint`` parameter:
 
-*   Tuple constraints: when creating or altering a space:
+*   Tuple constraints: when creating or altering a space.
 
     ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
         :language: lua
         :lines: 28-29
         :dedent:
 
-*   Field constraints: when setting up the space format:
+*   Field constraints: when setting up the space format.
 
     ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
         :language: lua

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -610,14 +610,14 @@ Constraint functions take two parameters:
 
     ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
         :language: lua
-        :lines: 21-23
+        :lines: 21-26
         :dedent:
 
 *   The field value and the constraint name for field constraints.
 
     ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
         :language: lua
-        :lines: 28-30
+        :lines: 31-36
         :dedent:
 
 
@@ -639,14 +639,14 @@ in the ``constraint`` parameter:
 
     ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
         :language: lua
-        :lines: 25-26
+        :lines: 28-29
         :dedent:
 
 *   Field constraints: when setting up the space format:
 
     ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
         :language: lua
-        :lines: 32-37
+        :lines: 38-43
         :dedent:
 
 In both cases, ``constraint`` can contain multiple function names passed as a tuple.
@@ -654,7 +654,7 @@ Each constraint can have an optional name:
 
 ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
     :language: lua
-    :lines: 54-57
+    :lines: 57-64
     :dedent:
 
 ..  note::
@@ -713,7 +713,8 @@ Creating foreign keys
 
 ..  important::
 
-    For each foreign key, there must exist an index that includes all its fields.
+    For each foreign key, there must exist a parent space index that includes
+    all its fields.
 
 To create a foreign key in a space, specify the parent space and linked fields in the ``foreign_key`` parameter.
 Parent spaces can be referenced by name or by id. When linking to the same space, the space can be omitted.
@@ -731,7 +732,7 @@ Fields can be referenced by name or by number:
 
     ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
         :language: lua
-        :lines: 34-46
+        :lines: 34-47
         :dedent:
 
 ..  note::
@@ -743,14 +744,14 @@ Foreign keys can have an optional name.
 
     ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
         :language: lua
-        :lines: 60-63
+        :lines: 61-69
         :dedent:
 
 A space can have multiple tuple foreign keys. In this case, they all must have names.
 
     ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
         :language: lua
-        :lines: 78-82
+        :lines: 84-96
         :dedent:
 
 Tarantool performs integrity checks upon data modifications in parent spaces.

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -606,23 +606,20 @@ To create a constraint function, use :ref:`func.create with function body <box_s
 
 Constraint functions take two parameters:
 
-*   The field value and the constraint name for field constraints.
-
-    ..  code-block:: tarantoolsession
-
-        tarantool> box.schema.func.create('check_age',
-                 > {language = 'LUA', is_deterministic = true, body = 'function(f, c) return (f >= 0 and f < 150) end'})
-        ---
-        ...
-
 *   The tuple and the constraint name for tuple constraints.
 
-    ..  code-block:: tarantoolsession
+    ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
+        :language: lua
+        :lines: 21-23
+        :dedent:
 
-        tarantool> box.schema.func.create('check_person',
-                 > {language = 'LUA', is_deterministic = true, body = 'function(t, c) return (t.age >= 0 and #(t.name) > 3) end'})
-        ---
-        ...
+*   The field value and the constraint name for field constraints.
+
+    ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
+        :language: lua
+        :lines: 25-27
+        :dedent:
+
 
 ..  warning::
 
@@ -638,28 +635,27 @@ Creating constraints
 To create a constraint in a space, specify the corresponding function's name
 in the ``constraint`` parameter:
 
-*   Field constraints: when setting up the space format:
-
-    ..  code-block:: tarantoolsession
-
-        tarantool> box.space.person:format({
-                 > {name = 'id',   type = 'number'},
-                 > {name = 'name', type = 'string'},
-                 > {name = 'age',  type = 'number', constraint = 'check_age'},
-                 > })
-
 *   Tuple constraints: when creating or altering a space:
 
-    ..  code-block:: tarantoolsession
+    ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
+        :language: lua
+        :lines: 29-30
+        :dedent:
 
-        tarantool> box.schema.space.create('person', { engine = 'memtx', constraint = 'check_tuple'})
+*   Field constraints: when setting up the space format:
+
+    ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
+        :language: lua
+        :lines: 32-37
+        :dedent:
 
 In both cases, ``constraint`` can contain multiple function names passed as a tuple.
 Each constraint can have an optional name:
 
-..  code-block:: lua
-
-    constraint = {'age_constraint' = 'check_age', 'name_constraint' = 'check_name'}
+..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
+    :language: lua
+    :lines: 55-58
+    :dedent:
 
 ..  note::
 
@@ -690,8 +686,10 @@ in the parent space.
 
 .. note::
 
-    A foreign key can link a field to another field in the same space. In this
-    case, the space is its own parent and child.
+    A foreign key can link a field to another field in the same space. In this case,
+    the child field must be nullable. Otherwise, it will be impossible to insert
+    the first tuple in such a space because there is no parent tuple to which
+    it can link.
 
 Foreign key types
 ~~~~~~~~~~~~~~~~~
@@ -723,28 +721,18 @@ Fields can be referenced by name or by number:
 
 *   Field foreign keys: when setting up the space format.
 
-    ..  code-block:: tarantoolsession
-
-        tarantool> box.space.orders:format({
-                 > {name = 'id',   type = 'number'},
-                 > {name = 'customer_id', foreign_key = {space = 'customers', field = 'id'}}, -- or field = 1
-                 > {name = 'price_total',  type = 'number'},
-                 > })
+    ..  literalinclude:: /code_snippets/test/foreign_keys/field_foreign_key_test.lua
+        :language: lua
+        :lines: 34-41
+        :dedent:
 
 *   Tuple foreign keys: when creating or altering a space. Note that for foreign
     keys with multiple fields there must exist an index that includes all these fields.
 
-  ..  code-block:: tarantoolsession
-
-      tarantool> box.schema.space.create("orders", {foreign_key={space='customers', field={customer_id='id', customer_name='name'}}})
-      ---
-      ...
-      tarantool> box.space.orders:format({
-               > {name = "id", type = "number"},
-               > {name = "customer_id" },
-               > {name = "customer_name"},
-               > {name = "price_total",    type = "number"},
-               > })
+    ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
+        :language: lua
+        :lines: 34-42
+        :dedent:
 
 ..  note::
 
@@ -753,15 +741,17 @@ Fields can be referenced by name or by number:
 
 Foreign keys can have an optional name.
 
-..  code-block:: lua
-
-    foreign_key = {customer = {space = '...', field = {...}}}
+    ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
+        :language: lua
+        :lines: 56-59
+        :dedent:
 
 A space can have multiple tuple foreign keys. In this case, they all must have names.
 
-..  code-block:: lua
-
-    foreign_key = {customer = {space = '...', field = {...} }, item = { space = '...', field = {...}}}
+    ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
+        :language: lua
+        :lines: 74-78
+        :dedent:
 
 Tarantool performs integrity checks upon data modifications in parent spaces.
 If you try to remove a tuple referenced by a foreign key or an entire parent space,

--- a/doc/reference/reference_lua/box_schema/space_create.rst
+++ b/doc/reference/reference_lua/box_schema/space_create.rst
@@ -36,6 +36,10 @@ box.schema.space.create()
         +---------------+----------------------------------------------------+---------+---------------------+
         | Name          | Effect                                             | Type    | Default             |
         +===============+====================================================+=========+=====================+
+        | constraint    | constraints that space tuples must satisfy.        | table   | (blank)             |
+        |               | See :ref:`Constraints <index-constraints>` for     |         |                     |
+        |               | details.                                           |         |                     |
+        +---------------+----------------------------------------------------+---------+---------------------+
         | engine        | 'memtx' or 'vinyl'                                 | string  | 'memtx'             |
         +---------------+----------------------------------------------------+---------+---------------------+
         | field_count   | fixed count of :ref:`fields <index-box_tuple>`:    | number  | 0 i.e. not fixed    |
@@ -43,6 +47,10 @@ box.schema.space.create()
         |               | field_count=5, it is illegal                       |         |                     |
         |               | to insert a tuple with fewer                       |         |                     |
         |               | than or more than 5 fields                         |         |                     |
+        +---------------+----------------------------------------------------+---------+---------------------+
+        | foreign_key   | foreign keys for space fields.                     | table   | (blank)             |
+        |               | See :ref:`Foreign keys <index-box_foreign_keys>`   |         |                     |
+        |               | for details.                                       |         |                     |
         +---------------+----------------------------------------------------+---------+---------------------+
         | format        | field names and types:                             | table   | (blank)             |
         |               | See the illustrations of format clauses in the     |         |                     |

--- a/doc/reference/reference_lua/box_schema/space_create.rst
+++ b/doc/reference/reference_lua/box_schema/space_create.rst
@@ -157,7 +157,7 @@ space_opts
 
         ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
             :language: lua
-            :lines: 21-26
+            :lines: 21-29
             :dedent:
 
     ..  _space_opts_foreign_key:
@@ -173,7 +173,7 @@ space_opts
 
         ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
             :language: lua
-            :lines: 34-46
+            :lines: 34-47
             :dedent:
 
     Saying ``box.cfg{read_only=true...}`` during :ref:`configuration <cfg_basic-read_only>`

--- a/doc/reference/reference_lua/box_schema/space_create.rst
+++ b/doc/reference/reference_lua/box_schema/space_create.rst
@@ -6,94 +6,161 @@ box.schema.space.create()
 
 .. module:: box.schema
 
-.. function:: box.schema.space.create(space-name [, {options}])
-              box.schema.create_space(space-name [, {options}])
+.. function:: box.schema.space.create(space-name [, {space_opts}])
+              box.schema.create_space(space-name [, {space_opts}])
 
     Create a :ref:`space <index-box_space>`.
-
-    :param string space-name: name of space, which should
-                              conform to the :ref:`rules for object names <app_server-names>`
-    :param table options: see "Options for box.schema.space.create" chart, below
-
-    :return: space object
-    :rtype: userdata
-
     You can use either syntax. For example,
     ``s = box.schema.space.create('tester')`` has the same effect as
     ``s = box.schema.create_space('tester')``.
 
-    .. container:: table
+    There are :ref:`three syntax variations <app_server-object_reference>`
+    for object references targeting space objects, for example
+    :samp:`box.schema.space.drop({space-id})`
+    will drop a space. However, the common approach is to use functions
+    attached to the space objects, for example
+    :ref:`space_object:drop() <box_space-drop>`.
 
-        **Options for box.schema.space.create**
+    After a space is created, usually the next step is to
+    :ref:`create an index <box_space-create_index>` for it, and then it is
+    available for insert, select, and all the other :ref:`box.space <box_space>`
+    functions.
 
-        .. rst-class:: left-align-column-1
-        .. rst-class:: left-align-column-2
-        .. rst-class:: left-align-column-3
-        .. rst-class:: left-align-column-4
+    :param string space-name: name of space, which should
+                              conform to the :ref:`rules for object names <app_server-names>`
+    :param table options: space options (see :ref:`space_opts <space_opts_object>`)
 
-        .. tabularcolumns:: |\Y{0.2}|\Y{0.4}|\Y{0.2}|\Y{0.2}|
+    :return: space object
+    :rtype: userdata
 
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | Name          | Effect                                             | Type    | Default             |
-        +===============+====================================================+=========+=====================+
-        | constraint    | constraints that space tuples must satisfy.        | table   | (blank)             |
-        |               | See :ref:`Constraints <index-constraints>` for     |         |                     |
-        |               | details.                                           |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | engine        | 'memtx' or 'vinyl'                                 | string  | 'memtx'             |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | field_count   | fixed count of :ref:`fields <index-box_tuple>`:    | number  | 0 i.e. not fixed    |
-        |               | for example if                                     |         |                     |
-        |               | field_count=5, it is illegal                       |         |                     |
-        |               | to insert a tuple with fewer                       |         |                     |
-        |               | than or more than 5 fields                         |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | foreign_key   | foreign keys for space fields.                     | table   | (blank)             |
-        |               | See :ref:`Foreign keys <index-box_foreign_keys>`   |         |                     |
-        |               | for details.                                       |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | format        | field names and types:                             | table   | (blank)             |
-        |               | See the illustrations of format clauses in the     |         |                     |
-        |               | :ref:`space_object:format() <box_space-format>`    |         |                     |
-        |               | description and in the                             |         |                     |
-        |               | :ref:`box.space._space <box_space-space>`          |         |                     |
-        |               | example. Optional and usually not specified.       |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | id            | unique identifier:                                 | number  | last space's id, +1 |
-        |               | users can refer to spaces with                     |         |                     |
-        |               | the id instead of the name                         |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | if_not_exists | create space only if a space                       | boolean | false               |
-        |               | with the same name does not                        |         |                     |
-        |               | exist already, otherwise do                        |         |                     |
-        |               | nothing but do not cause an                        |         |                     |
-        |               | error                                              |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | is_local      | space contents are                                 | boolean | false               |
-        |               | :ref:`replication-local <replication-local>`:      |         |                     |
-        |               | changes are stored in the                          |         |                     |
-        |               | :ref:`write-ahead log <internals-wal>`             |         |                     |
-        |               | of the local node but there is no                  |         |                     |
-        |               | :ref:`replication <replication>`.                  |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | is_sync       | any transaction doing a DML request on this space  | boolean | false               |
-        |               | becomes synchronous                                |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | temporary     | space contents are temporary:                      | boolean | false               |
-        |               | changes are not stored in the                      |         |                     |
-        |               | :ref:`write-ahead log <internals-wal>`             |         |                     |
-        |               | and there is no                                    |         |                     |
-        |               | :ref:`replication <replication>`.                  |         |                     |
-        |               | Note regarding storage engine: vinyl               |         |                     |
-        |               | does not support temporary spaces.                 |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
-        | user          | name of the user who is considered to be           | string  | current user's name |
-        |               | the space's                                        |         |                     |
-        |               | :ref:`owner <authentication-owners_privileges>`    |         |                     |
-        |               | for authorization purposes                         |         |                     |
-        +---------------+----------------------------------------------------+---------+---------------------+
+.. _space_opts_object:
 
-    .. _box_schema-space_create-options:
+space_opts
+----------
+
+..  class:: space_opts
+
+    Space options that include the space id, format, field count, constraints and
+    foreign keys, and so on.
+    These options are passed to the :ref:`box.schema.space.create() <box_schema-space_create>` method.
+
+    .. NOTE::
+
+    These options are also passed to :doc:`/reference/reference_lua/box_space/alter`.
+
+    ..  _space_opts_if_not_exists:
+
+    .. data:: if_not_exists
+
+        Create space only if a space with the same name does not exist already.
+        Otherwise, do nothing but do not cause an error.
+
+        | Type: boolean
+        | Default: ``false``
+
+    ..  _space_opts_engine:
+
+    .. data:: engine
+
+        :ref:`Storage engine <engines-chapter>`.
+
+        | Type: string
+        | Default: `memtx`
+        | Possible values: ``memtx``, ``vinyl``
+
+    ..  _space_opts_id:
+
+    .. data:: id
+
+        A unique numeric identifier of the space: users can refer to spaces with
+        this id instead of the name.
+
+        | Type: number
+        | Default: last space's ID + 1
+
+    ..  _space_opts_field_count:
+
+    .. data:: field_count
+
+        Fixed count of :ref:`fields <index-box_tuple>`. For example, if ``field_count=5``,
+        it is illegal to insert a tuple with fewer than or more than 5 fields.
+
+        | Type: number
+        | Default: ``0`` (not fixed)
+
+    ..  _space_opts_user:
+
+    .. data:: user
+
+        The name of the user who is considered to be the space's :ref:`owner <authentication-owners_privileges>`
+        for authorization purposes.
+
+        | Type: string
+        | Default: current user's name
+
+    ..  _space_opts_format:
+
+    .. data:: format
+
+        Field names and types.
+        See the illustrations of format clauses in the :ref:`space_object:format() <box_space-format>`
+        description and in the :ref:`box.space._space <box_space-space>`
+        example. Optional and usually not specified.
+
+        | Type: table
+        | Default: blank
+
+    ..  _space_opts_is_local:
+
+    .. data:: is_local
+
+        Space contents are :ref:`replication-local <replication-local>`:
+        changes are stored in the :ref:`write-ahead log <internals-wal>`
+        of the local node but there is no :ref:`replication <replication>`.
+
+        | Type: boolean
+        | Default: ``false``
+
+    ..  _space_opts_temporary:
+
+    .. data:: temporary
+
+        Space contents are temporary: changes are not stored in the :ref:`write-ahead log <internals-wal>`
+        and there is no :ref:`replication <replication>`.
+
+        .. note::
+
+            Vinyl does not support temporary spaces.
+
+        | Type: boolean
+        | Default: ``false``
+
+    ..  _space_opts_is_sync:
+
+    .. data:: is_sync
+
+        Any transaction doing a DML request on this space becomes synchronous.
+
+        | Type: boolean
+        | Default: ``false``
+
+    ..  _space_opts_constraint:
+
+    .. data:: constraint
+
+        The :ref:`constraints <index-constraints>` that space tuples must satisfy.
+
+        | Type: table
+        | Default: blank
+
+    ..  _space_opts_foreign_key:
+
+    .. data:: foreign_key
+
+        :ref:`Foreign keys <index-box_foreign_keys>` for space fields.
+
+        | Type: table
+        | Default: blank
 
     Saying ``box.cfg{read_only=true...}`` during :ref:`configuration <cfg_basic-read_only>`
     affects spaces differently depending on the options that were used during
@@ -111,12 +178,6 @@ box.schema.space.create()
         | is_local   | no              | yes                | no             | yes            |
         +------------+-----------------+--------------------+----------------+----------------+
 
-    There are three :ref:`syntax variations <app_server-object_reference>`
-    for object references targeting space objects, for example
-    :samp:`box.schema.space.drop({space-id})`
-    will drop a space. However, the common approach is to use functions
-    attached to the space objects, for example
-    :ref:`space_object:drop() <box_space-drop>`.
 
     **Example:**
 
@@ -137,8 +198,3 @@ box.schema.space.create()
                 > })
        ---
        ...
-
-    After a space is created, usually the next step is to
-    :ref:`create an index <box_space-create_index>` for it, and then it is
-    available for insert, select, and all the other :ref:`box.space <box_space>`
-    functions.

--- a/doc/reference/reference_lua/box_schema/space_create.rst
+++ b/doc/reference/reference_lua/box_schema/space_create.rst
@@ -153,6 +153,13 @@ space_opts
         | Type: table
         | Default: blank
 
+        **Example:**
+
+        ..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
+            :language: lua
+            :lines: 21-26
+            :dedent:
+
     ..  _space_opts_foreign_key:
 
     .. data:: foreign_key
@@ -161,6 +168,13 @@ space_opts
 
         | Type: table
         | Default: blank
+
+        **Example:**
+
+        ..  literalinclude:: /code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
+            :language: lua
+            :lines: 34-46
+            :dedent:
 
     Saying ``box.cfg{read_only=true...}`` during :ref:`configuration <cfg_basic-read_only>`
     affects spaces differently depending on the options that were used during

--- a/doc/reference/reference_lua/box_schema/space_create.rst
+++ b/doc/reference/reference_lua/box_schema/space_create.rst
@@ -17,7 +17,7 @@ box.schema.space.create()
     There are :ref:`three syntax variations <app_server-object_reference>`
     for object references targeting space objects, for example
     :samp:`box.schema.space.drop({space-id})`
-    will drop a space. However, the common approach is to use functions
+    drops a space. However, the common approach is to use functions
     attached to the space objects, for example
     :ref:`space_object:drop() <box_space-drop>`.
 
@@ -52,7 +52,7 @@ space_opts
 
     .. data:: if_not_exists
 
-        Create space only if a space with the same name does not exist already.
+        Create a space only if a space with the same name does not exist already.
         Otherwise, do nothing but do not cause an error.
 
         | Type: boolean
@@ -62,7 +62,7 @@ space_opts
 
     .. data:: engine
 
-        :ref:`Storage engine <engines-chapter>`.
+        A :ref:`storage engine <engines-chapter>`.
 
         | Type: string
         | Default: `memtx`
@@ -82,7 +82,7 @@ space_opts
 
     .. data:: field_count
 
-        Fixed count of :ref:`fields <index-box_tuple>`. For example, if ``field_count=5``,
+        A fixed count of :ref:`fields <index-box_tuple>`. For example, if ``field_count=5``,
         it is illegal to insert a tuple with fewer than or more than 5 fields.
 
         | Type: number
@@ -164,7 +164,7 @@ space_opts
 
     .. data:: foreign_key
 
-        :ref:`Foreign keys <index-box_foreign_keys>` for space fields.
+        The :ref:`foreign keys <index-box_foreign_keys>` for space fields.
 
         | Type: table
         | Default: blank

--- a/doc/reference/reference_lua/box_space/alter.rst
+++ b/doc/reference/reference_lua/box_space/alter.rst
@@ -11,9 +11,9 @@ space_object:alter()
         Since version :doc:`2.5.2 </release/2.5.2>`.
         Alter an existing space. This method changes certain space parameters.
 
-        :param table options: ``field_count``, ``user``,
-                              ``format``, ``temporary``, ``is_sync``, and ``name``
-                              -- the meaning of these parameters is the same as in
+        :param table options: the space options such as ``field_count``, ``user``,
+                              ``format``, ``name``, and other. The full list of
+                              these options with descriptions parameters is provided in
                               :doc:`/reference/reference_lua/box_schema/space_create`
 
         :return: nothing in case of success; an error when fails

--- a/doc/reference/reference_lua/box_space/create_check_constraint.rst
+++ b/doc/reference/reference_lua/box_space/create_check_constraint.rst
@@ -4,6 +4,13 @@
 box.space.create_check_constraint()
 ===============================================================================
 
+.. warning::
+
+    This function was removed in :doc:`2.11.0 </release/2.11.0>`.
+    The check constraint mechanism is replaced with the new tuple constraints.
+    Learn more about tuple constraints in :ref:`Constraints <index-constraints>`.
+
+
 .. class:: space_object
 
     .. method:: create_check_constraint(check_constraint_name, expression)

--- a/doc/reference/reference_lua/box_space/format.rst
+++ b/doc/reference/reference_lua/box_space/format.rst
@@ -46,7 +46,7 @@ space_object:format()
         * (Optional) The ``collation`` string value specifies the :ref:`collation <index-collation>` used to compare field values.
           See also: :ref:`key_part.collation <key_part_collation>`.
         * (Optional) The ``constraint`` table specifies the :ref:`constraints <index-constraints>` that the field value must satisfy.
-        * (Optional) The ``foreign_key`` table specifies the :ref:`foreign key <index-box_foreign_keys>` for the field.
+        * (Optional) The ``foreign_key`` table specifies the :ref:`foreign keys <index-box_foreign_keys>` for the field.
 
         It is not legal for tuples to contain values that have the wrong type.
         The example below will cause an error:

--- a/doc/reference/reference_lua/box_space/format.rst
+++ b/doc/reference/reference_lua/box_space/format.rst
@@ -45,7 +45,7 @@ space_object:format()
           See also: :ref:`key_part.is_nullable <key_part_is_nullable>`.
         * (Optional) The ``collation`` string value specifies the :ref:`collation <index-collation>` used to compare field values.
           See also: :ref:`key_part.collation <key_part_collation>`.
-        * (Optional) The ``constraints`` table specifies the :ref:`constraints <index-constraints>` that the field value must satisfy.
+        * (Optional) The ``constraint`` table specifies the :ref:`constraints <index-constraints>` that the field value must satisfy.
         * (Optional) The ``foreign_key`` table specifies the :ref:`foreign key <index-box_foreign_keys>` for the field.
 
         It is not legal for tuples to contain values that have the wrong type.

--- a/doc/reference/reference_lua/box_space/format.rst
+++ b/doc/reference/reference_lua/box_space/format.rst
@@ -45,6 +45,8 @@ space_object:format()
           See also: :ref:`key_part.is_nullable <key_part_is_nullable>`.
         * (Optional) The ``collation`` string value specifies the :ref:`collation <index-collation>` used to compare field values.
           See also: :ref:`key_part.collation <key_part_collation>`.
+        * (Optional) The ``constraints`` table specifies the :ref:`constraints <index-constraints>` that the field value must satisfy.
+        * (Optional) The ``foreign_key`` table specifies the :ref:`foreign key <index-box_foreign_keys>` for the field.
 
         It is not legal for tuples to contain values that have the wrong type.
         The example below will cause an error:


### PR DESCRIPTION
Resolves #3043, #3360, #3361, #3429

- #3043: Extended the [foreign keys doc section](https://docs.d.tarantool.io/en/doc/gh-3043-constraints/concepts/data_model/value_store/#foreign-keys) with the possibility to use the same space field as a foreign key.
- #3360 and #3361: Added the `constraint` and `foreign_key` parameters to reference pages of [space_create](https://docs.d.tarantool.io/en/doc/gh-3043-constraints/reference/reference_lua/box_schema/space_create/) and [space.format](https://docs.d.tarantool.io/en/doc/gh-3043-constraints/reference/reference_lua/box_space/format/)
- #3429: Added a deprecation note to the [create_check_constraint](https://docs.d.tarantool.io/en/doc/gh-3043-constraints/reference/reference_lua/box_space/create_check_constraint/) reference page. Provided a link to the new constraints doc page.
- Introduced testable snippets for constraints and foreign key; embedded them with `literalinclude`.