### PR TITLE
SQL array/map access

### DIFF
--- a/doc/code_snippets/test/sql/array_access_test.lua
+++ b/doc/code_snippets/test/sql/array_access_test.lua
@@ -1,0 +1,42 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+    cg.server:drop()
+end)
+
+g.test_space_is_updated = function(cg)
+    cg.server:exec(function()
+        box.execute([[SET SESSION "sql_seq_scan" = true;]])
+        box.execute([[
+            CREATE TABLE plays (user_id INTEGER PRIMARY KEY, scores ARRAY);
+        ]])
+        box.execute([[
+            INSERT INTO plays VALUES (1, [23, 17, 55, 48]);
+        ]])
+        box.execute([[
+            INSERT INTO plays VALUES (2, [12, 8, 20, 33]);
+        ]])
+        local result = box.execute([[
+            SELECT scores[2] FROM plays;
+            /* ---
+              rows:
+              - [17]
+              - [8]
+            ... */
+        ]])
+
+        t.assert_equals(result.rows[1], {17})
+        t.assert_equals(result.rows[2], {8})
+    end)
+end

--- a/doc/code_snippets/test/sql/map_access_test.lua
+++ b/doc/code_snippets/test/sql/map_access_test.lua
@@ -1,0 +1,42 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+    cg.server:drop()
+end)
+
+g.test_space_is_updated = function(cg)
+    cg.server:exec(function()
+        box.execute([[SET SESSION "sql_seq_scan" = true;]])
+        box.execute([[
+            CREATE TABLE bands (id INTEGER PRIMARY KEY, info MAP);
+        ]])
+        box.execute([[
+            INSERT INTO bands VALUES (1, {'name': 'The Beatles', 'year': 1960});
+        ]])
+        box.execute([[
+            INSERT INTO bands VALUES (2, {'name': 'The Doors', 'year': 1965});
+        ]])
+        local result = box.execute([[
+            SELECT info['name'] FROM bands;
+            /* ---
+              rows:
+              - ['The Beatles']
+              - ['The Doors']
+            ... */
+        ]])
+
+        t.assert_equals(result.rows[1], {'The Beatles'})
+        t.assert_equals(result.rows[2], {'The Doors'})
+    end)
+end

--- a/doc/how-to/sql/sql_beginners_guide.rst
+++ b/doc/how-to/sql/sql_beginners_guide.rst
@@ -1,8 +1,7 @@
 .. _sql_beginners_guide:
 
---------------------------------------------------------------------------------
 SQL beginners' guide
---------------------------------------------------------------------------------
+====================
 
 The Beginners' Guide describes how users can start up with SQL with Tarantool, and necessary concepts.
 
@@ -10,7 +9,10 @@ The SQL Beginners' Guide is about databases in general, and about the relationsh
 Tarantool's NoSQL and SQL products.
 Most of the matters in the Beginners' Guide will already be familiar to people who have used relational databases before.
 
-**Sample Simple Table**
+.. _sql_beginners_sample_table:
+
+Sample Table
+------------
 
 In football training camp it is traditional for the trainer to begin by showing a football
 and saying "this is a football". In that spirit, this is a table:
@@ -27,7 +29,7 @@ and saying "this is a football". In that spirit, this is a table:
      Row#3 | Row#3,Column#1  | Row#3,Column#2 | Row#3,Column#3 |
            +-----------------+----------------+----------------+
 
-but the labels are misleading -- one usually doesn't identify rows and columns by their ordinal positions,
+But the labels are misleading -- one usually doesn't identify rows and columns by their ordinal positions,
 one prefers to pick out specific items by their contents. In that spirit, this is a table:
 
 .. code-block:: none
@@ -42,18 +44,22 @@ one prefers to pick out specific items by their contents. In that spirit, this i
     | crypto          |    4 | Cryptography        |
     +-----------------+------+---------------------+
 
-so one does not use longitude/latitude navigation by talking about "Row#2 Column #2",
+So one does not use longitude/latitude navigation by talking about "Row#2 Column #2",
 one uses the contents of the Name column and the name of the Size column
 by talking about "the size, where the name is 'clock'".
 To be more exact, this is what one says:
 
-``SELECT size FROM modules WHERE name = 'clock';``
+..  code-block:: sql
+
+    SELECT size FROM modules WHERE name = 'clock';
 
 If you're familiar with Tarantool's architecture -- and ideally you read
 about that before coming to this chapter -- then you know that there is a NoSQL
 way to get the same thing:
 
-``box.space.MODULES:select()[2][2]``
+..  code-block:: lua
+
+    box.space.MODULES:select()[2][2]
 
 Well, you can do that. One of the advantages of Tarantool is that if you can get
 data via an SQL statement, then you can get the same data via a NoSQL request.
@@ -69,11 +75,16 @@ Tarantool/NoSQL's "format" clause causes the same restrictions.
 So an SQL "table" is a NoSQL "tuple set with format restrictions",
 an SQL "row" is a NoSQL "tuple", an SQL "column" is a NoSQL "list of fields within a tuple set".
 
-**Creating a table**
+.. _sql_beginners_creating_a_table:
+
+Creating a table
+----------------
 
 This is how to create the modules table:
 
-``CREATE TABLE modules (name STRING, size INTEGER, purpose STRING, PRIMARY KEY (name));``
+..  code-block:: sql
+
+    CREATE TABLE modules (name STRING, size INTEGER, purpose STRING, PRIMARY KEY (name));
 
 The words that are IN CAPITAL LETTERS are "keywords" (although it is only a convention in
 this manual that keywords are in capital letters, in practice many programmers prefer to avoid shouting).
@@ -93,7 +104,8 @@ The final clause, PRIMARY KEY (name), means that the name column is the main col
 
 .. _sql_nulls:
 
-**Nulls**
+Nulls
+-----
 
 Frequently it is necessary, at least temporarily, that a column value should be NULL.
 Typical situations are: the value is unknown, or the value is not applicable.
@@ -108,12 +120,17 @@ When nil means "unknown" or "inapplicable", yes.
 But when nil means "nonexistent" or "type is nil", no.
 NULL is a value, it has a data type because it is inside a column which is defined with that data type. 
 
-**Creating an index**
+.. _sql_beginners_creating_an_index:
+
+Creating an index
+-----------------
 
 This is how to create indexes for the modules table:
 
-``CREATE INDEX size ON modules (size);`` |br|
-``CREATE UNIQUE INDEX purpose ON modules (purpose);``
+.. code-block:: sql
+
+    CREATE INDEX size ON modules (size);
+    CREATE UNIQUE INDEX purpose ON modules (purpose);
 
 There is no need to create an index on the name column,
 because Tarantool creates an index automatically when it sees a PRIMARY KEY clause in the CREATE TABLE statement.
