### PR TITLE
Document SQL SEQSCAN

### DIFF
--- a/doc/how-to/sql/sql_beginners_guide.rst
+++ b/doc/how-to/sql/sql_beginners_guide.rst
@@ -11,7 +11,7 @@ Most of the matters in the Beginners' Guide will already be familiar to people w
 
 .. _sql_beginners_sample_table:
 
-Sample Table
+Sample table
 ------------
 
 In football training camp it is traditional for the trainer to begin by showing a football
@@ -270,7 +270,7 @@ NoSQL emphasizes freedom and making your own rules.
 
 .. _sql_beginners_table_relationships:
 
-Table Relationships
+Table relationships
 -------------------
 
 Think about the two tables that have been discussed so far:
@@ -311,6 +311,22 @@ That is wrong, as will be clear in the discussion about what makes a database re
 
 Selecting with WHERE
 --------------------
+
+.. important::
+
+    By default, Tarantool prohibits ``SELECT`` queries that scan table rows
+    instead of using indexes to avoid unwanted heavy load.
+
+    For the purposes of this tutorial, allow SQL scan queries in Tarantool
+    by running by running the command:
+
+    .. code-block:: sql
+
+        SET SESSION "sql_seq_scan" = true;
+
+    Alternatively, you can allow a specific query to perform a table scan by adding
+    the ``SEQSCAN`` keyword before the table name. Learn more about using ``SEQSCAN``
+    in SQL scan queries in the :ref:`SQL FROM clause description <sql_from>`.
 
 We gave a simple example of a SELECT statement earlier:
 
@@ -884,7 +900,7 @@ in format clauses. Indexes of NoSQL spaces will be used with SQL if and only if 
 
 .. _sql_beginners_relational_databases:
 
-Relational Databases
+Relational databases
 --------------------
 
 Edgar F. Codd, the person most responsible for researching and explaining relational database concepts,

--- a/doc/how-to/sql/sql_beginners_guide.rst
+++ b/doc/how-to/sql/sql_beginners_guide.rst
@@ -315,10 +315,8 @@ Selecting with WHERE
 .. important::
 
     By default, Tarantool prohibits ``SELECT`` queries that scan table rows
-    instead of using indexes to avoid unwanted heavy load.
-
-    For the purposes of this tutorial, allow SQL scan queries in Tarantool
-    by running by running the command:
+    instead of using indexes to avoid unwanted heavy load. For the purposes of
+    this tutorial, allow SQL scan queries in Tarantool by running the command:
 
     .. code-block:: sql
 

--- a/doc/how-to/sql/sql_tutorial.rst
+++ b/doc/how-to/sql/sql_tutorial.rst
@@ -122,7 +122,7 @@ The SEQSCAN keyword
 
 In Tarantool, SQL queries that perform sequential scans (that is, go through all
 the table instead of using indexes) are prohibited by default. For example, this
-query leads to the error ``Scanning is not allowed for 'table2':
+query leads to the error ``Scanning is not allowed for 'table2'``:
 
 .. code-block:: sql
 
@@ -140,23 +140,27 @@ Try to execute these queries that seem to return the same result:
 .. code-block:: sql
 
     SELECT * FROM table2 WHERE column1 = 1;
-    SELECT * FROM table2 WHERE column1 + 1 = 2
+    SELECT * FROM table2 WHERE column1 + 1 = 2;
 
 The result is:
 
-*   the first query returns
+*   The first query returns rows:
 
     .. code-block:: tarantoolsession
 
         - [1, 'AB', 'AB', 10.5]
         - [1, 'CD', '  ', 10005]
 
-*   the second query fails with the error ``Scanning is not allowed for 'TABLE2'``.
+*   The second query fails with the error ``Scanning is not allowed for 'TABLE2'``.
 
 .. note::
 
     You can allow SQL scan queries without ``SEQSCAN`` for the current session
-    by running ``SET SESSION "sql_seq_scan" = true;``.
+    by running the command:
+
+    .. code-block:: sql
+
+        SET SESSION "sql_seq_scan" = true;
 
 
 Learn more about using ``SEQSCAN`` in the :ref:`SQL FROM clause description <sql_from>`.

--- a/doc/reference/reference_lua/box_space/_session_settings.rst
+++ b/doc/reference/reference_lua/box_space/_session_settings.rst
@@ -26,6 +26,7 @@ box.space._session_settings
     *   ``sql_reverse_unordered_selects``: return result rows in reverse order if there is no :ref:`ORDER BY clause <sql_order_by>`.
         Default: ``false``.
     *   ``sql_select_debug``: show execution steps during :ref:`SELECT <sql_select>`. Default:``false``.
+    *   ``sql_seq_scan``: allow sequential scans in SQL :ref:`SELECT <sql_select>`. Default: ``true``.
     *   ``sql_vdbe_debug``: for internal use. Default:``false``.
     *   ``sql_defer_foreign_keys`` (removed in :doc:`2.11.0 </release/2.11.0>`): whether foreign-key checks can wait till
         commit. Default: ``false``.

--- a/doc/reference/reference_sql/README.md
+++ b/doc/reference/reference_sql/README.md
@@ -1,0 +1,30 @@
+The diagrams in the SQL reference are generated using [Syntrax](https://github.com/kevinpt/syntrax).
+
+# Install Syntrax
+
+```
+pip install syntrax
+```
+
+## Troubleshooting installation issues
+
+### pip: command not found
+
+- Ensure that Python is installed
+- Try `pip3` instead of `pip` 
+
+### error in syntrax setup command: use_2to3 is invalid.
+
+Run `pip3 install "setuptools<58.0.0"`
+
+### ModuleNotFoundError: No module named 'cairo'|'gi'|'pango'
+
+Search on stackoverflow %)
+
+# Generate a diagram
+
+Generate an SVG with the same file name:
+
+```
+syntrax <filename>.spec -o svg
+```

