### PR TITLE
Document the 'checks' module

### DIFF
--- a/doc/code_snippets/test/checks/checkers_test.lua
+++ b/doc/code_snippets/test/checks/checkers_test.lua
@@ -1,0 +1,46 @@
+-- datetime/interval checkers
+local datetime = require('datetime')
+local is_datetime = checkers.datetime(datetime.new { day = 1, month = 6, year = 2023 })
+local is_interval = checkers.interval(datetime.interval.new { day = 1 })
+-- is_datetime/is_interval = true
+
+-- decimal checker
+local decimal = require('decimal')
+local is_decimal = checkers.decimal(decimal.new(16))
+-- is_decimal = true
+
+-- error checker
+local server_error = box.error.new({ code = 500, reason = 'Server error' })
+local is_error = checkers.error(server_error)
+-- is_error = true
+
+-- int64/uint64 checkers
+local is_int64 = checkers.int64(-1024)
+local is_uint64 = checkers.uint64(2048)
+-- is_int64/is_uint64 = true
+
+-- tuple checker
+local is_tuple = checkers.tuple(box.tuple.new(1, 'The Beatles', 1960))
+-- is_tuple = true
+
+-- uuid checkers
+local uuid = require('uuid')
+local is_uuid = checkers.uuid(uuid())
+local is_uuid_bin = checkers.uuid_bin(uuid.bin())
+local is_uuid_str = checkers.uuid_str(uuid.str())
+-- is_uuid/is_uuid_bin/is_uuid_str = true
+
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(is_datetime, true)
+    luatest.assert_equals(is_interval, true)
+    luatest.assert_equals(is_decimal, true)
+    luatest.assert_equals(is_error, true)
+    luatest.assert_equals(is_int64, true)
+    luatest.assert_equals(is_uint64, true)
+    luatest.assert_equals(is_tuple, true)
+    luatest.assert_equals(is_uuid, true)
+    luatest.assert_equals(is_uuid_bin, true)
+    luatest.assert_equals(is_uuid_str, true)
+end