@@ -127,7 +144,10 @@ Another use for indexes is to enforce uniqueness.
 When an index is created with CREATE UNIQUE INDEX for the purpose column,
 it is not possible to have duplicate values in that column.
 
-**Data change**
+.. _sql_beginners_data_change:
+
+Data change
+-----------
 
 Putting data into a table is called "inserting".
 Changing data is called "updating".
@@ -136,23 +156,32 @@ Together, the three SQL statements INSERT plus UPDATE plus DELETE are the three 
 
 This is how to insert, update, and delete a row in the modules table:
 
-``INSERT INTO modules VALUES ('json', 14, 'format functions for JSON');`` |br|
-``UPDATE modules SET size = 15 WHERE name = 'json';`` |br|
-``DELETE FROM modules WHERE name = 'json';``
+.. code-block:: sql
+
+    INSERT INTO modules VALUES ('json', 14, 'format functions for JSON');
+    UPDATE modules SET size = 15 WHERE name = 'json';
+    DELETE FROM modules WHERE name = 'json';
 
 The corresponding non-SQL Tarantool requests would be:
 
-``box.space.MODULES:insert{'json', 14, 'format functions for JSON'}`` |br|
-``box.space.MODULES:update('json', {{'=', 2, 15}})`` |br|
-``box.space.MODULES:delete{'json'}`` |br|
+.. code-block:: lua
+
+    box.space.MODULES:insert{'json', 14, 'format functions for JSON'}
+    box.space.MODULES:update('json', {{'=', 2, 15}})
+    box.space.MODULES:delete{'json'}
 
 This is how one would populate the table with the values that was shown earlier:
 
-``INSERT INTO modules VALUES ('box', 1432, 'Database Management');`` |br|
-``INSERT INTO modules VALUES ('clock', 188, 'Seconds');`` |br|
-``INSERT INTO modules VALUES ('crypto', 4, 'Cryptography');`` |br|
+.. code-block:: sql
 
-**Constraints**
+    INSERT INTO modules VALUES ('box', 1432, 'Database Management');
+    INSERT INTO modules VALUES ('clock', 188, 'Seconds');
+    INSERT INTO modules VALUES ('crypto', 4, 'Cryptography');
+
+.. _sql_beginners_constraints:
+
+Constraints
+-----------
 
 Some data-change statements are illegal due to something in the table's definition.
 This is called "constraining what can be done". Some types of constraints have already been shown ...
@@ -204,8 +233,10 @@ it can be defined like this:
 
 Now try to insert a new row into this submodules table:
 
-``INSERT INTO submodules VALUES`` |br|
-|nbsp| |nbsp| ``('space', 'Box', 10000, 'insert etc.');``
+.. code-block:: sql
+
+    INSERT INTO submodules VALUES
+      ('space', 'Box', 10000, 'insert etc.');
 
 The insert will fail because the second column (module_name)
 refers to the name column in the modules table, and the name
@@ -213,12 +244,16 @@ column in the modules table does not contain 'Box'.
 However, it does contain 'box'.
 By default searches in Tarantool's SQL use a binary collation. This will work:
 
-``INSERT INTO submodules`` |br|
-|nbsp| |nbsp| ``VALUES ('space', 'box', 10000, 'insert etc.');``
+.. code-block:: sql
+
+    INSERT INTO submodules
+      VALUES ('space', 'box', 10000, 'insert etc.');
 
 Now try to delete the corresponding row from the modules table:
 
-``DELETE FROM modules WHERE name = 'box';``
+.. code-block:: sql
+
+    DELETE FROM modules WHERE name = 'box';
 
 The delete will fail because the second column (module_name) in the submodules
 table refers to the name column in the modules table, and the name column
@@ -233,7 +268,10 @@ and hard to bypass with SQL.
 This is often seen as a difference between SQL and NoSQL -- SQL emphasizes law and order,
 NoSQL emphasizes freedom and making your own rules.
 
-**Table Relationships**
+.. _sql_beginners_table_relationships:
+
+Table Relationships
+-------------------
 
 Think about the two tables that have been discussed so far:
 
@@ -269,11 +307,16 @@ do not trust anyone who tells you that databases made with SQL are relational
 "because there are relationships between tables".
 That is wrong, as will be clear in the discussion about what makes a database relational, later.
 
-**Selecting with WHERE**
+.. _sql_beginners_selecting_with_where:
+
+Selecting with WHERE
+--------------------
 
 We gave a simple example of a SELECT statement earlier:
 
-``SELECT size FROM modules WHERE name = 'clock';``
+.. code-block:: sql
+
+    SELECT size FROM modules WHERE name = 'clock';
 
 The clause "WHERE name = 'clock'" is legal in other statements -- it
 is in examples with UPDATE and DELETE -- but here the only examples will be with SELECT.
@@ -281,7 +324,9 @@ is in examples with UPDATE and DELETE -- but here the only examples will be with
 The first variation is that the WHERE clause does not have to be specified at all,
 it is optional. So this statement would return all rows:
 
-``SELECT size FROM modules;``
+.. code-block:: sql
+
+    SELECT size FROM modules;
 
 The second variation is that the comparison operator does not have to be '=',
 it can be anything that makes sense: '>' or '>=' or '<' or '<=',
@@ -290,8 +335,10 @@ contain wildcard characters '_' meaning 'match any one character'
 or '%' meaning 'match any zero or one or many characters'.
 These are legal statements which return all rows:
 
-``SELECT size FROM modules WHERE name >= '';`` |br|
-``SELECT size FROM modules WHERE name LIKE '%';``
+.. code-block:: sql
+
+    SELECT size FROM modules WHERE name >= '';
+    SELECT size FROM modules WHERE name LIKE '%';
 
 The third variation is that IS [NOT] NULL is a special condition.
 Remembering that the NULL value can mean "it is unknown what the value should be",
@@ -303,7 +350,9 @@ So when searching for NULL, say IS NULL;
 when searching anything that is not NULL, say IS NOT NULL.
 This statement will return all rows because (due to the definition) there are no NULLs in the name column:
 
-``SELECT size FROM modules WHERE name IS NOT NULL;``
+.. code-block:: sql
+
+    SELECT size FROM modules WHERE name IS NOT NULL;
 
 The fourth variation is that conditions can be combined with AND / OR, and negated with NOT.
 
@@ -320,7 +369,9 @@ but the second condition is true, and OR means "return true if either condition 
 
 Yet again, here is a simple example of a SELECT statement:
 