--- a/doc/reference/reference_sql/from.spec
+++ b/doc/reference/reference_sql/from.spec
@@ -2,6 +2,10 @@ stack (
   line(
     choice(
       line(
+        choice(
+          None,
+          line(' SEQSCAN ')
+         ),
         'table-name',
         choice(
           None,

--- a/doc/reference/reference_sql/from.svg
+++ b/doc/reference/reference_sql/from.svg
@@ -3,17 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="979" height="180" version="1.1">
+width="1087" height="177" version="1.1">
 <style type="text/css">
 <![CDATA[
-.box_font {fill:#000000; text-anchor:middle;
-    font-family:Courier; font-size:14pt; font-weight:regular; font-style:normal;}
-.name_font {fill:#000000; text-anchor:middle;
-    font-family:Courier; font-size:14pt; font-weight:regular; font-style:normal;}
 .title_font {fill:#000000; text-anchor:middle;
     font-family:Sans; font-size:22pt; font-weight:bold; font-style:normal;}
+.name_font {fill:#000000; text-anchor:middle;
+    font-family:Courier; font-size:14pt; font-weight:regular; font-style:normal;}
 .bubble_font {fill:#000000; text-anchor:middle;
     font-family:Courier; font-size:14pt; font-weight:bold; font-style:normal;}
+.box_font {fill:#000000; text-anchor:middle;
+    font-family:Courier; font-size:14pt; font-weight:regular; font-style:normal;}
 .token_font {fill:#000000; text-anchor:middle;
     font-family:Courier; font-size:14pt; font-weight:bold; font-style:normal;}
 .label {fill:#000;
@@ -29,141 +29,156 @@ width="979" height="180" version="1.1">
     <path d="M0,0 L0.5,2 L0,4 L4.5,2 z" fill="#FF0000" />
   </marker>
 </defs>
-<rect width="100%" height="100%" fill="white"/><path d="M59.0,33.0 A13.0,13.0 0 0,1 59.0,7.0 H163.0 A13.0,13.0 0 0,1 163.0,33.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M262.0,69.0 A13.0,13.0 0 0,1 262.0,43.0 H300.0 A13.0,13.0 0 0,1 300.0,69.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M371.0,51.0 A13.0,13.0 0 0,1 371.0,25.0 H475.0 A13.0,13.0 0 0,1 475.0,51.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M574.0,51.0 A13.0,13.0 0 0,1 574.0,25.0 H667.0 A13.0,13.0 0 0,1 667.0,51.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M710.0,51.0 A13.0,13.0 0 0,1 710.0,25.0 H748.0 A13.0,13.0 0 0,1 748.0,51.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M791.0,51.0 A13.0,13.0 0 0,1 791.0,25.0 H895.0 A13.0,13.0 0 0,1 895.0,51.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M574.0,81.0 A13.0,13.0 0 0,1 574.0,55.0 H623.0 A13.0,13.0 0 0,1 623.0,81.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M666.0,81.0 A13.0,13.0 0 0,1 666.0,55.0 H759.0 A13.0,13.0 0 0,1 759.0,81.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M69.0,111.0 A13.0,13.0 0 0,1 69.0,85.0 H74.0 A13.0,13.0 0 0,1 74.0,111.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<rect x="104.0" y="85.0" width="188.0" height="26.0" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M322.0,111.0 A13.0,13.0 0 0,1 322.0,85.0 H327.0 A13.0,13.0 0 0,1 327.0,111.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M426.0,147.0 A13.0,13.0 0 0,1 426.0,121.0 H464.0 A13.0,13.0 0 0,1 464.0,147.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M535.0,129.0 A13.0,13.0 0 0,1 535.0,103.0 H639.0 A13.0,13.0 0 0,1 639.0,129.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M69.0,177.0 A13.0,13.0 0 0,1 69.0,151.0 H74.0 A13.0,13.0 0 0,1 74.0,177.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<rect x="104.0" y="151.0" width="133.0" height="26.0" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<path d="M267.0,177.0 A13.0,13.0 0 0,1 267.0,151.0 H272.0 A13.0,13.0 0 0,1 272.0,177.0 z" stroke="none" fill-opacity="0.498039215686" fill="#000000"/>
-<circle cx="7" cy="17.0" r="2" stroke="#FF0000" stroke-width="1" fill="#FFFFFF"/>
-<path d="M57.0,31.0 A13.0,13.0 0 0,1 57.0,5.0 H161.0 A13.0,13.0 0 0,1 161.0,31.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="name_font" x="109.0" y="24.0">table-name</text>
-<line x1="352.0" y1="17.0" x2="353.0" y2="17.0" stroke="#FF0000" stroke-width="1" />
-<line x1="278.5" y1="35.0" x2="279.5" y2="35.0" stroke="#FF0000" stroke-width="1" />
-<path d="M260.0,67.0 A13.0,13.0 0 0,1 260.0,41.0 H298.0 A13.0,13.0 0 0,1 298.0,67.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="token_font" x="279.0" y="60.0"> AS </text>
-<line x1="219.0" y1="35.0" x2="274.5" y2="35.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="279.5" y1="35.0" x2="340.0" y2="35.0" stroke="#FF0000" stroke-width="1" />
-<path d="M228.0,44.0 A9.0,9.0 0 0,0 219.0,35.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="237.0" y1="53.0" x2="243.0" y2="53.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="311.0" y1="53.0" x2="317.0" y2="53.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M228.0,44.0 A9.0,9.0 0 0,0 237.0,53.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M321.0,53.0 A9.0,9.0 0 0,0 330.0,44.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M339.0,35.0 A9.0,9.0 0 0,0 330.0,44.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="228.0" y1="44.0" x2="228.0" y2="44.0" stroke="#FF0000" stroke-width="1" />
-<line x1="330.0" y1="44.0" x2="330.0" y2="44.0" stroke="#FF0000" stroke-width="1" />
-<path d="M369.0,49.0 A13.0,13.0 0 0,1 369.0,23.0 H473.0 A13.0,13.0 0 0,1 473.0,49.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="name_font" x="421.0" y="42.0">table-name</text>
-<line x1="338.0" y1="35.0" x2="352.0" y2="35.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="191.0" y1="17.0" x2="348.0" y2="17.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="353.0" y1="17.0" x2="515.0" y2="17.0" stroke="#FF0000" stroke-width="1" />
-<path d="M200.0,26.0 A9.0,9.0 0 0,0 191.0,17.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="209.0" y1="35.0" x2="215.0" y2="35.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="486.0" y1="35.0" x2="492.0" y2="35.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M200.0,26.0 A9.0,9.0 0 0,0 209.0,35.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M496.0,35.0 A9.0,9.0 0 0,0 505.0,26.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M514.0,17.0 A9.0,9.0 0 0,0 505.0,26.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="200.0" y1="26.0" x2="200.0" y2="26.0" stroke="#FF0000" stroke-width="1" />
-<line x1="505.0" y1="26.0" x2="505.0" y2="26.0" stroke="#FF0000" stroke-width="1" />
-<line x1="173.0" y1="17.0" x2="187.0" y2="17.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="732.0" y1="17.0" x2="733.0" y2="17.0" stroke="#FF0000" stroke-width="1" />
-<path d="M572.0,49.0 A13.0,13.0 0 0,1 572.0,23.0 H665.0 A13.0,13.0 0 0,1 665.0,49.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="token_font" x="618.5" y="42.0"> INDEXED </text>
-<path d="M708.0,49.0 A13.0,13.0 0 0,1 708.0,23.0 H746.0 A13.0,13.0 0 0,1 746.0,49.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="token_font" x="727.0" y="42.0"> BY </text>
-<line x1="677.0" y1="35.0" x2="691.0" y2="35.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M789.0,49.0 A13.0,13.0 0 0,1 789.0,23.0 H893.0 A13.0,13.0 0 0,1 893.0,49.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="name_font" x="841.0" y="42.0">index-name</text>
-<line x1="758.0" y1="35.0" x2="772.0" y2="35.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M572.0,79.0 A13.0,13.0 0 0,1 572.0,53.0 H621.0 A13.0,13.0 0 0,1 621.0,79.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="token_font" x="596.5" y="72.0"> NOT </text>
-<path d="M664.0,79.0 A13.0,13.0 0 0,1 664.0,53.0 H757.0 A13.0,13.0 0 0,1 757.0,79.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="token_font" x="710.5" y="72.0"> INDEXED </text>
-<line x1="633.0" y1="65.0" x2="647.0" y2="65.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="531.0" y1="17.0" x2="728.0" y2="17.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="733.0" y1="17.0" x2="935.0" y2="17.0" stroke="#FF0000" stroke-width="1" />
-<path d="M540.0,26.0 A9.0,9.0 0 0,0 531.0,17.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="549.0" y1="35.0" x2="555.0" y2="35.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="906.0" y1="35.0" x2="912.0" y2="35.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M540.0,26.0 A9.0,9.0 0 0,0 549.0,35.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M916.0,35.0 A9.0,9.0 0 0,0 925.0,26.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="549.0" y1="65.0" x2="555.0" y2="65.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="770.0" y1="65.0" x2="912.0" y2="65.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M540.0,56.0 A9.0,9.0 0 0,0 549.0,65.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M916.0,65.0 A9.0,9.0 0 0,0 925.0,56.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M934.0,17.0 A9.0,9.0 0 0,0 925.0,26.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="540.0" y1="56.0" x2="540.0" y2="26.0" stroke="#FF0000" stroke-width="1" />
-<line x1="925.0" y1="56.0" x2="925.0" y2="26.0" stroke="#FF0000" stroke-width="1" />
-<line x1="513.0" y1="17.0" x2="527.0" y2="17.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M67.0,109.0 A13.0,13.0 0 0,1 67.0,83.0 H72.0 A13.0,13.0 0 0,1 72.0,109.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="name_font" x="69.5" y="102.0">(</text>
-<rect x="102.0" y="83.0" width="188.0" height="26.0" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="box_font" x="196.0" y="102.0">select-statement</text>
-<line x1="84.0" y1="95.0" x2="98.0" y2="95.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M320.0,109.0 A13.0,13.0 0 0,1 320.0,83.0 H325.0 A13.0,13.0 0 0,1 325.0,109.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="name_font" x="322.5" y="102.0">)</text>
-<line x1="289.0" y1="95.0" x2="303.0" y2="95.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="516.0" y1="95.0" x2="517.0" y2="95.0" stroke="#FF0000" stroke-width="1" />
-<line x1="442.5" y1="113.0" x2="443.5" y2="113.0" stroke="#FF0000" stroke-width="1" />
-<path d="M424.0,145.0 A13.0,13.0 0 0,1 424.0,119.0 H462.0 A13.0,13.0 0 0,1 462.0,145.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="token_font" x="443.0" y="138.0"> AS </text>
-<line x1="383.0" y1="113.0" x2="438.5" y2="113.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="443.5" y1="113.0" x2="504.0" y2="113.0" stroke="#FF0000" stroke-width="1" />
-<path d="M392.0,122.0 A9.0,9.0 0 0,0 383.0,113.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="401.0" y1="131.0" x2="407.0" y2="131.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="475.0" y1="131.0" x2="481.0" y2="131.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M392.0,122.0 A9.0,9.0 0 0,0 401.0,131.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M485.0,131.0 A9.0,9.0 0 0,0 494.0,122.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M503.0,113.0 A9.0,9.0 0 0,0 494.0,122.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="392.0" y1="122.0" x2="392.0" y2="122.0" stroke="#FF0000" stroke-width="1" />
-<line x1="494.0" y1="122.0" x2="494.0" y2="122.0" stroke="#FF0000" stroke-width="1" />
-<path d="M533.0,127.0 A13.0,13.0 0 0,1 533.0,101.0 H637.0 A13.0,13.0 0 0,1 637.0,127.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="name_font" x="585.0" y="120.0">table-name</text>
-<line x1="502.0" y1="113.0" x2="516.0" y2="113.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="355.0" y1="95.0" x2="512.0" y2="95.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="517.0" y1="95.0" x2="679.0" y2="95.0" stroke="#FF0000" stroke-width="1" />
-<path d="M364.0,104.0 A9.0,9.0 0 0,0 355.0,95.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="373.0" y1="113.0" x2="379.0" y2="113.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="650.0" y1="113.0" x2="656.0" y2="113.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M364.0,104.0 A9.0,9.0 0 0,0 373.0,113.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M660.0,113.0 A9.0,9.0 0 0,0 669.0,104.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M678.0,95.0 A9.0,9.0 0 0,0 669.0,104.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="364.0" y1="104.0" x2="364.0" y2="104.0" stroke="#FF0000" stroke-width="1" />
-<line x1="669.0" y1="104.0" x2="669.0" y2="104.0" stroke="#FF0000" stroke-width="1" />
-<line x1="337.0" y1="95.0" x2="351.0" y2="95.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M67.0,175.0 A13.0,13.0 0 0,1 67.0,149.0 H72.0 A13.0,13.0 0 0,1 72.0,175.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="name_font" x="69.5" y="168.0">(</text>
-<rect x="102.0" y="149.0" width="133.0" height="26.0" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="box_font" x="168.5" y="168.0">join-source</text>
-<line x1="84.0" y1="161.0" x2="98.0" y2="161.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M265.0,175.0 A13.0,13.0 0 0,1 265.0,149.0 H270.0 A13.0,13.0 0 0,1 270.0,175.0 z" stroke="#FF0000" stroke-width="1" fill="#D3D3D3"/>
-<text class="name_font" x="267.5" y="168.0">)</text>
-<line x1="234.0" y1="161.0" x2="248.0" y2="161.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="26" y1="17.0" x2="40.0" y2="17.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="934.0" y1="17.0" x2="954.0" y2="17.0" stroke="#FF0000" stroke-width="1" />
-<path d="M35.0,26.0 A9,9 0 0,0 26.0,17.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="44" y1="95.0" x2="50.0" y2="95.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="678.0" y1="95.0" x2="931.0" y2="95.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M35.0,86.0 A9,9 0 0,0 44.0,95.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M935.0,95.0 A9.0,9.0 0 0,0 944.0,86.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="44" y1="161.0" x2="50.0" y2="161.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<line x1="283.0" y1="161.0" x2="931.0" y2="161.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<path d="M35.0,152.0 A9,9 0 0,0 44.0,161.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M935.0,161.0 A9.0,9.0 0 0,0 944.0,152.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<path d="M953.0,17.0 A9.0,9.0 0 0,0 944.0,26.0" stroke="#FF0000" stroke-width="1" fill="none"/>
-<line x1="35" y1="152.0" x2="35" y2="26.0" stroke="#FF0000" stroke-width="1" />
-<line x1="944.0" y1="152.0" x2="944.0" y2="26.0" stroke="#FF0000" stroke-width="1" />
-<line x1="8" y1="17.0" x2="22.0" y2="17.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
-<circle cx="972.0" cy="17.0" r="2.0" stroke="#FF0000" stroke-width="1" fill="#FFFFFF"/>
-<line x1="952.0" y1="17.0" x2="966.0" y2="17.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<rect width="100%" height="100%" fill="white"/><path d="M87.0,49.5 A12.0,12.0 0 0,1 87.0,25.5 H181.0 A12.0,12.0 0 0,1 181.0,49.5 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M251.0,31.5 A12.0,12.0 0 0,1 251.0,7.5 H336.0 A12.0,12.0 0 0,1 336.0,31.5 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M434.0,67.5 A12.0,12.0 0 0,1 434.0,43.5 H463.0 A12.0,12.0 0 0,1 463.0,67.5 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M533.0,49.5 A12.0,12.0 0 0,1 533.0,25.5 H618.0 A12.0,12.0 0 0,1 618.0,49.5 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M716.5,49.5 A12.0,12.0 0 0,1 716.5,25.5 H800.5 A12.0,12.0 0 0,1 800.5,49.5 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M842.5,49.5 A12.0,12.0 0 0,1 842.5,25.5 H871.5 A12.0,12.0 0 0,1 871.5,49.5 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M913.5,49.5 A12.0,12.0 0 0,1 913.5,25.5 H1002.5 A12.0,12.0 0 0,1 1002.5,49.5 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M716.5,79.0 A12.0,12.0 0 0,1 716.5,55.0 H759.5 A12.0,12.0 0 0,1 759.5,79.0 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M801.5,79.0 A12.0,12.0 0 0,1 801.5,55.0 H885.5 A12.0,12.0 0 0,1 885.5,79.0 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<circle cx="69.0" cy="96.5" r="12.0" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<rect x="99.0" y="84.5" width="145.0" height="24.0" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<circle cx="274.0" cy="96.5" r="12.0" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M372.0,144.5 A12.0,12.0 0 0,1 372.0,120.5 H401.0 A12.0,12.0 0 0,1 401.0,144.5 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<path d="M471.0,126.5 A12.0,12.0 0 0,1 471.0,102.5 H556.0 A12.0,12.0 0 0,1 556.0,126.5 z" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<circle cx="69.0" cy="162.0" r="12.0" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<rect x="99.0" y="150.0" width="100.0" height="24.0" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<circle cx="229.0" cy="162.0" r="12.0" stroke="none" fill="#000000" fill-opacity="0.4980392156862745"/>
+<circle cx="7.5" cy="16.5" r="2.0" stroke="#FF0000" fill="#FFFFFF" stroke-width="1"/>
+<line x1="131.0" y1="16.5" x2="132.0" y2="16.5" stroke="#FF0000" stroke-width="1" />
+<path d="M85.0,47.5 A12.0,12.0 0 0,1 85.0,23.5 H179.0 A12.0,12.0 0 0,1 179.0,47.5 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="token_font" x="132.0" y="41.0"> SEQSCAN </text>
+<line x1="44.5" y1="16.5" x2="127.0" y2="16.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="132.0" y1="16.5" x2="220.5" y2="16.5" stroke="#FF0000" stroke-width="1" />
+<path d="M53.5,25.5 A9.0,9.0 0 0,0 44.5,16.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="62.5" y1="34.5" x2="68.5" y2="34.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="191.5" y1="34.5" x2="201.5" y2="34.5" stroke="#FF0000" stroke-width="1" />
+<path d="M53.5,25.5 A9.0,9.0 0 0,0 62.5,34.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M201.5,34.5 A9.0,9.0 0 0,0 210.5,25.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M219.5,16.5 A9.0,9.0 0 0,0 210.5,25.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="53.5" y1="25.5" x2="53.5" y2="25.5" stroke="#FF0000" stroke-width="1" />
+<line x1="210.5" y1="25.5" x2="210.5" y2="25.5" stroke="#FF0000" stroke-width="1" />
+<path d="M249.0,29.5 A12.0,12.0 0 0,1 249.0,5.5 H334.0 A12.0,12.0 0 0,1 334.0,29.5 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="name_font" x="291.5" y="23.0">table-name</text>
+<line x1="218.5" y1="16.5" x2="232.5" y2="16.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="509.25" y1="16.5" x2="510.25" y2="16.5" stroke="#FF0000" stroke-width="1" />
+<line x1="445.5" y1="34.5" x2="446.5" y2="34.5" stroke="#FF0000" stroke-width="1" />
+<path d="M432.0,65.5 A12.0,12.0 0 0,1 432.0,41.5 H461.0 A12.0,12.0 0 0,1 461.0,65.5 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="token_font" x="446.5" y="59.0"> AS </text>
+<line x1="391.5" y1="34.5" x2="441.5" y2="34.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="446.5" y1="34.5" x2="502.5" y2="34.5" stroke="#FF0000" stroke-width="1" />
+<path d="M400.5,43.5 A9.0,9.0 0 0,0 391.5,34.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="409.5" y1="52.5" x2="415.5" y2="52.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="473.5" y1="52.5" x2="483.5" y2="52.5" stroke="#FF0000" stroke-width="1" />
+<path d="M400.5,43.5 A9.0,9.0 0 0,0 409.5,52.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M483.5,52.5 A9.0,9.0 0 0,0 492.5,43.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M501.5,34.5 A9.0,9.0 0 0,0 492.5,43.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="400.5" y1="43.5" x2="400.5" y2="43.5" stroke="#FF0000" stroke-width="1" />
+<line x1="492.5" y1="43.5" x2="492.5" y2="43.5" stroke="#FF0000" stroke-width="1" />
+<path d="M531.0,47.5 A12.0,12.0 0 0,1 531.0,23.5 H616.0 A12.0,12.0 0 0,1 616.0,47.5 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="name_font" x="573.5" y="41.0">table-name</text>
+<line x1="500.5" y1="34.5" x2="514.5" y2="34.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="363.5" y1="16.5" x2="505.25" y2="16.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="510.25" y1="16.5" x2="658.0" y2="16.5" stroke="#FF0000" stroke-width="1" />
+<path d="M372.5,25.5 A9.0,9.0 0 0,0 363.5,16.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="381.5" y1="34.5" x2="387.5" y2="34.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="628.5" y1="34.5" x2="639.0" y2="34.5" stroke="#FF0000" stroke-width="1" />
+<path d="M372.5,25.5 A9.0,9.0 0 0,0 381.5,34.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M639.0,34.5 A9.0,9.0 0 0,0 648.0,25.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M657.0,16.5 A9.0,9.0 0 0,0 648.0,25.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="372.5" y1="25.5" x2="372.5" y2="25.5" stroke="#FF0000" stroke-width="1" />
+<line x1="648.0" y1="25.5" x2="648.0" y2="25.5" stroke="#FF0000" stroke-width="1" />
+<line x1="345.5" y1="16.5" x2="359.5" y2="16.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="856.5" y1="16.5" x2="857.5" y2="16.5" stroke="#FF0000" stroke-width="1" />
+<path d="M714.5,47.5 A12.0,12.0 0 0,1 714.5,23.5 H798.5 A12.0,12.0 0 0,1 798.5,47.5 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="token_font" x="756.5" y="41.0"> INDEXED </text>
+<path d="M840.5,47.5 A12.0,12.0 0 0,1 840.5,23.5 H869.5 A12.0,12.0 0 0,1 869.5,47.5 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="token_font" x="855.0" y="41.0"> BY </text>
+<line x1="810.0" y1="34.5" x2="824.0" y2="34.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<path d="M911.5,47.5 A12.0,12.0 0 0,1 911.5,23.5 H1000.5 A12.0,12.0 0 0,1 1000.5,47.5 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="name_font" x="956.0" y="41.0">index-name</text>
+<line x1="881.0" y1="34.5" x2="895.0" y2="34.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<path d="M714.5,77.0 A12.0,12.0 0 0,1 714.5,53.0 H757.5 A12.0,12.0 0 0,1 757.5,77.0 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="token_font" x="736.0" y="70.5"> NOT </text>
+<path d="M799.5,77.0 A12.0,12.0 0 0,1 799.5,53.0 H883.5 A12.0,12.0 0 0,1 883.5,77.0 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="token_font" x="841.5" y="70.5"> INDEXED </text>
+<line x1="769.0" y1="64.0" x2="783.0" y2="64.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="674.0" y1="16.5" x2="852.5" y2="16.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="857.5" y1="16.5" x2="1042.0" y2="16.5" stroke="#FF0000" stroke-width="1" />
+<path d="M683.0,25.5 A9.0,9.0 0 0,0 674.0,16.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="692.0" y1="34.5" x2="698.0" y2="34.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="1013.0" y1="34.5" x2="1023.0" y2="34.5" stroke="#FF0000" stroke-width="1" />
+<path d="M683.0,25.5 A9.0,9.0 0 0,0 692.0,34.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M1023.0,34.5 A9.0,9.0 0 0,0 1032.0,25.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="692.0" y1="64.0" x2="698.0" y2="64.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="896.0" y1="64.0" x2="1023.0" y2="64.0" stroke="#FF0000" stroke-width="1" />
+<path d="M683.0,55.0 A9.0,9.0 0 0,0 692.0,64.0" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M1023.0,64.0 A9.0,9.0 0 0,0 1032.0,55.0" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M1041.0,16.5 A9.0,9.0 0 0,0 1032.0,25.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="683.0" y1="55.0" x2="683.0" y2="25.5" stroke="#FF0000" stroke-width="1" />
+<line x1="1032.0" y1="55.0" x2="1032.0" y2="25.5" stroke="#FF0000" stroke-width="1" />
+<line x1="656.0" y1="16.5" x2="670.0" y2="16.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<circle cx="67.0" cy="94.5" r="12.0" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="name_font" x="67.0" y="100.0">(</text>
+<rect x="97.0" y="82.5" width="145.0" height="24.0" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="box_font" x="169.5" y="100.0">select-statement</text>
+<line x1="78.5" y1="93.5" x2="92.5" y2="93.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<circle cx="272.0" cy="94.5" r="12.0" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="name_font" x="272.0" y="100.0">)</text>
+<line x1="241.5" y1="93.5" x2="255.5" y2="93.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="447.25" y1="93.5" x2="448.25" y2="93.5" stroke="#FF0000" stroke-width="1" />
+<line x1="383.5" y1="111.5" x2="384.5" y2="111.5" stroke="#FF0000" stroke-width="1" />
+<path d="M370.0,142.5 A12.0,12.0 0 0,1 370.0,118.5 H399.0 A12.0,12.0 0 0,1 399.0,142.5 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="token_font" x="384.5" y="136.0"> AS </text>
+<line x1="329.5" y1="111.5" x2="379.5" y2="111.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="384.5" y1="111.5" x2="440.5" y2="111.5" stroke="#FF0000" stroke-width="1" />
+<path d="M338.5,120.5 A9.0,9.0 0 0,0 329.5,111.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="347.5" y1="129.5" x2="353.5" y2="129.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="411.5" y1="129.5" x2="421.5" y2="129.5" stroke="#FF0000" stroke-width="1" />
+<path d="M338.5,120.5 A9.0,9.0 0 0,0 347.5,129.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M421.5,129.5 A9.0,9.0 0 0,0 430.5,120.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M439.5,111.5 A9.0,9.0 0 0,0 430.5,120.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="338.5" y1="120.5" x2="338.5" y2="120.5" stroke="#FF0000" stroke-width="1" />
+<line x1="430.5" y1="120.5" x2="430.5" y2="120.5" stroke="#FF0000" stroke-width="1" />
+<path d="M469.0,124.5 A12.0,12.0 0 0,1 469.0,100.5 H554.0 A12.0,12.0 0 0,1 554.0,124.5 z" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="name_font" x="511.5" y="118.0">table-name</text>
+<line x1="438.5" y1="111.5" x2="452.5" y2="111.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="301.5" y1="93.5" x2="443.25" y2="93.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="448.25" y1="93.5" x2="596.0" y2="93.5" stroke="#FF0000" stroke-width="1" />
+<path d="M310.5,102.5 A9.0,9.0 0 0,0 301.5,93.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="319.5" y1="111.5" x2="325.5" y2="111.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="566.5" y1="111.5" x2="577.0" y2="111.5" stroke="#FF0000" stroke-width="1" />
+<path d="M310.5,102.5 A9.0,9.0 0 0,0 319.5,111.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M577.0,111.5 A9.0,9.0 0 0,0 586.0,102.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M595.0,93.5 A9.0,9.0 0 0,0 586.0,102.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="310.5" y1="102.5" x2="310.5" y2="102.5" stroke="#FF0000" stroke-width="1" />
+<line x1="586.0" y1="102.5" x2="586.0" y2="102.5" stroke="#FF0000" stroke-width="1" />
+<line x1="283.5" y1="93.5" x2="297.5" y2="93.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<circle cx="67.0" cy="160.0" r="12.0" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="name_font" x="67.0" y="165.5">(</text>
+<rect x="97.0" y="148.0" width="100.0" height="24.0" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="box_font" x="147.0" y="165.5">join-source</text>
+<line x1="78.5" y1="159.0" x2="92.5" y2="159.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<circle cx="227.0" cy="160.0" r="12.0" stroke="#FF0000" fill="#D3D3D3" stroke-width="1"/>
+<text class="name_font" x="227.0" y="165.5">)</text>
+<line x1="196.5" y1="159.0" x2="210.5" y2="159.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="26.5" y1="16.5" x2="44.5" y2="16.5" stroke="#FF0000" stroke-width="1" />
+<line x1="1041.0" y1="16.5" x2="1062.0" y2="16.5" stroke="#FF0000" stroke-width="1" />
+<path d="M35.5,25.5 A9.0,9.0 0 0,0 26.5,16.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="44.5" y1="93.5" x2="50.5" y2="93.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="595.0" y1="93.5" x2="1043.0" y2="93.5" stroke="#FF0000" stroke-width="1" />
+<path d="M35.5,84.5 A9.0,9.0 0 0,0 44.5,93.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M1043.0,93.5 A9.0,9.0 0 0,0 1052.0,84.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="44.5" y1="159.0" x2="50.5" y2="159.0" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<line x1="239.5" y1="159.0" x2="1043.0" y2="159.0" stroke="#FF0000" stroke-width="1" />
+<path d="M35.5,150.0 A9.0,9.0 0 0,0 44.5,159.0" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M1043.0,159.0 A9.0,9.0 0 0,0 1052.0,150.0" stroke="#FF0000" fill="none" stroke-width="1"/>
+<path d="M1061.0,16.5 A9.0,9.0 0 0,0 1052.0,25.5" stroke="#FF0000" fill="none" stroke-width="1"/>
+<line x1="35.5" y1="150.0" x2="35.5" y2="25.5" stroke="#FF0000" stroke-width="1" />
+<line x1="1052.0" y1="150.0" x2="1052.0" y2="25.5" stroke="#FF0000" stroke-width="1" />
+<line x1="8.5" y1="16.5" x2="22.5" y2="16.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
+<circle cx="1080.0" cy="16.5" r="2.0" stroke="#FF0000" fill="#FFFFFF" stroke-width="1"/>
+<line x1="1060.0" y1="16.5" x2="1074.0" y2="16.5" stroke="#FF0000" stroke-width="1" marker-end="url(#arrow)" />
 </svg>

--- a/doc/reference/reference_sql/sql_statements_and_clauses.rst
+++ b/doc/reference/reference_sql/sql_statements_and_clauses.rst
@@ -1902,7 +1902,7 @@ For scan queries, the result contains ``SCAN TABLE table_name``.
 ..  note::
 
     For backward compatibility, the scan queries without the ``SEQSCAN`` keyword
-    are allowed in Tarantool 2.11. The errors on scan queries will be the default
+    are allowed in Tarantool 2.11. The errors on scan queries are the default
     behavior starting from 3.0. You can change the default behavior of scan queries
     using the :ref:`compat option sql_seq_scan <compat-option-sql-scan>`.
 

--- a/doc/reference/reference_sql/sql_statements_and_clauses.rst
+++ b/doc/reference/reference_sql/sql_statements_and_clauses.rst
@@ -1897,7 +1897,7 @@ Such queries are called *scan queries*. If a scan query doesn't have the
 names of the tables that the query scans.
 
 To find out if a query performs a sequential scan, use ``EXPLAIN QUERY PLAN``.
-For scan queries, the result contains ``SCAN_TABLE table_name``.
+For scan queries, the result contains ``SCAN TABLE table_name``.
 
 ..  note::
 

--- a/doc/reference/reference_sql/sql_statements_and_clauses.rst
+++ b/doc/reference/reference_sql/sql_statements_and_clauses.rst
@@ -1897,7 +1897,7 @@ Such queries are called *scan queries*. If a scan query doesn't have the
 names of the tables that the query scans.
 
 To find out if a query performs a sequential scan, use ``EXPLAIN QUERY PLAN``.
-For scan queries, the result contains ``SCAN_TABLE``.
+For scan queries, the result contains ``SCAN_TABLE tabe_name``.
 
 ..  note::
 

--- a/doc/reference/reference_sql/sql_statements_and_clauses.rst
+++ b/doc/reference/reference_sql/sql_statements_and_clauses.rst
@@ -1855,7 +1855,7 @@ FROM clause
 
 Syntax:
 
-:samp:`FROM table-reference [, table-reference ...]`
+:samp:`FROM [SEQSCAN] table-reference [, table-reference ...]`
 
 |br|
 
@@ -1889,18 +1889,35 @@ Parentheses are allowed, and ``[[AS] correlation-name]`` is allowed.
 
 The maximum number of joins in a FROM clause is 64.
 
+The ``SEQSCAN`` keyword (since :doc:`2.11 </release/2.11.0>`) marks the queries that
+perform sequential scans during the execution. It happens if the query can't use indexes,
+and goes through all the table rows one by one, sometimes causing a heavy load.
+Such queries are called *scan queries*. If a scan query doesn't have the
+``SEQSCAN`` keyword, Tarantool raises an error. ``SEQSCAN`` must precede all
+names of the tables that the query scans.
+
+To find out if a query performs a sequential scan, use ``EXPLAIN QUERY PLAN``.
+For scan queries, the result contains ``SCAN_TABLE``.
+
+..  note::
+
+    For backward compatibility, the scan queries without the ``SEQSCAN`` keyword
+    are allowed in Tarantool 2.11. The errors on scan queries will be the default
+    behavior starting from 3.0. You can change the default behavior of scan queries
+    using the :ref:`compat option sql_seq_scan <compat-option-sql-scan>`.
+
 Examples:
 
 .. code-block:: sql
 
    -- the simplest form:
-   SELECT * FROM t;
+   SELECT * FROM SEQSCAN t;
    -- with two tables, making a Cartesian join:
-   SELECT * FROM t1, t2;
+   SELECT * FROM SEQSCAN t1, SEQSCAN t2;
    -- with one table joined to itself, requiring correlation names:
-   SELECT a.*, b.* FROM t1 AS a, t1 AS b;
+   SELECT a.*, b.* FROM SEQSCAN t1 AS a, SEQSCAN t1 AS b;
    -- with a left outer join:
-   SELECT * FROM t1 LEFT JOIN t2;
+   SELECT * FROM SEQSCAN t1 LEFT JOIN SEQSCAN t2;
 
 .. _sql_where:
 

--- a/doc/reference/reference_sql/sql_statements_and_clauses.rst
+++ b/doc/reference/reference_sql/sql_statements_and_clauses.rst
@@ -1897,7 +1897,7 @@ Such queries are called *scan queries*. If a scan query doesn't have the
 names of the tables that the query scans.
 
 To find out if a query performs a sequential scan, use ``EXPLAIN QUERY PLAN``.
-For scan queries, the result contains ``SCAN_TABLE tabe_name``.
+For scan queries, the result contains ``SCAN_TABLE table_name``.
 
 ..  note::
 

--- a/doc/reference/reference_sql/sql_user_guide.rst
+++ b/doc/reference/reference_sql/sql_user_guide.rst
@@ -291,7 +291,7 @@ NULL NUM NUMBER NUMERIC OF ON OR ORDER OUT OUTER OVER PARTIAL
 PARTITION PRAGMA PRECISION PRIMARY PROCEDURE RANGE RANK
 READS REAL RECURSIVE REFERENCES REGEXP RELEASE RENAME
 REPEAT REPLACE RESIGNAL RETURN REVOKE RIGHT ROLLBACK ROW
-ROWS ROW_NUMBER SAVEPOINT SCALAR SELECT SENSITIVE SESSION SET
+ROWS ROW_NUMBER SAVEPOINT SCALAR SELECT SENSITIVE SEQSCAN SESSION SET
 SIGNAL SIMPLE SMALLINT SPECIFIC SQL START STRING SYSTEM TABLE
 TEXT THEN TO TRAILING TRANSACTION TRIGGER TRIM TRUE
 TRUNCATE UNION UNIQUE UNKNOWN UNSIGNED UPDATE USER USING UUID VALUES
@@ -1316,7 +1316,7 @@ In alphabetical order, the following statements are legal.
 |nbsp| :ref:`ROLLBACK [TO [SAVEPOINT] savepoint-name]; <sql_rollback>` |br|
 |nbsp| :ref:`SAVEPOINT savepoint-name; <sql_savepoint>` |br|
 |nbsp| :ref:`SELECT [DISTINCT|ALL] expression [, expression ...] <sql_select>` |br|
-|nbsp| |nbsp| |nbsp| |nbsp| :ref:`FROM table-name | joined-table-names [AS alias]  <sql_select>` |br|
+|nbsp| |nbsp| |nbsp| |nbsp| :ref:`FROM [SEQSCAN] table-name | joined-table-names [AS alias]  <sql_select>` |br|
 |nbsp| |nbsp| |nbsp| |nbsp| :ref:`[WHERE expression] <sql_select>` |br|
 |nbsp| |nbsp| |nbsp| |nbsp| :ref:`[GROUP BY expression [, expression ...]] <sql_group_by>` |br|
 |nbsp| |nbsp| |nbsp| |nbsp| :ref:`[HAVING expression] <sql_having>` |br|

--- a/styles/Vocab/Tarantool/accept.txt
+++ b/styles/Vocab/Tarantool/accept.txt
@@ -33,3 +33,4 @@ storages
 dereference
 upsert
 tt
+SEQSCAN


### PR DESCRIPTION
Resolves #3281 

- Added the SEQSCAN description to the FROM clause reference: https://docs.d.tarantool.io/en/doc/gh-3281-sql-seqscan/reference/reference_sql/sql_statements_and_clauses/#from-clause
- Added SEQSCAN to the list of reserved words in the SQL user guide: https://docs.d.tarantool.io/en/doc/gh-3281-sql-seqscan/reference/reference_sql/sql_user_guide/#reserved-words
- Added the SEQSCAN section to the SQL tutorial and updated all SELECT examples across this tutorial with SEQSCAN (where it is required): https://docs.d.tarantool.io/en/doc/gh-3281-sql-seqscan/how-to/sql/sql_tutorial/#the-seqscan-keyword
- Added a note about allowing scan queries to the SQL beginners' guide: https://docs.d.tarantool.io/en/doc/gh-3281-sql-seqscan/how-to/sql/sql_beginners_guide/#selecting-with-where
- Added `sql_seq_scan` session setting to the session settings reference: https://docs.d.tarantool.io/en/doc/gh-3281-sql-seqscan/reference/reference_lua/box_space/_session_settings/