--- a/doc/code_snippets/test/checks/checks_any_optional_test.lua
+++ b/doc/code_snippets/test/checks/checks_any_optional_test.lua
@@ -1,0 +1,19 @@
+function greet_fullname_any(firstname, lastname)
+    checks('string', '?')
+    return 'Hello, ' .. firstname .. ' ' .. tostring(lastname)
+end
+--[[
+greet_fullname_any('John', 'Doe')
+-- returns 'Hello, John Doe'
+
+greet_fullname_any('John', 1)
+-- returns 'Hello, John 1'
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(greet_fullname_any('John', 'Doe'), 'Hello, John Doe')
+    luatest.assert_equals(greet_fullname_any('John', 1), 'Hello, John 1')
+end

--- a/doc/code_snippets/test/checks/checks_decimal_test.lua
+++ b/doc/code_snippets/test/checks/checks_decimal_test.lua
@@ -1,0 +1,20 @@
+local decimal = require('decimal')
+function sqrt(value)
+    checks('decimal')
+    return decimal.sqrt(value)
+end
+--[[
+sqrt(decimal.new(16))
+-- returns 4
+
+sqrt(16)
+-- raises an error: bad argument #1 to nil (decimal expected, got number)
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(sqrt(decimal.new(16)), 4)
+    luatest.assert_error_msg_contains('bad argument #1 to nil (decimal expected, got number)', sqrt, 16)
+end

--- a/doc/code_snippets/test/checks/checks_function_test.lua
+++ b/doc/code_snippets/test/checks/checks_function_test.lua
@@ -1,0 +1,23 @@
+function checkers.positive(value)
+    return (type(value) == 'number') and (value > 0)
+end
+
+function get_doubled_number(value)
+    checks('positive')
+    return value * 2
+end
+--[[
+get_doubled_number(10)
+-- returns 20
+
+get_doubled_number(-5)
+-- raises an error: bad argument #1 to nil (positive expected, got number)
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(get_doubled_number(10), 20)
+    luatest.assert_error_msg_contains('bad argument #1 to nil (positive expected, got number)', get_doubled_number, -5)
+end

--- a/doc/code_snippets/test/checks/checks_metatable_type_test.lua
+++ b/doc/code_snippets/test/checks/checks_metatable_type_test.lua
@@ -1,0 +1,20 @@
+local blue = setmetatable({ 0, 0, 255 }, { __type = 'color' })
+function get_blue_value(color)
+    checks('color')
+    return color[3]
+end
+--[[
+get_blue_value(blue)
+-- returns 255
+
+get_blue_value({0, 0, 255})
+-- raises an error: bad argument #1 to nil (color expected, got table)
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(get_blue_value(blue), 255)
+    luatest.assert_error_msg_contains('bad argument #1 to nil (color expected, got table)', get_blue_value, { 0, 0, 255 })
+end

--- a/doc/code_snippets/test/checks/checks_string_multiple_test.lua
+++ b/doc/code_snippets/test/checks/checks_string_multiple_test.lua
@@ -1,0 +1,19 @@
+function greet_fullname(firstname, lastname)
+    checks('string', 'string')
+    return 'Hello, ' .. firstname .. ' ' .. lastname
+end
+--[[
+greet_fullname('John', 'Smith')
+-- returns 'Hello, John Smith'
+
+greet_fullname('John', 1)
+-- raises an error: bad argument #2 to nil (string expected, got number)
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(greet_fullname('John', 'Smith'), 'Hello, John Smith')
+    luatest.assert_error_msg_contains('bad argument #2 to nil (string expected, got number)', greet_fullname, 'John', 1)
+end

--- a/doc/code_snippets/test/checks/checks_string_optional_test.lua
+++ b/doc/code_snippets/test/checks/checks_string_optional_test.lua
@@ -1,0 +1,26 @@
+function greet(name)
+    checks('?string')
+    if name ~= nil then
+        return 'Hello, ' .. name
+    else
+        return 'Hello from Tarantool'
+    end
+end
+--[[
+greet('John')
+-- returns 'Hello, John'
+
+greet()
+-- returns 'Hello from Tarantool'
+
+greet(123)
+-- raises an error: bad argument #1 to nil (string expected, got number)
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(greet('John'), 'Hello, John')
+    luatest.assert_error_msg_contains('bad argument #1 to nil (string expected, got number)', greet, 123)
+end

--- a/doc/code_snippets/test/checks/checks_string_test.lua
+++ b/doc/code_snippets/test/checks/checks_string_test.lua
@@ -1,0 +1,19 @@
+function greet(name)
+    checks('string')
+    return 'Hello, ' .. name
+end
+--[[
+greet('John')
+-- returns 'Hello, John'
+
+greet(123)
+-- raises an error: bad argument #1 to nil (string expected, got number)
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(greet('John'), 'Hello, John')
+    luatest.assert_error_msg_contains('bad argument #1 to nil (string expected, got number)', greet, 123)
+end

--- a/doc/code_snippets/test/checks/checks_table_indexes_test.lua
+++ b/doc/code_snippets/test/checks/checks_table_indexes_test.lua
@@ -1,0 +1,21 @@
+function configure_connection(options)
+    checks({ 'string', 'number' })
+    local ip_address = options[1] or '127.0.0.1'
+    local port = options[2] or 3301
+    return ip_address .. ':' .. port
+end
+--[[
+configure_connection({'0.0.0.0', 3303})
+-- returns '0.0.0.0:3303'
+
+configure_connection({'0.0.0.0', '3303'})
+-- raises an error: bad argument options[2] to nil (number expected, got string)
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(configure_connection({ '0.0.0.0', 3303 }), '0.0.0.0:3303')
+    luatest.assert_error_msg_contains('bad argument options[2] to nil (number expected, got string)', configure_connection, { '0.0.0.0', '3303' })
+end

--- a/doc/code_snippets/test/checks/checks_table_keys_test.lua
+++ b/doc/code_snippets/test/checks/checks_table_keys_test.lua
@@ -1,0 +1,25 @@
+function configure_connection_opts(options)
+    checks({ ip_address = 'string', port = 'number' })
+    local ip_address = options.ip_address or '127.0.0.1'
+    local port = options.port or 3301
+    return ip_address .. ':' .. port
+end
+--[[
+configure_connection_opts({ip_address = '0.0.0.0', port = 3303})
+-- returns '0.0.0.0:3303'
+
+configure_connection_opts({ip_address = '0.0.0.0', port = '3303'})
+-- raises an error: bad argument options.port to nil (number expected, got string)
+
+configure_connection_opts({login = 'testuser', ip_address = '0.0.0.0', port = 3303})
+-- raises an error: unexpected argument options.login to nil
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(configure_connection_opts({ ip_address = '0.0.0.0', port = 3303 }), '0.0.0.0:3303')
+    luatest.assert_error_msg_contains('bad argument options.port to nil (number expected, got string)', configure_connection_opts, { ip_address = '0.0.0.0', port = '3303' })
+    luatest.assert_error_msg_contains('unexpected argument options.login to nil', configure_connection_opts, { login = 'testuser', ip_address = '0.0.0.0', port = 3303 })
+end

--- a/doc/code_snippets/test/checks/checks_type_combination_test.lua
+++ b/doc/code_snippets/test/checks/checks_type_combination_test.lua
@@ -1,0 +1,23 @@
+function get_argument_type(value)
+    checks('number|string')
+    return type(value)
+end
+--[[
+get_argument_type(1)
+-- returns 'number'
+
+get_argument_type('key1')
+-- returns 'string'
+
+get_argument_type(true)
+-- raises an error: bad argument #1 to nil (number|string expected, got boolean)
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(get_argument_type(1), 'number')
+    luatest.assert_equals(get_argument_type('key1'), 'string')
+    luatest.assert_error_msg_contains('bad argument #1 to nil (number|string expected, got boolean)', get_argument_type, true)
+end

--- a/doc/code_snippets/test/checks/checks_vararg_test.lua
+++ b/doc/code_snippets/test/checks/checks_vararg_test.lua
@@ -1,0 +1,19 @@
+function extra_arguments_num(a, b, ...)
+    checks('string', 'number')
+    return select('#', ...)
+end
+--[[
+extra_arguments_num('a', 2, 'c')
+-- returns 1
+
+extra_arguments_num('a', 'b', 'c')
+-- raises an error: bad argument #1 to nil (string expected, got number)
+--]]
+
+-- Tests
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_checks = function()
+    luatest.assert_equals(extra_arguments_num('a', 2, 'c'), 1)
+    luatest.assert_error_msg_contains('bad argument #2 to nil (number expected, got string)', extra_arguments_num, 'a', 'b', 'c')
+end

--- a/doc/reference/reference_lua/checks.rst
+++ b/doc/reference/reference_lua/checks.rst
@@ -1,0 +1,523 @@
+..  checks-module:
+
+Module checks
+=============
+
+**Since:** :doc:`2.11.0 </release/2.11.0>`
+
+The ``checks`` module provides the ability to check the types of arguments passed to a Lua function.
+You need to call the :ref:`checks(type_1, ...) <checks-checks>` function inside the target Lua function and pass :ref:`one or more <checks_number_of_arguments>` type qualifiers to check the corresponding argument types.
+There are two types of type qualifiers:
+
+-   A :ref:`string type qualifier <checks_string_type_qualifier>` checks whether a function's argument conforms to the specified type. Example: ``'string'``.
+-   A :ref:`table type qualifier <checks_table_type_qualifiers>` checks whether the values of a table passed as an argument conform to the specified types. Example: ``{ 'string', 'number' }``.
+
+.. NOTE::
+
+    For earlier versions, you can install the ``checks`` module from the `Tarantool rocks repository <https://www.tarantool.io/en/download/rocks>`_.
+
+.. _checks_loading:
+
+Loading checks
+--------------
+
+In Tarantool :doc:`2.11.0 </release/2.11.0>` and later versions, the :ref:`checks API <checks_api_reference>` is available in a script without loading the module.
+
+For earlier versions, you need to install the ``checks`` module from the Tarantool rocks repository and load the module using the ``require()`` directive:
+
+.. code-block:: lua
+
+    local checks = require('checks')
+
+
+.. _checks_number_of_arguments:
+
+Number of arguments to check
+----------------------------
+
+For each argument to check, you need to specify its own type qualifier in the :ref:`checks(type_1, ...) <checks-checks>` function.
+
+.. _checks_one_argument:
+
+One argument
+~~~~~~~~~~~~
+
+In the example below, the ``checks`` function accepts a ``string`` type qualifier to verify that only a string value can be passed to the ``greet`` function.
+Otherwise, an error is raised.
+
+..  literalinclude:: /code_snippets/test/checks/checks_string_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+
+.. _checks_multiple_arguments:
+
+Multiple arguments
+~~~~~~~~~~~~~~~~~~
+
+To check the types of several arguments, you need to pass the corresponding type qualifiers to the ``checks`` function.
+In the example below, both arguments should be string values.
+
+..  literalinclude:: /code_snippets/test/checks/checks_string_multiple_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+To skip checking specific arguments, use the :ref:`? placeholder <checks_any_type>`.
+
+
+.. _checks_variable_number_of_arguments:
+
+Variable number of arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can check the types of explicitly specified arguments for functions that accept a variable number of arguments.
+
+..  literalinclude:: /code_snippets/test/checks/checks_vararg_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+
+
+.. _checks_string_type_qualifier:
+
+String type qualifier
+---------------------
+
+This section describes how to check a specific argument type using a string type qualifier:
+
+- The :ref:`Supported types <checks_string_supported_types>` section describes all the types supported by the ``checks`` module.
+- If required, you can make a :ref:`union type <checks_union_type>` to allow an argument to accept several types.
+- You can make any of the supported types :ref:`optional <checks_optional_type>`.
+- To skip checking specific arguments, use the :ref:`? placeholder <checks_any_type>`.
+
+.. _checks_string_supported_types:
+
+Supported types
+~~~~~~~~~~~~~~~
+
+.. _checks_lua_types:
+
+Lua types
+*********
+
+A string type qualifier can accept any of the `Lua types <https://www.lua.org/pil/2.html>`_, for example, ``string``, ``number``, ``table``, or ``nil``.
+In the example below, the ``checks`` function accepts ``string`` to validate that only a string value can be passed to the ``greet`` function.
+
+..  literalinclude:: /code_snippets/test/checks/checks_string_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+
+.. _checks_tarantool_types:
+
+Tarantool types
+***************
+
+You can use :ref:`Tarantool-specific types <index_box_field_type_details>` in a string qualifier.
+The example below shows how to check that a function argument is a decimal value.
+
+..  literalinclude:: /code_snippets/test/checks/checks_decimal_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+This table lists all the checks available for Tarantool types:
+
+..  container:: table
+
+    ..  list-table::
+        :widths: 30 40 30
+        :header-rows: 1
+
+        *   -   Check
+            -   Description
+            -   See also
+
+        *   -   ``checks('datetime')``
+            -   Check whether the specified value is :ref:`datetime_object <datetime_obj>`
+            -   :ref:`checkers.datetime(value) <checks-checkers-datetime>`
+
+        *   -   ``checks('decimal')``
+            -   Check whether the specified value has the :ref:`decimal <decimal>` type
+            -   :ref:`checkers.decimal(value) <checks-checkers-decimal>`
+
+        *   -   ``checks('error')``
+            -   Check whether the specified value is :ref:`error_object <box_error-error_object>`
+            -   :ref:`checkers.error(value) <checks-checkers-error>`
+
+        *   -   ``checks('int64')``
+            -   Check whether the specified value is an ``int64`` value
+            -   :ref:`checkers.int64(value) <checks-checkers-int64>`
+
+        *   -   ``checks('interval')``
+            -   Check whether the specified value is :ref:`interval_object <interval_obj>`
+            -   :ref:`checkers.interval(value) <checks-checkers-interval>`
+
+        *   -   ``checks('tuple')``
+            -   Check whether the specified value is a :ref:`tuple <box_tuple-new>`
+            -   :ref:`checkers.tuple(value) <checks-checkers-tuple>`
+
+        *   -   ``checks('uint64')``
+            -   Check whether the specified value is a ``uint64`` value
+            -   :ref:`checkers.uint64(value) <checks-checkers-uint64>`
+
+        *   -   ``checks('uuid')``
+            -   Check whether the specified value is :ref:`uuid_object <uuid-module>`
+            -   :ref:`checkers.uuid(value) <checks-checkers-uuid>`
+
+        *   -   ``checks('uuid_bin')``
+            -   Check whether the specified value is :ref:`uuid <uuid-module>` represented by a 16-byte binary string
+            -   :ref:`checkers.uuid_bin(value) <checks-checkers-uuid_bin>`
+
+        *   -   ``checks('uuid_str')``
+            -   Check whether the specified value is :ref:`uuid <uuid-module>` represented by a 36-byte hexadecimal string
+            -   :ref:`checkers.uuid_str(value) <checks-checkers-uuid_str>`
+
+
+
+.. _checks_custom_function:
+
+Custom function
+***************
+
+A string type qualifier can accept the name of a custom function that performs arbitrary validations.
+To achieve this, create a function returning ``true`` if the value is valid and add this function to the :ref:`checkers <checks-checkers>` table.
+
+The example below shows how to use the ``positive`` function to check that an argument value is a positive number.
+
+..  literalinclude:: /code_snippets/test/checks/checks_function_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+
+.. _checks_metatable_type:
+
+Metatable type
+**************
+
+A string qualifier can accept a value stored in the ``__type`` field of the argument `metatable <https://www.lua.org/pil/13.html>`_.
+
+..  literalinclude:: /code_snippets/test/checks/checks_metatable_type_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+
+.. _checks_union_type:
+
+Union types
+~~~~~~~~~~~
+
+To allow an argument to accept several types (a union type), concatenate type names with a pipe (``|``).
+In the example below, the argument can be both a ``number`` and ``string`` value.
+
+..  literalinclude:: /code_snippets/test/checks/checks_type_combination_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+
+
+.. _checks_optional_type:
+
+Optional types
+~~~~~~~~~~~~~~
+
+To make any of the supported types optional, prefix its name with a question mark (``?``).
+In the example below, the ``name`` argument is optional.
+This means that the ``greet`` function can accept ``string`` and ``nil`` values.
+
+..  literalinclude:: /code_snippets/test/checks/checks_string_optional_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+As for a specific type, you can make a :ref:`union type <checks_union_type>` value optional: ``?number|string``.
+
+
+.. _checks_any_type:
+
+Skipping argument checking
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can skip checking of the specified arguments using the question mark (``?``) placeholder.
+In this case, the argument can be any type.
+
+..  literalinclude:: /code_snippets/test/checks/checks_any_optional_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+
+
+
+.. _checks_table_type_qualifiers:
+
+Table type qualifier
+--------------------
+
+A table type qualifier checks whether the values of a table passed as an argument conform to the specified types.
+In this case, the following checks are made:
+
+-   The argument is checked to conform to the ``?table`` type, and its content is validated.
+-   Table values are validated against the specified :ref:`string type qualifiers <checks_string_type_qualifier>`.
+-   Table keys missing in ``checks`` are validated against the ``nil`` type.
+
+The code below checks that the first and second table values have the ``string`` and ``number`` types.
+
+..  literalinclude:: /code_snippets/test/checks/checks_table_indexes_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+In the next example, the same checks are made for the specified keys.
+
+..  literalinclude:: /code_snippets/test/checks/checks_table_keys_test.lua
+    :language: lua
+    :end-before: -- Tests
+    :dedent:
+
+.. NOTE::
+
+    Table qualifiers can be nested and use tables, too.
+
+
+
+.. _checks_api_reference:
+
+API Reference
+-------------
+
+..  container:: table
+
+    ..  rst-class:: left-align-column-1
+    ..  rst-class:: left-align-column-2
+
+    ..  list-table::
+        :widths: 35 65
+
+        *   -   **Members**
+            -
+
+        *   -   :ref:`checks() <checks-checks>`
+            -   When called inside a function, checks that the function's arguments conform to the specified types
+
+        *   -   :ref:`checkers <checks-checkers>`
+            -   A global variable that provides access to checkers for different types
+
+
+..  _checks-checks:
+
+checks()
+~~~~~~~~
+
+..  function:: checks(type_1, ...)
+
+    When called inside a function, checks that the function's arguments conform to the specified types.
+
+    :param string/table type_1: a :ref:`string <checks_string_type_qualifier>` or :ref:`table <checks_table_type_qualifiers>` type qualifier used to check the argument type
+    :param ...: optional type qualifiers used to check the types of :ref:`other arguments <checks_number_of_arguments>`
+
+..  _checks-checkers:
+
+checkers
+~~~~~~~~
+
+The ``checkers`` global variable provides access to checkers for different types.
+You can use this variable to add a :ref:`custom checker <checks_custom_function>` that performs arbitrary validations.
+
+.. NOTE::
+
+    The ``checkers`` variable also provides access to checkers for Tarantool-specific types.
+    These checkers can be used in a custom checker.
+
+.. _checks-checkers-datetime:
+
+.. function:: checkers.datetime(value)
+
+    Check whether the specified value is :ref:`datetime_object <datetime_obj>`.
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value is ``datetime_object``; otherwise, ``false``
+    :rtype: boolean
+
+    **Example**
+
+    ..  literalinclude:: /code_snippets/test/checks/checkers_test.lua
+        :language: lua
+        :start-after: datetime/interval checkers
+        :end-before: is_datetime/is_interval = true
+
+    .. _checks-checkers-decimal:
+
+.. function:: checkers.decimal(value)
+
+    Check whether the specified value has the :ref:`decimal <decimal>` type.
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value has the ``decimal`` type; otherwise, ``false``
+    :rtype: boolean
+
+    **Example**
+
+    ..  literalinclude:: /code_snippets/test/checks/checkers_test.lua
+        :language: lua
+        :start-after: decimal checker
+        :end-before: is_decimal = true
+
+
+.. _checks-checkers-error:
+
+.. function:: checkers.error(value)
+
+    Check whether the specified value is :ref:`error_object <box_error-error_object>`.
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value is ``error_object``; otherwise, ``false``
+    :rtype: boolean
+
+    **Example**
+
+    ..  literalinclude:: /code_snippets/test/checks/checkers_test.lua
+        :language: lua
+        :start-after: error checker
+        :end-before: is_error = true
+
+
+.. _checks-checkers-int64:
+
+.. function:: checkers.int64(value)
+
+    Check whether the specified value is one of the following ``int64`` values:
+
+    *  a Lua number in a range from -2^53+1 to 2^53-1 (inclusive)
+    *  Lua cdata ``ctype<uint64_t>`` in a range from 0 to ``LLONG_MAX``
+    *  Lua cdata ``ctype<int64_t>``
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value is an ``int64`` value; otherwise, ``false``
+    :rtype: boolean
+
+    **Example**
+
+    ..  literalinclude:: /code_snippets/test/checks/checkers_test.lua
+        :language: lua
+        :start-after: int64/uint64 checkers
+        :end-before: is_int64/is_uint64 = true
+
+
+.. _checks-checkers-interval:
+
+.. function:: checkers.interval(value)
+
+    Check whether the specified value is :ref:`interval_object <interval_obj>`.
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value is ``interval_object``; otherwise, ``false``
+    :rtype: boolean
+
+    **Example**
+
+    ..  literalinclude:: /code_snippets/test/checks/checkers_test.lua
+        :language: lua
+        :start-after: datetime/interval checkers
+        :end-before: is_datetime/is_interval = true
+
+
+.. _checks-checkers-tuple:
+
+.. function:: checkers.tuple(value)
+
+    Check whether the specified value is a :ref:`tuple <box_tuple-new>`.
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value is a tuple; otherwise, ``false``
+    :rtype: boolean
+
+    **Example**
+
+    ..  literalinclude:: /code_snippets/test/checks/checkers_test.lua
+        :language: lua
+        :start-after: tuple checker
+        :end-before: is_tuple = true
+
+
+.. _checks-checkers-uint64:
+
+.. function:: checkers.uint64(value)
+
+    Check whether the specified value is one of the following ``uint64`` values:
+
+    *  a Lua number in a range from 0 to 2^53-1 (inclusive)
+    *  Lua cdata ``ctype<uint64_t>``
+    *  Lua cdata ``ctype<int64_t>`` in range from 0 to ``LLONG_MAX``
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value is an ``uint64`` value; otherwise, ``false``
+    :rtype: boolean
+
+    **Example**
+
+    ..  literalinclude:: /code_snippets/test/checks/checkers_test.lua
+        :language: lua
+        :start-after: int64/uint64 checkers
+        :end-before: is_int64/is_uint64 = true
+
+
+.. _checks-checkers-uuid:
+
+.. function:: checkers.uuid(value)
+
+    Check whether the specified value is :ref:`uuid_object <uuid-module>`.
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value is ``uuid_object``; otherwise, ``false``
+    :rtype: boolean
+
+    **Example**
+
+    ..  literalinclude:: /code_snippets/test/checks/checkers_test.lua
+        :language: lua
+        :start-after: uuid checkers
+        :end-before: is_uuid/is_uuid_bin/is_uuid_str = true
+
+
+.. _checks-checkers-uuid_bin:
+
+.. function:: checkers.uuid_bin(value)
+
+    Check whether the specified value is :ref:`uuid <uuid-module>` represented by a 16-byte binary string.
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value is ``uuid`` represented by a 16-byte binary string; otherwise, ``false``
+    :rtype: boolean
+
+    **See also:** :ref:`uuid(value) <checks-checkers-uuid>`
+
+
+.. _checks-checkers-uuid_str:
+
+.. function:: checkers.uuid_str(value)
+
+    Check whether the specified value is :ref:`uuid <uuid-module>` represented by a 36-byte hexadecimal string.
+
+    :param any value: the value to check the type for
+
+    :return: ``true`` if the specified value is ``uuid`` represented by a 36-byte hexadecimal string; otherwise, ``false``
+    :rtype: boolean
+
+    **See also:** :ref:`uuid(value) <checks-checkers-uuid>`

--- a/doc/reference/reference_lua/index.rst
+++ b/doc/reference/reference_lua/index.rst
@@ -22,6 +22,7 @@ This reference covers Tarantool's built-in Lua modules.
 
     box
     buffer
+    checks
     clock
     compat
     console


### PR DESCRIPTION
Added a new page for the ``checks`` module:
https://docs.d.tarantool.io/en/doc/embedded-checks/reference/reference_lua/checks/

> Note that new documentation topics now references testable code snippets from the [code_snippets](https://github.com/tarantool/doc/tree/latest/doc/code_snippets) folder.