-``SELECT size FROM modules WHERE name = 'clock';``
+.. code-block:: sql
+
+    SELECT size FROM modules WHERE name = 'clock';
 
 The words between SELECT and FROM are the select list.
 In this case, the select list is just one word: size.
@@ -329,7 +380,9 @@ and technically the name for picking a particular column is called "projection".
 
 The first variation is that one can specify any column in any order:
 
-``SELECT name, purpose, size FROM modules;``
+.. code-block:: sql
+
+    SELECT name, purpose, size FROM modules;
 
 The second variation is that one can specify an expression,
 it does not have to be a column name, it does not even have to include a column name.
@@ -337,15 +390,19 @@ The common expression operators for numbers are the arithmetic operators ``+ - /
 the common expression operator for strings is the concatenation operator ||.
 For example this statement will return 8, 'XY':
 
-``SELECT size * 2, 'X' || 'Y' FROM modules WHERE size = 4;``
+.. code-block:: sql
+
+    SELECT size * 2, 'X' || 'Y' FROM modules WHERE size = 4;
 
 The third variation is that one can add a clause [AS name] after every expression,
 so that in the return the column titles will make sense.
 This is especially important when a title might otherwise be ambiguous or meaningless.
 For example this statement will return 8, 'XY' as before
 
-``SELECT size * 2 AS double_size, 'X' || 'Y' AS concatenated_literals  FROM modules`` |br|
-|nbsp| |nbsp| ``WHERE size = 4;``
+.. code-block:: sql
+
+    SELECT size * 2 AS double_size, 'X' || 'Y' AS concatenated_literals  FROM modules
+      WHERE size = 4;
 
 but displayed as a table the result will look like
 
@@ -361,11 +418,15 @@ but displayed as a table the result will look like
 
 Instead of listing columns in a select list, one can just say ``'*'``. For example
 
-``SELECT * FROM modules;``
+.. code-block:: sql
+
+    SELECT * FROM modules;
 
 This is the same thing as
 
-``SELECT name, size, purpose FROM modules;``
+.. code-block:: sql
+
+    SELECT name, size, purpose FROM modules;
 
 Selecting with ``"*"``  saves time for the writer,
 but it is unclear to a reader who has not memorized what the column names are.
@@ -374,7 +435,10 @@ definition (the ALTER statement, which is an advanced topic).
 Nevertheless, although it might be bad to use it for production,
 it is handy to use it for introduction, so ``"*"`` will appear in some following examples.
 
-**Select with subqueries**
+.. _sql_beginners_select_with_subqueries:
+
+Select with subqueries
+----------------------
 
 Remember that there is a modules table and there is a submodules table.
 Suppose that there is a desire to list the submodules that refer to modules for which the purpose is X.
@@ -422,14 +486,23 @@ But it is true that the query syntax allows for a structural component,
 namely the subquery, and that was the original idea.
 However, there is a different way to combine tables -- with joins instead of subqueries.
 
-**Select with Cartesian join**
+.. _sql_beginners_select_with_cartesian_join:
+
+Select with Cartesian join
+--------------------------
 
 Until now only "FROM modules" or "FROM submodules" was used in SELECT statements.
 What if there was more than one table in the FROM clause? For example
 
-``SELECT * FROM modules, submodules;`` |br|
+.. code-block:: sql
+
+    SELECT * FROM modules, submodules;
+
 or
-``SELECT * FROM modules JOIN submodules;``
+
+.. code-block:: sql
+
+    SELECT * FROM modules JOIN submodules;
 
 That is legal. Usually it is not what you want, but it is a learning aid. The result will be:
 
@@ -488,7 +561,10 @@ It is good to start by looking at Cartesian joins because they show the concept.
 Many people, though, prefer to use different syntaxes for joins because they
 look better or clearer. So now those alternatives will be shown.
 
-**Select with join with ON clause**
+.. _sql_beginners_select_with_join_with_on_clause:
+
+Select with join with ON clause
+-------------------------------
 
 The ON clause would have the same comparisons as the WHERE clause that was illustrated
 for the previous section, but the use of different syntax would be making it clear
@@ -496,30 +572,44 @@ for the previous section, but the use of different syntax would be making it cle
 Readers can see at a glance that it is, in concept at least, an initial step before
 the result rows are filtered. For example this
 
-``SELECT * FROM modules JOIN submodules`` |br|
-|nbsp| |nbsp| ``ON (modules.name = submodules.module_name);``
+.. code-block:: sql
+
+    SELECT * FROM modules JOIN submodules
+      ON (modules.name = submodules.module_name);
 
 is the same as
 
-``SELECT * FROM modules, submodules`` |br|
-|nbsp| |nbsp| ``WHERE modules.name = submodules.module_name;``
+.. code-block:: sql
 
-**Select with join with USING clause**
+    SELECT * FROM modules, submodules
+      WHERE modules.name = submodules.module_name;
+
+.. _sql_beginners_select_with_join_with_using_clause:
+
+Select with join with USING clause
+----------------------------------
 
 The USING clause would take advantage of names that are held in common between the two tables,
 with the assumption that the intent is to match those columns with '=' comparisons. For example,
 
-``SELECT * FROM modules JOIN submodules USING (name);``
+.. code-block:: sql
+
+    SELECT * FROM modules JOIN submodules USING (name);
 
 has the same effect as
 
-``SELECT * FROM modules JOIN submodules WHERE modules.name = submodules.name;``
+.. code-block:: sql
+
+    SELECT * FROM modules JOIN submodules WHERE modules.name = submodules.name;
 
 If the table had been created with a plan in advance to use USING clauses,
 that would save time. But that did not happen.
 So, although the above example "works", the results will not be sensible.
 
-**Select with natural join**
+.. _sql_beginners_select_with_natural_join:
+
+Select with natural join
+------------------------
 
 A natural join would take advantage of names that are held in common between the two tables,
 and would do the filtering automatically based on that knowledge, and throw away duplicate columns.
@@ -527,13 +617,18 @@ and would do the filtering automatically based on that knowledge, and throw away
 If the table had been created with a plan in advance to use natural joins, that would be very handy.
 But that did not happen. So, although the following example "works", the results won't be sensible.
 
-``SELECT * FROM modules NATURAL JOIN submodules;``
+.. code-block:: sql
+
+    SELECT * FROM modules NATURAL JOIN submodules;
 
 Result: nothing, because modules.name does not match submodules.name,
 and so on And even if there had been a result, it would only have included
 four columns: name, module_name, size, purpose.
 
-**Select with left join**
+.. _sql_beginners_select_with_left_join:
+
+Select with left join
+---------------------
 
 Now what if there is a desire to join modules to submodules,
 but it's necessary to be sure that all the modules are found?
@@ -566,7 +661,10 @@ which returns:
 Thus, for the submodules of the clock module and the submodules of the crypto
 module -- which do not exist -- there are NULLs in every column.
 
-**Select with functions**
+.. _sql_beginners_select_with_functions:
+
+Select with functions
+---------------------
 
 A function can take any expression, including an expression that contains another function,
 and return a scalar value. There are many such functions. Here will be a description of only one, SUBSTR,
@@ -601,7 +699,9 @@ all that is important is their aggregation, that is, take the attributes of the 
 SQL allows aggregation functions including: AVG (average), SUM, MIN (minimum), MAX (maximum), and COUNT.
 For example
 
-``SELECT AVG(size), SUM(size), MIN(size), MAX(size), COUNT(size) FROM modules;``
+.. code-block:: sql
+
+    SELECT AVG(size), SUM(size), MIN(size), MAX(size), COUNT(size) FROM modules;
 
 The result will look like this:
 
@@ -636,14 +736,22 @@ The result will look like this:
      +------------+--------------+-----------+-----------+-----------+-------------+
 
 
-**Select with common table expression**
+.. _sql_beginners_select_with_common_table_expression:
+
+Select with common table expression
+-----------------------------------
 
 It is possible to define a temporary (viewed) table within a statement,
 usually within a SELECT statement, using a WITH clause. For example:
 
-``WITH tmp_table AS (SELECT x1 FROM t1) SELECT * FROM tmp_table;``
+.. code-block:: sql
 
-**Select with order, limit, and offset clauses**
+    WITH tmp_table AS (SELECT x1 FROM t1) SELECT * FROM tmp_table;
+
+.. _sql_beginners_select_with_order_limit_and_offset_clauses:
+
+Select with order, limit, and offset clauses
+--------------------------------------------
 
 So far, tor every search in the modules table, the rows have come out in alphabetical order by name:
 'box', then 'clock', then 'crypto'.
@@ -653,24 +761,33 @@ it is necessary to be explicit and add a clause:
 (ASC stands for ASCending, DESC stands for DESCending.)
 For example:
 
-``SELECT * FROM modules ORDER BY name DESC;``
+.. code-block:: sql
+
+    SELECT * FROM modules ORDER BY name DESC;
 
 The result will be the usual rows, in descending alphabetical order: 'crypto' then 'clock' then 'box'.
 
 After the ORDER BY clause there can be a clause LIMIT n, where n is the maximum number of rows to retrieve. For example:
 
-``SELECT * FROM modules ORDER BY name DESC LIMIT 2;``
+.. code-block:: sql
+
+    SELECT * FROM modules ORDER BY name DESC LIMIT 2;
 
 The result will be the first two rows, 'crypto' and 'clock'.
 
 After the ORDER BY clause and the LIMIT clause there can be a clause OFFSET n,
 where n is the row to start with. The first offset is 0. For example:
 
-``SELECT * FROM modules ORDER BY name DESC LIMIT 2 OFFSET 2;``
+.. code-block:: sql
+
+    SELECT * FROM modules ORDER BY name DESC LIMIT 2 OFFSET 2;
 
 The result will be the third row, 'box'.
 
-**Views**
+.. _sql_beginners_views:
+
+Views
+-----
 
 A view is a canned SELECT. If you have a complex SELECT that you want to run frequently, create a view and then do a simple SELECT on the view. For example:
 
@@ -682,7 +799,10 @@ A view is a canned SELECT. If you have a complex SELECT that you want to run fre
     ORDER BY size_times_5;
     SELECT * FROM v;
 
-**Transactions**
+.. _sql_beginners_transactions:
+
+Transactions
+------------
 
 Tarantool has a "Write Ahead Log" (WAL).
 Effects of data-change statements are logged before they are permanently stored on disk.
@@ -717,7 +837,10 @@ After START TRANSACTION, statements are not automatically committed -- Tarantool
 that a transaction is now "active", until the transaction ends with a COMMIT statement or a ROLLBACK statement.
 While a transaction is active, all statements are legal except another START TRANSACTION.
 
-**Implementing Tarantool's SQL On Top of NoSQL**
+.. _sql_beginners_implementing_tarantool_sql_on_top_of_no_sql:
+
+Implementing Tarantool's SQL On Top of NoSQL
+--------------------------------------------
 
 Tarantool's SQL data is the same as Tarantool's NoSQL data. When you create a table or an index with SQL,
 you are creating a space or an index in NoSQL. For example:
@@ -759,7 +882,10 @@ use SQL to access the database's metadata catalog.
 Fields in NoSQL spaces can be accessed with SQL if and only if they are scalar and are defined
 in format clauses. Indexes of NoSQL spaces will be used with SQL if and only if they are TREE indexes.
 
-**Relational Databases**
+.. _sql_beginners_relational_databases:
+
+Relational Databases
+--------------------
 
 Edgar F. Codd, the person most responsible for researching and explaining relational database concepts,
 listed the main criteria as

--- a/doc/reference/reference_sql/sql_user_guide.rst
+++ b/doc/reference/reference_sql/sql_user_guide.rst
@@ -1,9 +1,8 @@
 
 .. _sql_user_guide:
 
---------------------------------------------------------------------------------
 SQL user guide
---------------------------------------------------------------------------------
+==============
 
 The User Guide describes how users can start up with SQL with Tarantool, and necessary concepts.
 
@@ -25,9 +24,8 @@ The User Guide describes how users can start up with SQL with Tarantool, and nec
 
 .. _sql_getting_started:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Getting Started
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------
 
 The explanations for installing and starting the Tarantool server are in earlier chapters of the Tarantool manual.
 
@@ -74,9 +72,8 @@ It is also legal to enclose SQL statements inside single or double quote marks i
 
 .. _sql_supported_syntax:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Supported Syntax
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------
 
 Keywords, for example CREATE or INSERT or VALUES, may be entered in either upper case or lower case.
 
@@ -105,9 +102,8 @@ Expressions, for example ``a + b`` or ``a > b AND NOT a <= b``, may have arithme
 
 .. _sql_concepts:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Concepts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------
 
 In the :ref:`SQL beginners' guide <sql_beginners_guide>` there was discussion of: |br|
 What are: relational databases, tables, views, rows, and columns? |br|
@@ -134,9 +130,8 @@ possible with NoSQL. Mixing SQL statements with NoSQL requests is allowed.
 
 .. _sql_tokens:
 
-********************************************************************************
 Tokens
-********************************************************************************
+~~~~~~
 
 The token is the minimum SQL-syntax unit that Tarantool understands.
 These are the types of tokens:
@@ -159,9 +154,8 @@ but for readability one would usually use spaces to separate tokens: |br|
 
 .. _sql_literals:
 
-********************************************************************************
 Literals
-********************************************************************************
+~~~~~~~~
 
 There are eight kinds of literals: BOOLEAN INTEGER DOUBLE DECIMAL STRING VARBINARY MAP ARRAY.
 
@@ -258,9 +252,8 @@ one must say ``UPDATE ... SET string_column = CAST(X'41' AS STRING);``. |br|
 
 .. _sql_identifiers:
 
-********************************************************************************
 Identifiers
-********************************************************************************
+~~~~~~~~~~~
 
 All database objects -- tables, triggers, indexes, columns, constraints, functions, collations -- have identifiers.
 An identifier should begin with a letter or underscore (``'_'``) and should contain
@@ -275,9 +268,8 @@ so Cyrillic identifiers consume a tiny amount more space.
 
 .. _sql_reserved_words:
 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Reserved words
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+**************
 
 Certain words are reserved and should not be used for identifiers.
 The simple rule is: if a word means something in Tarantool SQL syntax,
@@ -404,9 +396,9 @@ The following example shows that conversion to upper case affects regular identi
 
 .. _sql_operands:
 
-********************************************************************************
 Operands
-********************************************************************************
+~~~~~~~~
+
 
 An operand is something that can be operated on. Literals and column identifiers are operands. So are NULL and DEFAULT.
 
@@ -414,9 +406,11 @@ NULL and DEFAULT are keywords which represent values whose data types are not kn
 so they are known by the technical term "contextually typed value specifications".
 (Exception: for the non-standard statement "SELECT NULL FROM table-name;"  NULL has data type BOOLEAN.)
 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. _sql_operand_data_types:
+
 Operand data types
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+******************
 
 Every operand has a data type.
 
@@ -816,9 +810,12 @@ For example, ``SELECT "flags" FROM "_vspace";`` would return a column whose type
 Such columns can only be manipulated in SQL by
 :ref:`invoking Lua functions <sql_calling_lua>`.
 
-********************************************************************************
+
+.. _sql_operators:
+
 Operators
-********************************************************************************
+~~~~~~~~~
+
 
 An operator signifies what operation can be performed on operands.
 
@@ -849,150 +846,228 @@ Starting with Tarantool version 2.10.1, arithmetic operands cannot be NUMBERs.
 
 .. _sql_operator_addition:
 
-``+`` addition (arithmetic)
-Add two numerics according to standard arithmetic rules.
-Example: ``1 + 5``, result = 6.
+*   ``+`` addition (arithmetic)
+
+    Add two numerics according to standard arithmetic rules.
+    Example: ``1 + 5``, result = 6.
 
 .. _sql_operator_subtraction:
 
-``-`` subtraction (arithmetic)
-Subtract second numeric from first numeric according to standard arithmetic rules.
-Example: ``1 - 5``, result = -4.
+*   ``-`` subtraction (arithmetic)
 
-``*`` multiplication (arithmetic)
-Multiply two numerics according to standard arithmetic rules.
-Example: ``2 * 5``, result = 10.
+    Subtract second numeric from first numeric according to standard arithmetic rules.
 
-``/`` division (arithmetic)
-Divide second numeric into first numeric according to standard arithmetic rules.
-Division by zero is not legal.
-Division of integers always results in rounding toward zero,
-use :ref:`CAST <sql_function_cast>` to DOUBLE or to DECIMAL to get
-non-integer results.
-Example: ``5 / 2``, result = 2.
+    Example: ``1 - 5``, result = -4.
 
-``%`` modulus (arithmetic)
-Divide second numeric into first numeric according to standard arithmetic rules.
-The result is the remainder.
-Starting with Tarantool version 2.10.1, operands must be INTEGER or UNSIGNED.
-Example: ``17 % 5``, result = 2.
-Example: ``-123 % 4``, result = -3.
+*   ``*`` multiplication (arithmetic)
 
-``<<`` shift left (arithmetic)
-Shift the first numeric to the left N times, where N = the second numeric.
-For positive numerics, each 1-bit shift to the left is equivalent to multiplying times 2.
-Example: ``5 << 1``, result = 10.
-Starting with Tarantool version 2.10.1, operands must be non-negative INTEGER or UNSIGNED.
+    Multiply two numerics according to standard arithmetic rules.
 
-``>>`` shift right (arithmetic)
-Shift the first numeric to the right N times, where N = the second numeric.
-For positive numerics, each 1-bit shift to the right is equivalent to dividing by 2.
-Example: ``5 >> 1``, result = 2.
-Starting with Tarantool version 2.10.1, operands must be non-negative INTEGER or UNSIGNED.
+    Example: ``2 * 5``, result = 10.
 
-``&`` and (arithmetic)
-Combine the two numerics, with 1 bits in the result if and only if both original numerics have 1 bits.
-Example: ``5 & 4``, result = 4.
-Starting with Tarantool version 2.10.1, operands must be non-negative INTEGER or UNSIGNED.
+*   ``/`` division (arithmetic)
 
-``|`` or (arithmetic)
-Combine the two numerics, with 1 bits in the result if either original numeric has a 1 bit.
-Example: ``5 | 2``, result = 7.
-Starting with Tarantool version 2.10.1, operands must be non-negative INTEGER or UNSIGNED.
+    Divide second numeric into first numeric according to standard arithmetic rules.
+    Division by zero is not legal.
+    Division of integers always results in rounding toward zero,
+    use :ref:`CAST <sql_function_cast>` to DOUBLE or to DECIMAL to get
+    non-integer results.
 
-``~`` negate (arithmetic), sometimes called bit inversion
-Change 0 bits to 1 bits, change 1 bits to 0 bits.
-Example: ``~5``, result = -6.
-Starting with Tarantool version 2.10.1, the operand must be non-negative INTEGER or UNSIGNED.
+    Example: ``5 / 2``, result = 2.
+
+*   ``%`` modulus (arithmetic)
+
+    Divide second numeric into first numeric according to standard arithmetic rules.
+    The result is the remainder.
+    Starting with Tarantool version 2.10.1, operands must be INTEGER or UNSIGNED.
+
+    Examples: ``17 % 5``, result = 2; ``-123 % 4``, result = -3.
+
+*   ``<<`` shift left (arithmetic)
+
+    Shift the first numeric to the left N times, where N = the second numeric.
+    For positive numerics, each 1-bit shift to the left is equivalent to multiplying times 2.
+
+    Example: ``5 << 1``, result = 10.
+
+    .. NOTE::
+
+        Starting with Tarantool version 2.10.1, operands must be non-negative INTEGER or UNSIGNED.
+
+*   ``>>`` shift right (arithmetic)
+
+    Shift the first numeric to the right N times, where N = the second numeric.
+    For positive numerics, each 1-bit shift to the right is equivalent to dividing by 2.
+
+    Example: ``5 >> 1``, result = 2.
+
+    .. NOTE::
+
+        Starting with Tarantool version 2.10.1, operands must be non-negative INTEGER or UNSIGNED.
+
+*   ``&`` and (arithmetic)
+
+    Combine the two numerics, with 1 bits in the result if and only if both original numerics have 1 bits.
+
+    Example: ``5 & 4``, result = 4.
+
+    .. NOTE::
+
+        Starting with Tarantool version 2.10.1, operands must be non-negative INTEGER or UNSIGNED.
+
+*   ``|`` or (arithmetic)
+
+    Combine the two numerics, with 1 bits in the result if either original numeric has a 1 bit.
+
+    Example: ``5 | 2``, result = 7.
+
+    .. NOTE::
+
+        Starting with Tarantool version 2.10.1, operands must be non-negative INTEGER or UNSIGNED.
+
+*   ``~`` negate (arithmetic), sometimes called bit inversion
+
+    Change 0 bits to 1 bits, change 1 bits to 0 bits.
+
+    Example: ``~5``, result = -6.
+
+    .. NOTE::
+
+        Starting with Tarantool version 2.10.1, the operand must be non-negative INTEGER or UNSIGNED.
 
 .. _sql_operator_comparison:
 
-``<`` less than (comparison)
-Return TRUE if the first operand is less than the second by arithmetic or collation rules.
-Example for numerics: ``5 < 2``, result = FALSE. Example for strings: ``'C' < ' '``, result = FALSE.
+*   ``<`` less than (comparison)
 
-``<=`` less than or equal (comparison)
-Return TRUE if the first operand is less than or equal to the second by arithmetic or collation rules.
-Example for numerics: ``5 <= 5``, result = TRUE. Example for strings: ``'C' <= 'B'``, result = FALSE.
+    Return TRUE if the first operand is less than the second by arithmetic or collation rules.
 
-``>`` greater than (comparison)
-Return TRUE if the first operand is greater than the second by arithmetic or collation rules.
-Example for numerics: ``5 > -5``, result = TRUE. Example for strings: ``'C' > '!'``, result = TRUE.
+    Example for numerics: ``5 < 2``, result = FALSE
 
-``>=`` greater than or equal (comparison)
-Return TRUE if the first operand is greater than or equal to the second by arithmetic or collation rules.
-Example for numerics: ``0 >= 0``, result = TRUE. Example for strings: ``'Z' >= 'Γ'``, result = FALSE.
+    Example for strings: ``'C' < ' '``, result = FALSE
+
+*   ``<=`` less than or equal (comparison)
+
+    Return TRUE if the first operand is less than or equal to the second by arithmetic or collation rules.
+
+    Example for numerics: ``5 <= 5``, result = TRUE
+
+    Example for strings: ``'C' <= 'B'``, result = FALSE
+
+*   ``>`` greater than (comparison)
+
+    Return TRUE if the first operand is greater than the second by arithmetic or collation rules.
+
+    Example for numerics: ``5 > -5``, result = TRUE
+
+    Example for strings: ``'C' > '!'``, result = TRUE
+
+*   ``>=`` greater than or equal (comparison)
+
+    Return TRUE if the first operand is greater than or equal to the second by arithmetic or collation rules.
+
+    Example for numerics: ``0 >= 0``, result = TRUE
+    Example for strings: ``'Z' >= 'Γ'``, result = FALSE
 
 .. _sql_equal:
 
-``=`` equal (assignment or comparison)
-After the word SET, "=" means the first operand gets the value from the second operand.
-In other contexts, "=" returns TRUE if operands are equal.
-Example for assignment: ``... SET column1 = 'a';``
-Example for numerics: ``0 = 0``, result = TRUE. Example for strings: ``'1' = '2 '``, result = FALSE.
+*   ``=`` equal (assignment or comparison)
 
-``==`` equal (assignment), or equal (comparison)
-This is a non-standard equivalent of
-:ref:`"= equal (assignment or comparison)" <sql_equal>`.
+    After the word SET, "=" means the first operand gets the value from the second operand.
+    In other contexts, "=" returns TRUE if operands are equal.
+
+    Example for assignment: ``... SET column1 = 'a';``
+
+    Example for numerics: ``0 = 0``, result = TRUE
+
+    Example for strings: ``'1' = '2 '``, result = FALSE
+
+*   ``==`` equal (assignment), or equal (comparison)
+
+    This is a non-standard equivalent of
+    :ref:`"= equal (assignment or comparison)" <sql_equal>`.
 
 .. _sql_not_equal:
 
-``<>`` not equal (comparison)
-Return TRUE if the first operand is not equal to the second by arithmetic or collation rules.
-Example for strings: ``'A' <> 'A     '`` is TRUE.
+*   ``<>`` not equal (comparison)
 
-``!=`` not equal (comparison)
-This is a non-standard equivalent of
-:ref:`"\<\> not equal (comparison)" <sql_not_equal>`.
+    Return TRUE if the first operand is not equal to the second by arithmetic or collation rules.
+
+    Example for strings: ``'A' <> 'A     '`` is TRUE.
+
+*   ``!=`` not equal (comparison)
+
+    This is a non-standard equivalent of
+    :ref:`"\<\> not equal (comparison)" <sql_not_equal>`.
+
+*   ``[`` , ``]`` (indexed access operator)
+
+    Array example: ``['a', 'b', 'c'] [2]`` (returns ``'b'``)
+
+    Map example: ``{'a' : 123, 7: 'asd'}['a']`` (returns ``123``)
+
+    See also: :ref:`ARRAY index expression <sql_array_index_expression>` and :ref:`MAP index expression <sql_map_index_expression>`.
 
 .. _sql_is_null:
 
-``IS NULL`` and ``IS NOT NULL`` (comparison)
-For IS NULL: Return TRUE if the first operand is NULL, otherwise return FALSE.
-Example: column1 IS NULL, result = TRUE if column1 contains NULL.
-For IS NOT NULL: Return FALSE if the first operand is NULL, otherwise return TRUE.
-Example: ``column1 IS NOT NULL``, result = FALSE if column1 contains NULL.
+*   ``IS NULL`` and ``IS NOT NULL`` (comparison)
+
+    For IS NULL: Return TRUE if the first operand is NULL, otherwise return FALSE.
+    Example: column1 IS NULL, result = TRUE if column1 contains NULL.
+
+    For IS NOT NULL: Return FALSE if the first operand is NULL, otherwise return TRUE.
+    Example: ``column1 IS NOT NULL``, result = FALSE if column1 contains NULL.
 
 .. _sql_operator_like:
 
-``LIKE`` (comparison)
-Perform a comparison of two string operands.
-If the second operand contains ``'_'``, the ``'_'`` matches any single character in the first operand.
-If the second operand contains ``'%'``, the ``'%'`` matches 0 or more characters in the first operand.
-If it is necessary to search for either ``'_'`` or ``'%'`` within a string without treating it specially,
-an optional clause can be added, ESCAPE single-character-operand, for example
-``'abc_' LIKE 'abcX_' ESCAPE 'X'`` is TRUE because ``X'`` means "following character is not
-special". Matching is also affected by the string's collation.
+*   ``LIKE`` (comparison)
+
+    Perform a comparison of two string operands.
+    If the second operand contains ``'_'``, the ``'_'`` matches any single character in the first operand.
+    If the second operand contains ``'%'``, the ``'%'`` matches 0 or more characters in the first operand.
+    If it is necessary to search for either ``'_'`` or ``'%'`` within a string without treating it specially,
+    an optional clause can be added, ESCAPE single-character-operand, for example
+    ``'abc_' LIKE 'abcX_' ESCAPE 'X'`` is TRUE because ``X'`` means "following character is not
+    special". Matching is also affected by the string's collation.
 
 .. _sql_operator_between:
 
-``BETWEEN`` (comparison)
-:samp:`{x} BETWEEN {y} AND {z}` is shorthand for :samp:`{x} >= {y} AND {x} <= {z}`.
+*   ``BETWEEN`` (comparison)
 
-``NOT`` negation (logic)
-Return TRUE if operand is FALSE return FALSE if operand is TRUE, else return UNKNOWN.
-Example: ``NOT (1 > 1)``, result = TRUE.
+    :samp:`{x} BETWEEN {y} AND {z}` is shorthand for :samp:`{x} >= {y} AND {x} <= {z}`.
 
-``IN`` is equal to one of a list of operands (comparison)
-Return TRUE if first operand equals any of the operands in a parenthesized list.
-Example: ``1 IN (2,3,4,1,7)``, result = TRUE.
+*   ``NOT`` negation (logic)
 
-``AND`` and (logic)
-Return TRUE if both operands are TRUE.
-Return UNKNOWN if both operands are UNKNOWN.
-Return UNKNOWN if one operand is TRUE and the other operand is UNKNOWN.
-Return FALSE if one operand is FALSE and the other operand is (UNKNOWN or TRUE or FALSE).
+    Return TRUE if operand is FALSE return FALSE if operand is TRUE, else return UNKNOWN.
 
-``OR`` or (logic)
-Return TRUE if either operand is TRUE.
-Return FALSE if both operands are FALSE.
-Return UNKNOWN if one operand is UNKNOWN and the other operand is (UNKNOWN or FALSE).
+    Example: ``NOT (1 > 1)``, result = TRUE.
+
+*   ``IN`` is equal to one of a list of operands (comparison)
+
+    Return TRUE if first operand equals any of the operands in a parenthesized list.
+
+    Example: ``1 IN (2,3,4,1,7)``, result = TRUE.
+
+*   ``AND`` and (logic)
+
+    Return TRUE if both operands are TRUE.
+    Return UNKNOWN if both operands are UNKNOWN.
+    Return UNKNOWN if one operand is TRUE and the other operand is UNKNOWN.
+    Return FALSE if one operand is FALSE and the other operand is (UNKNOWN or TRUE or FALSE).
+
+*   ``OR`` or (logic)
+
+    Return TRUE if either operand is TRUE.
+    Return FALSE if both operands are FALSE.
+    Return UNKNOWN if one operand is UNKNOWN and the other operand is (UNKNOWN or FALSE).
 
 .. _sql_operator_concatenate:
 
-``||`` concatenate (string manipulation)
-Return the value of the first operand concatenated with the value of the second operand.
-Example: ``'A' || 'B'``, result = ``'AB'``.
+*   ``||`` concatenate (string manipulation)
+
+    Return the value of the first operand concatenated with the value of the second operand.
+
+    Example: ``'A' || 'B'``, result = ``'AB'``.
+
 
 The precedence of dyadic operators is:
 
@@ -1007,11 +1082,13 @@ The precedence of dyadic operators is:
     AND
     OR
 
-To ensure a desired precedence, use () parentheses.
+To ensure a desired precedence, use ``()`` parentheses.
 
-********************************************************************************
+
+.. _sql_special_situations:
+
 Special situations
-********************************************************************************
+~~~~~~~~~~~~~~~~~~
 
 If one of the operands has data type DOUBLE, Tarantool uses floating-point arithmetic.
 This means that exact results are not guaranteed and rounding may occur without warning.
@@ -1036,11 +1113,11 @@ Limitations: (`Issue#2346 <https://github.com/tarantool/tarantool/issues/2346>`_
 * Some words, for example MATCH and REGEXP, are reserved but are not necessary for current or planned Tarantool versions |br|
 * 999999999999999 << 210 yields 0.
 
+
 .. _sql_expressions:
 
-********************************************************************************
 Expressions
-********************************************************************************
+~~~~~~~~~~~
 
 An expression is a chunk of syntax that causes return of a value.
 Expressions may contain literals, column-names, operators, and parentheses.
@@ -1050,18 +1127,39 @@ Therefore these are examples of expressions:
 
 Also there are two expressions that involve keywords:
 
-value IS [NOT] NULL |br|
-  ... for determining whether value is (not) NULL
+*  ``value IS [NOT] NULL``: determine whether value is (not) ``NULL``.
 
-CASE ... WHEN ... THEN ... ELSE ... END |br|
-  ... for setting a series of conditions.
+*  ``CASE ... WHEN ... THEN ... ELSE ... END``: set a series of conditions.
+
+.. _sql_array_expression:
+
+
+ARRAY expressions
+*****************
+
+Usage: ``[ value ... ]``
+
+Examples: ``[1,2,3,4]``, ``[1,[2,3],4]``, ``['a', "column_1", uuid()]``
+
+An expression has data type = ARRAY if it is a sequence of zero or more values
+enclosed in square brackets (``[`` and ``]``).
+Often the values in the sequence are called "elements".
+The element data type may be anything, including ARRAY -- that is, ARRAYs may be nested.
+Different elements may have different types.
+The Lua equivalent type is `'array' <https://www.lua.org/pil/11.1.html>`_.
+
 
 .. _sql_map_expression:
 
-{ key : value } |br|
-... for MAP expressions. |br|
-Literal examples: ``{'a':1}``, ``{ "column_1" : X'1234' }`` |br|
-Non-literal examples: ``{"a":"a"}``, ``{UUID(): (SELECT 1) + 1}``, ``{1:'a123', 'two':uuid()}`` |br|
+MAP expressions
+***************
+
+Usage: ``{ key : value }``
+
+Literal examples: ``{'a':1}``, ``{ "column_1" : X'1234' }``
+
+Non-literal examples: ``{"a":"a"}``, ``{UUID(): (SELECT 1) + 1}``, ``{1:'a123', 'two':uuid()}``
+
 An expression has data type = MAP if it is enclosed in curly brackets
 (also called braces) ``{`` and ``}`` and contains a key for identification,
 then a colon ``:``, then a value for what the key identifies.
@@ -1070,39 +1168,49 @@ The value data type may be anything, including MAP -- that is, MAPs may be neste
 The Lua equivalent type is 'map' but the syntax is slightly different,
 for example the SQL value ``{'a': 1}`` is represented in Lua as ``{a = 1}``.
 
-.. _sql_array_expression:
-
-[ value ... ] |br|
-... for ARRAY expressions. |br|
-Examples: ``[1,2,3,4]``, ``[1,[2,3],4]``, ``['a', "column_1", uuid()]`` |br|
-An expression has data type = ARRAY if it is a sequence of zero or more values
-enclosed in square brackets (``[`` and ``]``).
-Often the values in the sequence are called "elements".
-The element data type may be anything, including ARRAY -- that is, ARRAYs may be nested.
-Different elements may have different types.
-The Lua equivalent type is `'array' <https://www.lua.org/pil/11.1.html>`_.
-
 .. _sql_array_index_expression:
 
-ARRAY index expression: |br|
-array-value [square bracket] index [square bracket] |br|
-Example: ``['a', 'b', 'c'] [2]`` (this returns 'b') |br|
+ARRAY index expression
+**********************
+
+Usage: ``array-value [square bracket] index [square bracket]``
+
+Example: ``['a', 'b', 'c'] [2]`` (this returns 'b')
+
 As in other languages, an element of an array can be referenced with an
 integer inside square brackets.
 The returned value is of type ANY.
 
+The ``SELECT`` query below retrieves all score values stored in the second position of the ``scores`` array field:
+
+..  literalinclude:: /code_snippets/test/sql/array_access_test.lua
+    :language: sql
+    :lines: 22,25,28,31-36
+    :dedent:
+
 .. _sql_map_index_expression:
 
-MAP index expression: |br|
-map-value [square bracket] index [square bracket] |br|
-Example: ``{'a' : 123, 7: 'asd'}['a']`` (this returns 123)
-The returned value is of type ANY.
+MAP index expression
+********************
+
+Usage: ``map-value [square bracket] index [square bracket]``
+
+Example: ``{'a' : 123, 7: 'asd'}['a']`` (this returns 123). The returned value is of type ANY.
+
+The ``SELECT`` query below retrieves all values stored in the ``name`` attribute of the ``info`` map field:
+
+..  literalinclude:: /code_snippets/test/sql/map_access_test.lua
+    :language: sql
+    :lines: 22,25,28,31-36
+    :dedent:
 
 See also: :ref:`subquery <sql_subquery>`.
 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. _sql_expressions_comparing_and_ordering:
+
 Comparing and ordering
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+**********************
 
 There are rules for determining whether value-1 is "less than", "equal to", or "greater than" value-2.
 These rules are applied for searches, for sorting results in order by column values,
@@ -1155,9 +1263,11 @@ When comparing any value to an ARRAY or MAP or ANY: |br|
 Limitations: |br|
 * LIKE is not expected to work with VARBINARY.
 
-********************************************************************************
+
+.. _sql_statements:
+
 Statements
-********************************************************************************
+~~~~~~~~~~
 
 A statement consists of SQL-language keywords and expressions that direct Tarantool to do something with a database.
 Statements begin with one of the words
@@ -1169,9 +1279,10 @@ A client sends a statement to the Tarantool server.
 The Tarantool server parses the statement and executes it.
 If there is an error, Tarantool returns an error message.
 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. _sql_list_of_legal_statements:
+
 List of legal statements
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+************************
 
 In alphabetical order, the following statements are legal.
 
@@ -1222,9 +1333,8 @@ In alphabetical order, the following statements are legal.
 
 .. _sql_data_type_conversion:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Data Type Conversion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Data type conversion, also called casting, is necessary for any operation involving two operands X and Y,
 when X and Y have different data types. |br|
@@ -1322,9 +1432,8 @@ the assignment will fail.
 
 .. _sql-implicit_cast:
 
-********************************************************************************
 Implicit string/numeric cast
-********************************************************************************
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The examples in this section are true only for Tarantool versions before Tarantool 2.10.
 Starting with Tarantool 2.10, implicit string/numeric cast is no longer allowed.


### PR DESCRIPTION
This PR is related to the https://github.com/tarantool/doc/issues/2884 and https://github.com/tarantool/doc/issues/2865 issues.
Looks like some info was already added before. I've updated the topic structure to make it a bit clearer and added a couple of examples that show how to query spaces containing array and map fields:

- The `[]` operator is described in this section: https://docs.d.tarantool.io/en/doc/sql-beginner-structure/reference/reference_sql/sql_user_guide/#operators
- MAP literal is described here: https://docs.d.tarantool.io/en/doc/sql-beginner-structure/reference/reference_sql/sql_user_guide/#literals
- Added the example in `ARRAY index expression`: https://docs.d.tarantool.io/en/doc/sql-beginner-structure/reference/reference_sql/sql_user_guide/#array-index-expression
- Added the example in `MAP index expression`: https://docs.d.tarantool.io/en/doc/sql-beginner-structure/reference/reference_sql/sql_user_guide/#map-index-expression

> For some reason, the second example doesn't use proper SQL highlighting.

Updated the structure of the Beginners Guide - now it has the Table of Contents on the right:
- https://docs.d.tarantool.io/en/doc/sql-beginner-structure/how-to/sql/sql_beginners_guide/

Also, converted inline code samples to code blocks for better readability.
