### PR TITLE
Replace tarantoolctl with tt (CE part)

### DIFF
--- a/doc/archive/shard.rst
+++ b/doc/archive/shard.rst
@@ -81,7 +81,7 @@ To acquire it, do a separate installation:
 
   .. code-block:: console
 
-      $ tarantoolctl rocks install shard
+      $ tt rocks install shard
 
 * install with `yum` or `apt`, for example on Ubuntu say:
 

--- a/doc/book/admin/daemon_supervision.rst
+++ b/doc/book/admin/daemon_supervision.rst
@@ -57,12 +57,11 @@ an instance:
 
     $ systemctl status tarantool@my_app|grep PID
     Main PID: 5885 (tarantool)
-    $ tarantoolctl enter my_app
-    /bin/tarantoolctl: Found my_app.lua in /etc/tarantool/instances.available
-    /bin/tarantoolctl: Connecting to /var/run/tarantool/my_app.control
-    /bin/tarantoolctl: connected to unix/:/var/run/tarantool/my_app.control
+    $ tt connect my_app
+       • Connecting to the instance...
+       • Connected to unix/:/var/run/tarantool/my_app.control
     unix/:/var/run/tarantool/my_app.control> os.exit(-1)
-    /bin/tarantoolctl: unix/:/var/run/tarantool/my_app.control: Remote host closed connection
+       ⨯ Connection was closed. Probably instance process isn't running anymore
 
 Now let’s make sure that ``systemd`` has restarted the instance:
 
@@ -118,9 +117,11 @@ instance:
 .. code-block:: console
 
     $ # !!! please never do this on a production system !!!
-    $ tarantoolctl enter my_app
+    $ tt connect my_app
+       • Connecting to the instance...
+       • Connected to unix/:/var/run/tarantool/my_app.control
     unix/:/var/run/tarantool/my_app.control> require('ffi').cast('char *', 0)[0] = 48
-    /bin/tarantoolctl: unix/:/var/run/tarantool/my_app.control: Remote host closed connection
+       ⨯ Connection was closed. Probably instance process isn't running anymore
 
 Alternatively, if you know the process ID of the instance (here we refer to it
 as $PID), you can abort a Tarantool instance by running ``gdb`` debugger:

--- a/doc/book/admin/daemon_supervision.rst
+++ b/doc/book/admin/daemon_supervision.rst
@@ -70,7 +70,7 @@ Now let’s make sure that ``systemd`` has restarted the instance:
     $ systemctl status tarantool@my_app|grep PID
     Main PID: 5914 (tarantool)
 
-Finally, check the boot logs:
+Additionally, you can find the information about the instance restart in the boot logs:
 
 .. code-block:: console
 

--- a/doc/book/admin/daemon_supervision.rst
+++ b/doc/book/admin/daemon_supervision.rst
@@ -59,8 +59,8 @@ an instance:
     Main PID: 5885 (tarantool)
     $ tt connect my_app
        • Connecting to the instance...
-       • Connected to unix/:/var/run/tarantool/my_app.control
-    unix/:/var/run/tarantool/my_app.control> os.exit(-1)
+       • Connected to /var/run/tarantool/my_app.control
+    /var/run/tarantool/my_app.control> os.exit(-1)
        ⨯ Connection was closed. Probably instance process isn't running anymore
 
 Now let’s make sure that ``systemd`` has restarted the instance:
@@ -70,20 +70,11 @@ Now let’s make sure that ``systemd`` has restarted the instance:
     $ systemctl status tarantool@my_app|grep PID
     Main PID: 5914 (tarantool)
 
-Finally, let’s check the boot logs:
+Finally, check the boot logs:
 
 .. code-block:: console
 
     $ journalctl -u tarantool@my_app -n 8
-    -- Logs begin at Fri 2016-01-08 12:21:53 MSK, end at Thu 2016-01-21 21:09:45 MSK. --
-    Jan 21 21:09:45 localhost.localdomain systemd[1]: tarantool@my_app.service: Unit entered failed state.
-    Jan 21 21:09:45 localhost.localdomain systemd[1]: tarantool@my_app.service: Failed with result 'exit-code'.
-    Jan 21 21:09:45 localhost.localdomain systemd[1]: tarantool@my_app.service: Service hold-off time over, scheduling restart.
-    Jan 21 21:09:45 localhost.localdomain systemd[1]: Stopped Tarantool Database Server.
-    Jan 21 21:09:45 localhost.localdomain systemd[1]: Starting Tarantool Database Server...
-    Jan 21 21:09:45 localhost.localdomain tarantoolctl[5910]: /usr/bin/tarantoolctl: Found my_app.lua in /etc/tarantool/instances.available
-    Jan 21 21:09:45 localhost.localdomain tarantoolctl[5910]: /usr/bin/tarantoolctl: Starting instance...
-    Jan 21 21:09:45 localhost.localdomain systemd[1]: Started Tarantool Database Server.
 
 .. _admin-core_dumps:
 
@@ -119,8 +110,8 @@ instance:
     $ # !!! please never do this on a production system !!!
     $ tt connect my_app
        • Connecting to the instance...
-       • Connected to unix/:/var/run/tarantool/my_app.control
-    unix/:/var/run/tarantool/my_app.control> require('ffi').cast('char *', 0)[0] = 48
+       • Connected to /var/run/tarantool/my_app.control
+    /var/run/tarantool/my_app.control> require('ffi').cast('char *', 0)[0] = 48
        ⨯ Connection was closed. Probably instance process isn't running anymore
 
 Alternatively, if you know the process ID of the instance (here we refer to it

--- a/doc/book/admin/disaster_recovery.rst
+++ b/doc/book/admin/disaster_recovery.rst
@@ -78,7 +78,7 @@ transferred to the replica before crash. If you were able to salvage the master
 
       .. code-block:: console
 
-          $ tarantoolctl <new_master_uri> <xlog_file> play --from 23425 --replica 1
+          $ tt play <new_master_uri> <xlog_file> --from 23425 --replica 1
 
 .. _admin-disaster_recovery-master_master:
 
@@ -118,9 +118,9 @@ Your actions:
    made with older checkpoints until :doc:`/reference/reference_lua/box_backup/stop` is called.
 
 2. Get the latest valid :ref:`.snap file <internals-snapshot>` and
-   use ``tarantoolctl cat`` command to calculate at which lsn the data loss occurred.
+   use ``tt cat`` command to calculate at which lsn the data loss occurred.
 
-3. Start a new instance (instance#1) and use ``tarantoolctl play`` command to
+3. Start a new instance (instance#1) and use ``tt play`` command to
    play to it the contents of .snap/.xlog files up to the calculated lsn.
 
 4. Bootstrap a new replica from the recovered master (instance#1).

--- a/doc/book/admin/index.rst
+++ b/doc/book/admin/index.rst
@@ -13,7 +13,7 @@ Here we show how to administer Tarantool instances using any of the following
 utilities:
 
 * ``systemd`` native utilities, or
-* :ref:`tt CLI <tt-cli>`, an administrative command-line utility.
+* :ref:`tt <tt-cli>`, an administrative command-line utility.
 
 .. NOTE::
 

--- a/doc/book/admin/index.rst
+++ b/doc/book/admin/index.rst
@@ -13,8 +13,7 @@ Here we show how to administer Tarantool instances using any of the following
 utilities:
 
 * ``systemd`` native utilities, or
-* :ref:`tarantoolctl <tarantoolctl>`, an administrative utility shipped and installed as
-  part of Tarantool distribution.
+* :ref:`tt CLI <tt-cli>`, an administrative command-line utility.
 
 .. NOTE::
 

--- a/doc/book/admin/index.rst
+++ b/doc/book/admin/index.rst
@@ -12,7 +12,7 @@ Here we show how to administer Tarantool instances using any of the following
 utilities:
 
 * ``systemd`` native utilities, or
-* :ref:`tt <tt-cli>`, an command-line utility for managing Tarantool-based applications.
+* :ref:`tt <tt-cli>`, a command-line utility for managing Tarantool-based applications.
 
 .. NOTE::
 

--- a/doc/book/admin/index.rst
+++ b/doc/book/admin/index.rst
@@ -3,9 +3,8 @@
 
 .. _admin:
 
-********************************************************************************
 Administration
-********************************************************************************
+==============
 
 Tarantool is designed to have multiple running instances on the same host.
 
@@ -13,7 +12,7 @@ Here we show how to administer Tarantool instances using any of the following
 utilities:
 
 * ``systemd`` native utilities, or
-* :ref:`tt <tt-cli>`, an administrative command-line utility.
+* :ref:`tt <tt-cli>`, an command-line utility for managing Tarantool-based applications.
 
 .. NOTE::
 

--- a/doc/book/admin/instance_config.rst
+++ b/doc/book/admin/instance_config.rst
@@ -28,8 +28,7 @@ For each Tarantool instance, you need two files:
 * An :ref:`instance file <admin-instance_file>` with
   instance-specific initialization logic and parameters. Put this file, or a
   symlink to it, into the **instance directory**
-  (see :ref:`instance_dir <admin-instance_dir>` parameter in ``tarantoolctl``
-  configuration file).
+  (see ``instances_enabled`` parameter in :ref:`tt configuration file <tt-config_file>`).
 
   For example, ``/etc/tarantool/instances.enabled/my_app.lua`` (here we load
   ``my_app.lua`` module and make a call to ``start()`` function from that
@@ -53,7 +52,7 @@ Instance file
 -------------
 
 After this short introduction, you may wonder what an instance file is, what it
-is for, and how ``tarantoolctl`` uses it. After all, Tarantool is an application
+is for, and how ``tt`` uses it. After all, Tarantool is an application
 server, so why not start the application stored in ``/usr/share/tarantool``
 directly?
 
@@ -76,7 +75,7 @@ An instance file is designed to not differ in any way from a Lua application.
 It must, however, configure the database, i.e. contain a call to
 :doc:`box.cfg{} </reference/reference_lua/box_cfg>` somewhere in it, because it’s the
 only way to turn a Tarantool script into a background process, and
-``tarantoolctl`` is a tool to manage background processes. Other than that, an
+``tt`` is a tool to manage background processes. Other than that, an
 instance file may contain arbitrary Lua code, and, in theory, even include the
 entire application business logic in it. We, however, do not recommend this,
 since it clutters the instance file and leads to unnecessary copy-paste when
@@ -155,82 +154,24 @@ You get the following output:
 If an error happens during the execution of the preload script or module, Tarantool
 reports the problem and exits.
 
-.. _admin-tarantoolctl_config_file:
+.. _admin-tt_config_file:
 
-tarantoolctl configuration file
--------------------------------
+tt configuration file
+---------------------
 
-While instance files contain instance configuration, the ``tarantoolctl``
-configuration file contains the configuration that ``tarantoolctl`` uses to
-override instance configuration. In other words, it contains system-wide
-configuration defaults. If ``tarantoolctl`` fails to find this file with
-the method described in section
-:ref:`Starting/stopping an instance <admin-start_stop_instance>`, it uses
-default settings.
+While instance files contain instance configuration, the ``tt`` configuration file
+contains the configuration that ``tt`` uses to set up the application environment.
+This includes the path to instance files, various working directories, and other
+parameters that connect the application to the system.
 
-Most of the parameters are similar to those used by
-:doc:`box.cfg{} </reference/reference_lua/box_cfg>`. Here are the default settings
-(possibly installed in ``/etc/default/tarantool`` or ``/etc/sysconfig/tarantool``
-as part of Tarantool distribution -- see OS-specific default paths in
-:ref:`Notes for operating systems <admin-os_notes>`):
+To create a default ``tt`` configuration, run ``tt init``. This creates a ``tt.yaml``
+configuration file. Its location depends on the :ref:`tt launch mode <tt-config_modes>`
+(system or local).
 
-.. code-block:: lua
+Some ``tt`` configuration parameters are similar to those used by
+:doc:`box.cfg{} </reference/reference_lua/box_cfg>`, for example, ``memxt_dir``
+or ``wal_dir``. Other parameters define the ``tt`` environment, for example,
+paths to installation files used by ``tt`` or to connected :ref:`external modules <tt-external_modules>`.
 
-   default_cfg = {
-       pid_file  = "/var/run/tarantool",
-       wal_dir   = "/var/lib/tarantool",
-       memtx_dir = "/var/lib/tarantool",
-       vinyl_dir = "/var/lib/tarantool",
-       log       = "/var/log/tarantool",
-       username  = "tarantool",
-       language  = "Lua",
-   }
-   instance_dir = "/etc/tarantool/instances.enabled"
-
-where:
-
-* | ``pid_file``
-  | Directory for the pid file and control-socket file; ``tarantoolctl`` will
-    add “/instance_name” to the directory name.
-
-* | ``wal_dir``
-  | Directory for write-ahead .xlog files; ``tarantoolctl`` will add
-    "/instance_name" to the directory name.
-
-* | ``memtx_dir``
-  | Directory for snapshot .snap files; ``tarantoolctl`` will add
-    "/instance_name" to the directory name.
-
-* | ``vinyl_dir``
-  | Directory for vinyl files; ``tarantoolctl`` will add "/instance_name" to the
-    directory name.
-
-* | ``log``
-  | The place where the application log will go; ``tarantoolctl`` will add
-    "/instance_name.log" to the name.
-
-* | ``username``
-  | The user that runs the Tarantool instance. This is the operating-system user
-    name rather than the Tarantool-client user name. Tarantool will change its
-    effective user to this user after becoming a daemon.
-
-* | ``language``
-  | The :ref:`interactive console <interactive_console>` language. Can be either ``Lua`` or ``SQL``.
-
-.. _admin-instance_dir:
-
-* | ``instance_dir``
-  | The directory where all instance files for this host are stored. Put
-    instance files in this directory, or create symbolic links.
-
-  The default instance directory depends on Tarantool's ``WITH_SYSVINIT``
-  build option: when ON, it is ``/etc/tarantool/instances.enabled``,
-  otherwise (OFF or not set) it is ``/etc/tarantool/instances.available``.
-  The latter case is typical for Tarantool builds for Linux distros with
-  ``systemd``.
-
-  To check the build options, say ``tarantool --version``.
-
-As a full-featured example, you can take
-`example.lua <https://github.com/tarantool/tarantool/blob/2.1/extra/dist/example.lua>`_
-script that ships with Tarantool and defines all configuration options.
+Find the detailed information about the ``tt`` configuration parameters and launch modes
+on the :ref:`tt configuration page <tt-config>`.

--- a/doc/book/admin/instance_config.rst
+++ b/doc/book/admin/instance_config.rst
@@ -159,7 +159,7 @@ reports the problem and exits.
 tt configuration file
 ---------------------
 
-While instance files contain instance configuration, the ``tt`` configuration file
+While instance files contain instance configuration, the :ref:`tt <tt-cli>` configuration file
 contains the configuration that ``tt`` uses to set up the application environment.
 This includes the path to instance files, various working directories, and other
 parameters that connect the application to the system.

--- a/doc/book/admin/logs.rst
+++ b/doc/book/admin/logs.rst
@@ -6,8 +6,8 @@ Logs
 Each Tarantool instance logs important events to its own log file ``<instance-name>.log``.
 For instances started with :ref:`tt <tt-cli>`, the log location is defined by
 the ``log_dir`` parameter in the :ref:`tt configuration <tt-config>`.
-By default, it's ``/var/log/tarantool`` in the ``tt`` :ref:`system mode <config_modes>`,
-and the ``var/log/`` subdirectory of the ``tt`` working directory in the :ref:`local mode <config_modes>`.
+By default, it's ``/var/log/tarantool`` in the ``tt`` :ref:`system mode <tt-config_modes>`,
+and the ``var/log/`` subdirectory of the ``tt`` working directory in the :ref:`local mode <tt-config_modes>`.
 In the specified location, ``tt`` creates separate directories for each instance's logs.
 
 To check how logging works, write something to the log using the :ref:`log <log-module>` module:

--- a/doc/book/admin/logs.rst
+++ b/doc/book/admin/logs.rst
@@ -5,40 +5,38 @@ Logs
 ================================================================================
 
 Tarantool logs important events to a file, e.g. ``/var/log/tarantool/my_app.log``.
-To build the log file path, ``tarantoolctl`` takes the instance name, prepends
+To build the log file path, ``tt`` takes the instance name, prepends
 the instance directory and appends “.log” extension.
 
 Let’s write something to the log file:
 
 .. code-block:: console
 
-    $ tarantoolctl enter my_app
-    /bin/tarantoolctl: connected to unix/:/var/run/tarantool/my_app.control
+    $ tt connect my_app
+       • Connecting to the instance...
+       • Connected to unix/:/var/run/tarantool/my_app.control
+
     unix/:/var/run/tarantool/my_app.control> require('log').info("Hello for the manual readers")
-    ---
-    ...
 
 Then check the logs:
 
 .. code-block:: console
 
     $ tail /var/log/tarantool/my_app.log
-    2017-04-04 15:54:04.977 [29255] main/101/tarantoolctl C> version 1.7.3-382-g68ef3f6a9
-    2017-04-04 15:54:04.977 [29255] main/101/tarantoolctl C> log level 5
-    2017-04-04 15:54:04.978 [29255] main/101/tarantoolctl I> mapping 134217728 bytes for tuple arena...
-    2017-04-04 15:54:04.985 [29255] iproto/101/main I> binary: bound to [::1]:3301
-    2017-04-04 15:54:04.986 [29255] main/101/tarantoolctl I> recovery start
-    2017-04-04 15:54:04.986 [29255] main/101/tarantoolctl I> recovering from `/var/lib/tarantool/my_app/00000000000000000000.snap'
-    2017-04-04 15:54:04.988 [29255] main/101/tarantoolctl I> ready to accept requests
-    2017-04-04 15:54:04.988 [29255] main/101/tarantoolctl I> set 'checkpoint_interval' configuration option to 3600
-    2017-04-04 15:54:04.988 [29255] main/101/my_app I> Run console at unix/:/var/run/tarantool/my_app.control
-    2017-04-04 15:54:04.989 [29255] main/106/console/unix/:/var/ I> started
-    2017-04-04 15:54:04.989 [29255] main C> entering the event loop
-    2017-04-04 15:54:47.147 [29255] main/107/console/unix/: I> Hello for the manual readers
+    2023-09-12 18:13:00.396 [67173] main/111/guard of feedback_daemon/box.feedback_daemon V> metrics_collector restarted
+    2023-09-12 18:13:00.396 [67173] main/103/-/box.feedback_daemon V> feedback_daemon started
+    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(14) = 0x1090077b4
+    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(26) = 0x1090077ec
+    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(39) = 0x109007824
+    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(24) = 0x10900785c
+    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(39) = 0x109007894
+    2023-09-12 18:13:00.396 [67173] main/106/checkpoint_daemon I> scheduled next checkpoint for Tue Sep 12 19:44:34 2023
+    2023-09-12 18:13:00.396 [67173] main I> entering the event loop
+    2023-09-12 18:13:11.656 [67173] main/114/console/unix/:/tarantool I> Hello for the manual readers
 
 When :ref:`logging to a file <cfg_logging-log>`, the system administrator must ensure logs are
 rotated timely and do not take up all the available disk space. With
-``tarantoolctl``, log rotation is pre-configured to use ``logrotate`` program,
+``tt``, log rotation is pre-configured to use ``logrotate`` program,
 which you must have installed.
 
 File ``/etc/logrotate.d/tarantool`` is part of the standard Tarantool
@@ -56,21 +54,21 @@ this file is usually like:
        delaycompress
        create 0640 tarantool adm
        postrotate
-           /usr/bin/tarantoolctl logrotate `basename ${1%%.*}`
+           /usr/bin/tt logrotate `basename ${1%%.*}`
        endscript
    }
 
 If you use a different log rotation program, you can invoke
-``tarantoolctl logrotate`` command to request instances to reopen their log
+:ref:`tt logrotate <tt-logrotate>` command to request instances to reopen their log
 files after they were moved by the program of your choice.
 
 Tarantool can write its logs to a log file, ``syslog`` or a program specified
 in the configuration file (see :ref:`log <cfg_logging-log>` parameter).
 
-By default, logs are written to a file as defined in ``tarantoolctl``
-defaults. ``tarantoolctl`` automatically detects if an instance is using
+By default, logs are written to a file as defined in ``tt``
+defaults. ``tt`` automatically detects if an instance is using
 ``syslog`` or an external program for logging, and does not override the log
 destination in this case. In such configurations, log rotation is usually
 handled by the external program used for logging. So,
-``tarantoolctl logrotate`` command works only if logging-into-file is enabled
+``tt logrotate`` command works only if logging-into-file is enabled
 in the instance file.

--- a/doc/book/admin/logs.rst
+++ b/doc/book/admin/logs.rst
@@ -14,9 +14,9 @@ Let’s write something to the log file:
 
     $ tt connect my_app
        • Connecting to the instance...
-       • Connected to unix/:/var/run/tarantool/my_app.control
+       • Connected to /var/run/tarantool/my_app.control
 
-    unix/:/var/run/tarantool/my_app.control> require('log').info("Hello for the manual readers")
+    /var/run/tarantool/my_app.control> require('log').info("Hello for the manual readers")
 
 Then check the logs:
 

--- a/doc/book/admin/modules.rst
+++ b/doc/book/admin/modules.rst
@@ -114,7 +114,7 @@ Here's an example that illustrates the most typical case -- "update and reload".
 
     In this example, we use recommended :ref:`administration practices <admin>`
     based on :ref:`instance files <admin-instance_file>` and
-    :ref:`tarantoolctl <tarantoolctl>` utility.
+    :ref:`tt <tt-cli>` utility.
 
 1. Update the application file.
 
@@ -196,11 +196,11 @@ Here's an example that illustrates the most typical case -- "update and reload".
 
 3. Manually reload the application file.
 
-   For example, using ``tarantoolctl``:
+   For example, using ``tt``:
 
    .. code-block:: console
 
-       $ tarantoolctl eval my_app /etc/tarantool/instances.enabled/my_app.lua
+       $ tt connect my_app -f /etc/tarantool/instances.enabled/my_app.lua
 
 .. _app_server-reloading_c_module:
 

--- a/doc/book/admin/os_notes.rst
+++ b/doc/book/admin/os_notes.rst
@@ -7,10 +7,10 @@ Notes for operating systems
 .. _admin-os_notes-mac:
 
 --------------------------------------------------------------------------------
-Mac OS
+macOS
 --------------------------------------------------------------------------------
 
-On Mac OS, you can administer Tarantool instances only with :ref:`tt <tt-cli>`.
+On macOS, you can administer Tarantool instances only with :ref:`tt <tt-cli>`.
 No native system tools are supported.
 
 .. _admin-os_notes-freebsd:

--- a/doc/book/admin/os_notes.rst
+++ b/doc/book/admin/os_notes.rst
@@ -18,7 +18,6 @@ No native system tools are supported.
 --------------------------------------------------------------------------------
 FreeBSD
 --------------------------------------------------------------------------------
-.. TODO TT
 
 To make ``tarantoolctl`` work along with ``init.d`` utilities on FreeBSD, use
 paths other than those suggested in

--- a/doc/book/admin/os_notes.rst
+++ b/doc/book/admin/os_notes.rst
@@ -10,7 +10,7 @@ Notes for operating systems
 Mac OS
 --------------------------------------------------------------------------------
 
-On Mac OS, you can administer Tarantool instances only with :ref:`tt <tt_cli>`.
+On Mac OS, you can administer Tarantool instances only with :ref:`tt <tt-cli>`.
 No native system tools are supported.
 
 .. _admin-os_notes-freebsd:
@@ -18,6 +18,7 @@ No native system tools are supported.
 --------------------------------------------------------------------------------
 FreeBSD
 --------------------------------------------------------------------------------
+.. TODO TT
 
 To make ``tarantoolctl`` work along with ``init.d`` utilities on FreeBSD, use
 paths other than those suggested in

--- a/doc/book/admin/os_notes.rst
+++ b/doc/book/admin/os_notes.rst
@@ -6,51 +6,16 @@ Notes for operating systems
 
 .. _admin-os_notes-mac:
 
---------------------------------------------------------------------------------
 macOS
---------------------------------------------------------------------------------
+-----
 
-On macOS, you can administer Tarantool instances only with :ref:`tt <tt-cli>`.
-No native system tools are supported.
-
-.. _admin-os_notes-freebsd:
-
---------------------------------------------------------------------------------
-FreeBSD
---------------------------------------------------------------------------------
-
-To make ``tarantoolctl`` work along with ``init.d`` utilities on FreeBSD, use
-paths other than those suggested in
-:ref:`Instance configuration <admin-instance_config>`. Instead of
-``/usr/share/tarantool/`` directory, use ``/usr/local/etc/tarantool/`` and
-create the following subdirectories:
-
-* ``default`` for ``tarantoolctl`` defaults (see example below),
-* ``instances.available`` for all available instance files, and
-* ``instances.enabled`` for instance files to be auto-started by sysvinit.
-
-Here is an example of ``tarantoolctl`` defaults on FreeBSD:
-
-.. code-block:: lua
-
-   default_cfg = {
-       pid_file   = "/var/run/tarantool", -- /var/run/tarantool/${INSTANCE}.pid
-       wal_dir    = "/var/db/tarantool", -- /var/db/tarantool/${INSTANCE}/
-       snap_dir   = "/var/db/tarantool", -- /var/db/tarantool/${INSTANCE}
-       vinyl_dir = "/var/db/tarantool", -- /var/db/tarantool/${INSTANCE}
-       logger     = "/var/log/tarantool", -- /var/log/tarantool/${INSTANCE}.log
-       username   = "admin"
-   }
-
-   -- instances.available - all available instances
-   -- instances.enabled - instances to autostart by sysvinit
-   instance_dir = "/usr/local/etc/tarantool/instances.available"
+On macOS, no native system tools for administering Tarantool are supported.
+The recommended way to administer Tarantool instances is using :ref:`tt CLI <tt-cli>`.
 
 .. _admin-os_notes-gentoo:
 
---------------------------------------------------------------------------------
 Gentoo Linux
---------------------------------------------------------------------------------
+------------
 
 The section below is about a dev-db/tarantool package installed from the
 official layman overlay (named ``tarantool``).
@@ -73,3 +38,12 @@ Checking that it works:
 
     $ /etc/init.d/your_service_name start
     $ tail -f -n 100 /var/log/tarantool/your_service_name.log
+
+
+.. _admin-os_notes-freebsd:
+
+FreeBSD
+-------
+
+To learn about specifics of using the deprecated ``tarantoolctl`` utility on FreeBSD,
+check its :ref:`documentation <tarantoolctl-freebsd>`.

--- a/doc/book/admin/os_notes.rst
+++ b/doc/book/admin/os_notes.rst
@@ -10,7 +10,7 @@ Notes for operating systems
 Mac OS
 --------------------------------------------------------------------------------
 
-On Mac OS, you can administer Tarantool instances only with ``tarantoolctl``.
+On Mac OS, you can administer Tarantool instances only with :ref:`tt <tt_cli>`.
 No native system tools are supported.
 
 .. _admin-os_notes-freebsd:

--- a/doc/book/admin/replication/repl_recover.rst
+++ b/doc/book/admin/replication/repl_recover.rst
@@ -100,7 +100,7 @@ To declare that one of the replicas must now take over as a new master:
    If there are updates on the old master that were not propagated before the
    old master went down,
    :ref:`re-apply them manually <admin-disaster_recovery-master_replica>` to the
-   new master using ``tarantoolctl cat`` and ``tarantoolctl play`` commands.
+   new master using ``tt cat`` and ``tt play`` commands.
 
 There is no automatic way for a replica to detect that the master is gone
 forever, since sources of failure and replication environments vary

--- a/doc/book/admin/security.rst
+++ b/doc/book/admin/security.rst
@@ -72,7 +72,7 @@ For ease of use, ``tt connect`` command automatically detects the type
 of connection during handshake and uses :ref:`EVAL <box_protocol-eval>`
 binary protocol command when it’s necessary to execute Lua commands over a binary
 connection. To execute EVAL, the authenticated user must have global "EXECUTE"
-privilege. The ``tarantoolctl connect`` command is for administrators.
+privilege.
 
 Therefore, when ``ssh`` access to the machine is not available, creating a
 Tarantool user with global "EXECUTE" privilege and non-empty password can be

--- a/doc/book/admin/security.rst
+++ b/doc/book/admin/security.rst
@@ -66,8 +66,6 @@ When you connect to a binary port:
 * The user is automatically ':ref:`guest <authentication-users>`'.
 * To change the user, it’s necessary to authenticate.
 
-.. TODO TT
-
 For ease of use, ``tt connect`` command automatically detects the type
 of connection during handshake and uses :ref:`EVAL <box_protocol-eval>`
 binary protocol command when it’s necessary to execute Lua commands over a binary

--- a/doc/book/admin/security.rst
+++ b/doc/book/admin/security.rst
@@ -9,7 +9,7 @@ Tarantool allows for two types of connections:
 * With :ref:`console.listen() <console-listen>` function from ``console`` module,
   you can set up a port which can be used to open an administrative console to
   the server. This is for administrators to connect to a running instance and
-  make requests. ``tarantoolctl`` invokes ``console.listen()`` to create a
+  make requests. ``tt`` invokes ``console.listen()`` to create a
   control socket for each started instance.
 
 * With :ref:`box.cfg{listen=...} <cfg_basic-listen>` parameter from ``box``
@@ -40,8 +40,8 @@ and a typical connection :ref:`URI <index-uri>` is:
 
 if the listener has the privilege to write on ``/var/lib/tarantool`` and the
 connector has the privilege to read on ``/var/lib/tarantool``. Alternatively,
-to connect to an admin console of an instance started with ``tarantoolctl``, use
-:ref:`tarantoolctl enter <admin-executing_code_on_an_instance>`.
+to connect to an admin console of an instance started with ``tt``, use
+:ref:`tt connect <tt-connect>`.
 
 To find out whether a TCP port is a port for admin console, use ``telnet``.
 For example:
@@ -66,7 +66,9 @@ When you connect to a binary port:
 * The user is automatically ':ref:`guest <authentication-users>`'.
 * To change the user, it’s necessary to authenticate.
 
-For ease of use, ``tarantoolctl connect`` command automatically detects the type
+.. TODO TT
+
+For ease of use, ``tt connect`` command automatically detects the type
 of connection during handshake and uses :ref:`EVAL <box_protocol-eval>`
 binary protocol command when it’s necessary to execute Lua commands over a binary
 connection. To execute EVAL, the authenticated user must have global "EXECUTE"

--- a/doc/book/admin/server_introspection.rst
+++ b/doc/book/admin/server_introspection.rst
@@ -19,8 +19,7 @@ Tarantool displays a prompt (e.g. "tarantool>") and you can enter requests.
 When used this way, Tarantool can be a client for a remote server.
 See basic examples in :ref:`Getting started <getting_started>`.
 
-The interactive mode is used by ``tarantoolctl`` to implement "enter" and
-"connect" commands.
+The interactive mode is used in the ``tt`` utility's :ref:`connect <tt-connect>` command.
 
 .. _admin-executing_code_on_an_instance:
 
@@ -28,15 +27,15 @@ Executing code on an instance
 -----------------------------
 
 You can attach to an instance's :ref:`admin console <admin-security>` and
-execute some Lua code using ``tarantoolctl``:
+execute some Lua code using ``tt``:
 
 .. code-block:: console
 
     $ # for local instances:
-    $ tarantoolctl enter my_app
-    /bin/tarantoolctl: Found my_app.lua in /etc/tarantool/instances.available
-    /bin/tarantoolctl: Connecting to /var/run/tarantool/my_app.control
-    /bin/tarantoolctl: connected to unix/:/var/run/tarantool/my_app.control
+    $ tt connect my_app
+       • Connecting to the instance...
+       • Connected to unix/:/var/run/tarantool/my_app.control
+
     unix/:/var/run/tarantool/my_app.control> 1 + 1
     ---
     - 2
@@ -44,21 +43,21 @@ execute some Lua code using ``tarantoolctl``:
     unix/:/var/run/tarantool/my_app.control>
 
     $ # for local and remote instances:
-    $ tarantoolctl connect username:password@127.0.0.1:3306
+    $ tt connect username:password@127.0.0.1:3306
 
-You can also use ``tarantoolctl`` to execute Lua code on an instance without
+You can also use ``tt`` to execute Lua code on an instance without
 attaching to its admin console. For example:
 
 .. code-block:: console
 
     $ # executing commands directly from the command line
-    $ <command> | tarantoolctl eval my_app
+    $ <command> | tt connect my_app -f
     <...>
 
     $ # - OR -
 
     $ # executing commands from a script file
-    $ tarantoolctl eval my_app script.lua
+    $ tt connect my_app -f script.lua
     <...>
 
 .. NOTE::
@@ -67,7 +66,7 @@ attaching to its admin console. For example:
     :ref:`net.box <net_box-module>` module from a Tarantool server. Also, you can
     write your client programs with any of the
     :ref:`connectors <index-box_connectors>`. However, most of the examples in
-    this manual illustrate usage with either ``tarantoolctl connect`` (for administrative purposes) or
+    this manual illustrate usage with either ``tt connect`` or
     :ref:`using the Tarantool server as a client <admin-using_tarantool_as_a_client>`.
 
 .. _admin-health_checks:
@@ -79,9 +78,9 @@ To check the instance status, say:
 
 .. code-block:: console
 
-    $ tarantoolctl status my_app
-    my_app is running (pid: /var/run/tarantool/my_app.pid)
-
+    $ tt status my_app
+    INSTANCE     STATUS      PID
+    my_app       RUNNING     67172
     $ # - OR -
 
     $ systemctl status tarantool@my_app
@@ -236,7 +235,7 @@ First, enter your instance’s interactive administrator console:
 
 .. code-block:: console
 
-    $ tarantoolctl enter NAME
+    $ tt connect NAME|URI
 
 Once there, load the ``fiber`` module:
 
@@ -508,13 +507,13 @@ Once you do this, install Lua bindings:
 
 .. code-block:: console
 
-    $ tarantoolctl rocks install gperftools
+    $ tt rocks install gperftools
 
 Now you're ready to go. Enter your instance’s interactive administrator console:
 
 .. code-block:: console
 
-    $ tarantoolctl enter NAME
+    $ tt connect NAME|URI
 
 To start profiling, say:
 

--- a/doc/book/admin/server_introspection.rst
+++ b/doc/book/admin/server_introspection.rst
@@ -34,13 +34,13 @@ execute some Lua code using ``tt``:
     $ # for local instances:
     $ tt connect my_app
        • Connecting to the instance...
-       • Connected to unix/:/var/run/tarantool/my_app.control
+       • Connected to /var/run/tarantool/example.control
 
-    unix/:/var/run/tarantool/my_app.control> 1 + 1
+    /var/run/tarantool/my_app.control> 1 + 1
     ---
     - 2
     ...
-    unix/:/var/run/tarantool/my_app.control>
+    /var/run/tarantool/my_app.control>
 
     $ # for local and remote instances:
     $ tt connect username:password@127.0.0.1:3306
@@ -51,7 +51,7 @@ attaching to its admin console. For example:
 .. code-block:: console
 
     $ # executing commands directly from the command line
-    $ <command> | tt connect my_app -f
+    $ <command> | tt connect my_app -f -
     <...>
 
     $ # - OR -
@@ -74,37 +74,23 @@ attaching to its admin console. For example:
 Health checks
 -------------
 
-To check the instance status, say:
+To check the instance status, run:
 
 .. code-block:: console
 
     $ tt status my_app
     INSTANCE     STATUS      PID
     my_app       RUNNING     67172
+
     $ # - OR -
 
     $ systemctl status tarantool@my_app
-    tarantool@my_app.service - Tarantool Database Server
-    Loaded: loaded (/etc/systemd/system/tarantool@.service; disabled; vendor preset: disabled)
-    Active: active (running)
-    Docs: man:tarantool(1)
-    Process: 5346 ExecStart=/usr/bin/tarantoolctl start %I (code=exited, status=0/SUCCESS)
-    Main PID: 5350 (tarantool)
-    Tasks: 11 (limit: 512)
-    CGroup: /system.slice/system-tarantool.slice/tarantool@my_app.service
-    + 5350 tarantool my_app.lua <running>
 
-To check the boot log, on systems with ``systemd``, say:
+To check the boot log, on systems with ``systemd``, run:
 
 .. code-block:: console
 
     $ journalctl -u tarantool@my_app -n 5
-    -- Logs begin at Fri 2016-01-08 12:21:53 MSK, end at Thu 2016-01-21 21:17:47 MSK. --
-    Jan 21 21:17:47 localhost.localdomain systemd[1]: Stopped Tarantool Database Server.
-    Jan 21 21:17:47 localhost.localdomain systemd[1]: Starting Tarantool Database Server...
-    Jan 21 21:17:47 localhost.localdomain tarantoolctl[5969]: /usr/bin/tarantoolctl: Found my_app.lua in /etc/tarantool/instances.available
-    Jan 21 21:17:47 localhost.localdomain tarantoolctl[5969]: /usr/bin/tarantoolctl: Starting instance...
-    Jan 21 21:17:47 localhost.localdomain systemd[1]: Started Tarantool Database Server
 
 For more specific checks, use the reports provided by functions in the following submodules:
 
@@ -345,7 +331,7 @@ the ``fiber-info.txt`` file:
 .. code-block:: console
 
     $ rm -f fiber.info.txt
-    $ watch -n 0.5 "echo 'require(\"fiber\").info()' | tarantoolctl enter NAME | tee -a fiber-info.txt"
+    $ watch -n 0.5 "echo 'require(\"fiber\").info()' | tt connect NAME -f - | tee -a fiber-info.txt"
 
 If you can't understand which fiber causes performance issues, collect the
 metrics of the ``fiber.info()`` output for 10-15 seconds using the script above

--- a/doc/book/admin/start_stop_instance.rst
+++ b/doc/book/admin/start_stop_instance.rst
@@ -27,7 +27,7 @@ Here is what ``tarantoolctl`` does when you issue the command:
    (``$HOME/.config/tarantool/tarantool``). If no configuration file is found
    there, or in the ``/usr/local/etc/default/tarantool`` file,
    then ``tarantoolctl`` falls back to
-   :ref:`built-in defaults <admin-tarantoolctl_config_file>`.
+   :ref:`built-in defaults <admin-tt_config_file>`.
 
 3. Look up the instance file in the instance directory, for example
    ``/etc/tarantool/instances.enabled``. To build the instance file path,

--- a/doc/book/admin/troubleshoot.rst
+++ b/doc/book/admin/troubleshoot.rst
@@ -21,9 +21,7 @@ Problem: INSERT/UPDATE-requests result in ER_MEMORY_ISSUE error
   .. code-block:: console
 
       $ # attaching to a Tarantool instance
-      $ tarantoolctl enter <instance_name>
-      $ # -- OR --
-      $ tarantoolctl connect <URI>
+      $ tt connect <instance_name|URI>
 
   .. code-block:: tarantoolsession
 
@@ -76,16 +74,15 @@ over 60% CPU.
 
 **Solution**
 
-Attach to the Tarantool instance with :ref:`tarantoolctl <tarantoolctl>` utility,
+Attach to the Tarantool instance with :ref:`tt <tt-cli>` utility,
 analyze the query statistics with :doc:`box.stat() </reference/reference_lua/box_stat>`
 and spot the CPU consumption leader. The following commands can help:
 
 .. code-block:: console
 
     $ # attaching to a Tarantool instance
-    $ tarantoolctl enter <instance_name>
-    $ # -- OR --
-    $ tarantoolctl connect <URI>
+    $ tt connect <instance_name|URI>
+
 
 .. code-block:: tarantoolsession
 
@@ -134,15 +131,14 @@ Problem: Query processing times out
 
      This parameter can be changed on the fly, so you don't need to restart
      Tarantool. Attach to the Tarantool instance with
-     :ref:`tarantoolctl <tarantoolctl>` utility and call ``box.cfg{}`` with a
+     :ref:`tt <tt-cli>` utility and call ``box.cfg{}`` with a
      new ``readahead`` value:
 
      .. code-block:: console
 
          $ # attaching to a Tarantool instance
-         $ tarantoolctl enter <instance_name>
-         $ # -- OR --
-         $ tarantoolctl connect <URI>
+         $ tt connect <instance_name|URI>
+
 
      .. code-block:: tarantoolsession
 
@@ -258,9 +254,7 @@ Restart replication with the following commands (at each master instance):
 .. code-block:: console
 
     $ # attaching to a Tarantool instance
-    $ tarantoolctl enter <instance_name>
-    $ # -- OR --
-    $ tarantoolctl connect <URI>
+    $ tt connect <instance_name|URI>
 
 .. code-block:: tarantoolsession
 
@@ -294,9 +288,7 @@ Example of calculating memory usage statistics:
 .. code-block:: console
 
     $ # attaching to a Tarantool instance
-    $ tarantoolctl enter <instance_name>
-    $ # -- OR --
-    $ tarantoolctl connect <URI>
+    $ tt connect <instance_name|URI>
 
 .. code-block:: tarantoolsession
 

--- a/doc/book/admin/upgrades/upgrade_cluster.rst
+++ b/doc/book/admin/upgrades/upgrade_cluster.rst
@@ -329,5 +329,5 @@ Switching the master
         the replica set state by calling ``box.cfg{ read_only == false }`` on the master.
         Then pick another candidate and restart the procedure.
 
-After switching the master, perform the :ref:`replication check <upgrades-admin-replication-check>`
+After switching the master, perform the :ref:`replication check <admin-upgrades-replication-check>`
 on each instance of the replica set.

--- a/doc/book/admin/vshard_admin.rst
+++ b/doc/book/admin/vshard_admin.rst
@@ -16,7 +16,7 @@ To install the module, execute the following command:
 
 ..  code-block:: console
 
-    $ tarantoolctl rocks install vshard
+    $ tt rocks install vshard
 
 ..  note::
 
@@ -51,12 +51,6 @@ highly discouraged and should be avoided on production deployments.
 
 All ``storage`` instances can be deployed using identical instance (configuration)
 files.
-
-Self-identification is currently performed using ``tarantoolctl``:
-
-..  code-block:: console
-
-    $ tarantoolctl instance_name
 
 All ``router`` instances can also be deployed using identical instance (configuration)
 files.

--- a/doc/concepts/data_model/migrations.rst
+++ b/doc/concepts/data_model/migrations.rst
@@ -115,7 +115,6 @@ This method is described in the README file of the
 
     **Method 3**: the :ref:`tt <tt-cli>` utility
 
-    The ``tt`` utility ships with Tarantool.
     Connect to the necessary instance using ``tt connect``.
 
     ..  code:: console
@@ -134,6 +133,13 @@ This method is described in the README file of the
 
     -   (or) Copy the migration script code,
         paste it into the console, and run it.
+
+    You can also connect to the instance and execute the migration script in a single call:
+
+    ..  code:: console
+
+        $ tt connect admin:password@localhost:3301 -f 0001-delete-space.lua
+
 
     **Method 4**: applying migration with Ansible
 

--- a/doc/concepts/data_model/migrations.rst
+++ b/doc/concepts/data_model/migrations.rst
@@ -113,14 +113,14 @@ This method is described in the README file of the
     There are also two other methods that we **do not recommend**,
     but you may find them useful for one reason or another.
 
-    **Method 3**: the ``tarantoolctl`` utility
+    **Method 3**: the :ref:`tt <tt-cli>` utility
 
-    The ``tarantoolctl`` utility ships with Tarantool.
-    Connect to the necessary instance using ``tarantoolctl connect``.
+    The ``tt`` utility ships with Tarantool.
+    Connect to the necessary instance using ``tt connect``.
 
     ..  code:: console
 
-        $ tarantoolctl connect admin:password@localhost:3301
+        $ tt connect admin:password@localhost:3301
 
     -   If your migration is written in a Lua file, you can execute it
         using ``dofile()``. Call this function and specify the path to the

--- a/doc/concepts/modules.rst
+++ b/doc/concepts/modules.rst
@@ -40,8 +40,7 @@ For example, here's a Lua application that uses ``myfun()`` from
    end
 
 Tarantool provides an `extensive library <https://www.tarantool.io/en/download/rocks>`_ of compatible modules.
-Install them using Tarantool's CLI utilities like :ref:`tarantoolctl <tarantoolctl>`
-or :ref:`tt CLI <tt-cli>`.
+Install them using Tarantool's CLI utility :ref:`tt <tt-cli>`.
 Some modules are also included in the Tarantool repository and can be installed
 via your operating system's package manager.
 

--- a/doc/dev_guide/building_from_source.rst
+++ b/doc/dev_guide/building_from_source.rst
@@ -236,8 +236,6 @@ FreeBSD
 Additional steps
 ----------------
 
-.. TODO TT
-
 .. _building_from_source-tarantoolctl:
 
 -DENABLE_DIST=ON for tarantoolctl installation

--- a/doc/dev_guide/building_from_source.rst
+++ b/doc/dev_guide/building_from_source.rst
@@ -241,6 +241,12 @@ Additional steps
 -DENABLE_DIST=ON for tarantoolctl installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. important::
+
+    ``tarantoolctl`` is deprecated in favor of :ref:`tt CLI <tt-cli>`.
+    Find the instructions on switching from ``tarantoolctl`` to ``tt`` in
+    :ref:`Migration from tarantoolctl to tt <tarantoolctl-migration-to-tt>``.
+
 The CMake option for hinting that the result will be distributed is
 :code:`-DENABLE_DIST=ON`. With this option, ``make install``
 installs ``tarantoolctl`` files in addition to ``tarantool`` files.

--- a/doc/dev_guide/building_from_source.rst
+++ b/doc/dev_guide/building_from_source.rst
@@ -245,7 +245,7 @@ Additional steps
 
     ``tarantoolctl`` is deprecated in favor of :ref:`tt CLI <tt-cli>`.
     Find the instructions on switching from ``tarantoolctl`` to ``tt`` in
-    :ref:`Migration from tarantoolctl to tt <tarantoolctl-migration-to-tt>``.
+    :ref:`Migration from tarantoolctl to tt <tarantoolctl-migration-to-tt>`.
 
 The CMake option for hinting that the result will be distributed is
 :code:`-DENABLE_DIST=ON`. With this option, ``make install``

--- a/doc/dev_guide/building_from_source.rst
+++ b/doc/dev_guide/building_from_source.rst
@@ -236,6 +236,8 @@ FreeBSD
 Additional steps
 ----------------
 
+.. TODO TT
+
 .. _building_from_source-tarantoolctl:
 
 -DENABLE_DIST=ON for tarantoolctl installation

--- a/doc/dev_guide/internals/iproto/requests.rst
+++ b/doc/dev_guide/internals/iproto/requests.rst
@@ -287,7 +287,7 @@ its own code, for example :samp:`box.space.{space-name}:drop()`,
 will be handled either with :ref:`IPROTO_CALL <box_protocol-call>`
 or IPROTO_EVAL.
 
-The :ref:`tarantoolctl <tarantoolctl>` administrative utility
+The :ref:`tt <tt-cli>` administrative utility
 makes extensive use of ``eval``.
 
 The body is a 2-item map:

--- a/doc/how-to/app/creating_app/avro_schemas.rst
+++ b/doc/how-to/app/creating_app/avro_schemas.rst
@@ -11,7 +11,7 @@ will contain only field values, and thus take a lot less space than the original
 document. In avro-schema terms, converting JSON documents to tuples is
 "flattening", and restoring the original documents is "unflattening".
 
-First you need to :ref:`install <app_server-installing_module>`_
+First you need to :ref:`install <app_server-installing_module>`
 the module with ``tt rocks install avro-schema``.
 
 Further usage is quite straightforward:

--- a/doc/how-to/app/creating_app/avro_schemas.rst
+++ b/doc/how-to/app/creating_app/avro_schemas.rst
@@ -11,9 +11,8 @@ will contain only field values, and thus take a lot less space than the original
 document. In avro-schema terms, converting JSON documents to tuples is
 "flattening", and restoring the original documents is "unflattening".
 
-First you need to
-`install <https://www.tarantool.io/en/doc/1.10/book/app_server/installing_module/>`_
-the module with ``tarantoolctl rocks install avro-schema``.
+First you need to :ref:`install <app_server-installing_module>`_
+the module with ``tt rocks install avro-schema``.
 
 Further usage is quite straightforward:
 

--- a/doc/how-to/sql/improving_mysql.rst
+++ b/doc/how-to/sql/improving_mysql.rst
@@ -222,18 +222,19 @@ So let’s proceed.
       mkdir instances.enabled
       ln -s /instances.available/example.lua instances.enabled
 
-#. Next we can start up our Lua program with ``tarantoolctl``, a wrapper for systemd:
+#. Next we can start up our Lua program with ``tt``, the Tarantool command-line
+   utility:
 
    .. code-block:: bash
 
-      tarantoolctl start example.lua
+      tt start example.lua
 
 #. Now let’s enter our Tarantool instance, where we can check that our target
    spaces were successfully created:
 
    .. code-block:: bash
 
-      tarantoolctl enter example.lua
+      tt connect example.lua
 
    .. code-block:: tarantoolsession
 
@@ -295,7 +296,7 @@ So let’s proceed.
 
    .. code-block:: bash
 
-      tarantoolctl enter example.lua
+      tt connect example.lua
 
    .. code-block:: tarantoolsession
 
@@ -327,7 +328,7 @@ So let’s proceed.
 
    .. code-block:: bash
 
-      tarantoolctl enter example.lua
+      tt connect example.lua
 
    .. code-block:: tarantoolsession
 

--- a/doc/how-to/sql/improving_mysql.rst
+++ b/doc/how-to/sql/improving_mysql.rst
@@ -227,14 +227,14 @@ So let’s proceed.
 
    .. code-block:: bash
 
-      tt start example.lua
+      tt start example
 
 #. Now let’s enter our Tarantool instance, where we can check that our target
    spaces were successfully created:
 
    .. code-block:: bash
 
-      tt connect example.lua
+      tt connect example
 
    .. code-block:: tarantoolsession
 
@@ -296,7 +296,7 @@ So let’s proceed.
 
    .. code-block:: bash
 
-      tt connect example.lua
+      tt connect example
 
    .. code-block:: tarantoolsession
 
@@ -328,7 +328,7 @@ So let’s proceed.
 
    .. code-block:: bash
 
-      tt connect example.lua
+      tt connect example
 
    .. code-block:: tarantoolsession
 

--- a/doc/how-to/sql/sql_tutorial.rst
+++ b/doc/how-to/sql/sql_tutorial.rst
@@ -181,6 +181,7 @@ Retrieve the 4 rows in the table, in descending order by ``column2``, then
 .. important::
 
     Tarantool has its own
+
 The result is:
 
 .. code-block:: tarantoolsession

--- a/doc/how-to/using_package_manager.rst
+++ b/doc/how-to/using_package_manager.rst
@@ -220,7 +220,7 @@ listen URI via:
 (1) ``telnet``,
 (2) a :ref:`connector <index-box_connectors>`,
 (3) another instance of Tarantool (using the :ref:`console <console-module>` module), or
-(4) :ref:`tt <tt_cli>` administrative utility.
+(4) :ref:`tt <tt-cli>` administrative utility.
 
 Let’s try (3).
 

--- a/doc/how-to/using_package_manager.rst
+++ b/doc/how-to/using_package_manager.rst
@@ -220,7 +220,7 @@ listen URI via:
 (1) ``telnet``,
 (2) a :ref:`connector <index-box_connectors>`,
 (3) another instance of Tarantool (using the :ref:`console <console-module>` module), or
-(4) :ref:`tarantoolctl <tarantoolctl>` administrative utility.
+(4) :ref:`tt <tt_cli>` administrative utility.
 
 Let’s try (3).
 

--- a/doc/how-to/vshard_quick.rst
+++ b/doc/how-to/vshard_quick.rst
@@ -15,7 +15,7 @@ This example includes 5 Tarantool instances and 2 replica sets:
 * ``storage_2_a`` – a ``storage`` instance, the **master** of the **second** replica set
 * ``storage_2_b`` – a ``storage`` instance, the **replica** of the **second** replica set
 
-All instances are managed using the ``tarantoolctl`` administrative utility which comes with Tarantool.
+All instances are managed using the :ref:`tt <tt_cli>` administrative utility.
 
 Change the directory to ``example/`` and use ``make`` to run the development cluster:
 
@@ -57,13 +57,13 @@ Change the directory to ``example/`` and use ``make`` to run the development clu
     connected to unix/:./data/router_1.control
     unix/:./data/router_1.control>
 
-Some ``tarantoolctl`` commands:
+Some ``tt`` commands:
 
-*   ``tarantoolctl start router_1`` – start the router instance
-*   ``tarantoolctl enter router_1``  – enter the admin console
+*   ``tt start router_1`` – start the router instance
+*   ``tt enter router_1``  – enter the admin console
 
-The full list of ``tarantoolctl`` commands for managing Tarantool instances is
-available in the :ref:`tarantoolctl reference <tarantoolctl>`.
+The full list of ``tt`` commands for managing Tarantool instances is
+available in the :ref:`tt CLI reference <tt_cli>`.
 
 Essential ``make`` commands you need to know:
 

--- a/doc/how-to/vshard_quick.rst
+++ b/doc/how-to/vshard_quick.rst
@@ -23,47 +23,6 @@ Change the directory to ``example/`` and use ``make`` to run the development clu
 
     $ cd example/
     $ make
-    tarantoolctl stop storage_1_a  # stop the first storage instance
-    Stopping instance storage_1_a...
-    tarantoolctl stop storage_1_b
-    <...>
-    rm -rf data/
-    tarantoolctl start storage_1_a # start the first storage instance
-    Starting instance storage_1_a...
-    Starting configuration of replica 8a274925-a26d-47fc-9e1b-af88ce939412
-    I am master
-    Taking on replicaset master role...
-    Run console at unix/:./data/storage_1_a.control
-    started
-    mkdir ./data/storage_1_a
-    <...>
-    tarantoolctl start router_1 # start the router
-    Starting instance router_1...
-    Starting router configuration
-    Calling box.cfg()...
-    <...>
-    Run console at unix/:./data/router_1.control
-    started
-    mkdir ./data/router_1
-    Waiting cluster to start
-    echo "vshard.router.bootstrap()" | tarantoolctl enter router_1
-    connected to unix/:./data/router_1.control
-    unix/:./data/router_1.control> vshard.router.bootstrap()
-    ---
-    - true
-    ...
-    unix/:./data/router_1.control>
-    tarantoolctl enter router_1 # enter the admin console
-    connected to unix/:./data/router_1.control
-    unix/:./data/router_1.control>
-
-Some ``tt`` commands:
-
-*   ``tt start router_1`` – start the router instance
-*   ``tt enter router_1``  – enter the admin console
-
-The full list of ``tt`` commands for managing Tarantool instances is
-available in the :ref:`tt CLI reference <tt_cli>`.
 
 Essential ``make`` commands you need to know:
 

--- a/doc/how-to/vshard_quick.rst
+++ b/doc/how-to/vshard_quick.rst
@@ -15,7 +15,7 @@ This example includes 5 Tarantool instances and 2 replica sets:
 * ``storage_2_a`` – a ``storage`` instance, the **master** of the **second** replica set
 * ``storage_2_b`` – a ``storage`` instance, the **replica** of the **second** replica set
 
-All instances are managed using the :ref:`tt <tt_cli>` administrative utility.
+All instances are managed using the :ref:`tt <tt-cli>` administrative utility.
 
 Change the directory to ``example/`` and use ``make`` to run the development cluster:
 

--- a/doc/reference/configuration/index.rst
+++ b/doc/reference/configuration/index.rst
@@ -345,7 +345,7 @@ The priority of parameter sources is the following, from higher to lower:
 
 *   ``box.cfg`` options
 *   :ref:`environment variables <box-cfg-params-env>`
-*   :doc:`tarantoolctl </reference/tooling/tarantoolctl>` options
+*   :ref:`tt configuration <tt-config>`
 *   default values.
 
 ..  _box-cfg-params-env:

--- a/doc/reference/reference_lua/box_schema/space_create.rst
+++ b/doc/reference/reference_lua/box_schema/space_create.rst
@@ -46,7 +46,7 @@ space_opts
 
     .. NOTE::
 
-    These options are also passed to :doc:`/reference/reference_lua/box_space/alter`.
+        These options are also passed to :doc:`/reference/reference_lua/box_space/alter`.
 
     ..  _space_opts_if_not_exists:
 

--- a/doc/reference/reference_lua/box_space/create_index.rst
+++ b/doc/reference/reference_lua/box_space/create_index.rst
@@ -58,7 +58,7 @@ index_opts
 
     .. NOTE::
 
-    These options are also passed to :doc:`/reference/reference_lua/box_index/alter`.
+        These options are also passed to :doc:`/reference/reference_lua/box_index/alter`.
 
     ..  _index_opts_type:
 
@@ -289,7 +289,7 @@ key_part
 
         .. NOTE::
 
-        To create a key part by a field name, you need to specify :ref:`space_object:format() <box_space-format>` first.
+            To create a key part by a field name, you need to specify :ref:`space_object:format() <box_space-format>` first.
 
         | Type: string or number
 

--- a/doc/reference/reference_lua/compat/box_cfg_replication_sync_timeout.rst
+++ b/doc/reference/reference_lua/compat/box_cfg_replication_sync_timeout.rst
@@ -37,7 +37,7 @@ It is important to set the desired behavior before the initial ``box.cfg{}`` cal
     ---
     - error: 'builtin/box/load_cfg.lua:253: The compat  option ''box_cfg_replication_sync_timeout''
         takes effect only before the initial box.cfg() call'
-...
+    ...
 
 A fresh Tarantool run:
 

--- a/doc/reference/reference_lua/compat/compat_tutorial.rst
+++ b/doc/reference/reference_lua/compat/compat_tutorial.rst
@@ -31,7 +31,7 @@ The options list is serialized in the interactive console with additional detail
     - - option_2: old
     - - option_default_old: default (old)
     - - option_default_new: default (new)
-...
+    ...
 
 Listing options details
 -----------------------

--- a/doc/reference/reference_lua/fiber.rst
+++ b/doc/reference/reference_lua/fiber.rst
@@ -1679,13 +1679,13 @@ Example
 
 Assume that a Tarantool instance is running and listening for connections on
 localhost port 3301. Assume that guest users have privileges to connect. We will
-use the tarantoolctl utility (a utility for administrators) to start two clients.
+use the :ref:`tt <tt-cli>` utility to start two clients.
 
 On terminal #1, say
 
 ..  code-block:: tarantoolsession
 
-    $ tarantoolctl connect '3301'
+    $ tt connect '3301'
     tarantool> fiber = require('fiber')
     tarantool> cond = fiber.cond()
     tarantool> cond:wait()
@@ -1697,7 +1697,7 @@ On terminal #2, say
 
 ..  code-block:: tarantoolsession
 
-    $ tarantoolctl connect '3301'
+    $ tt connect '3301'
     tarantool> cond:signal()
 
 Now look again at terminal #1. It will show that the waiting stopped, and the

--- a/doc/reference/reference_lua/fiber.rst
+++ b/doc/reference/reference_lua/fiber.rst
@@ -1685,7 +1685,7 @@ On terminal #1, say
 
 ..  code-block:: tarantoolsession
 
-    $ tt connect '3301'
+    $ tt connect localhost:3301
     tarantool> fiber = require('fiber')
     tarantool> cond = fiber.cond()
     tarantool> cond:wait()
@@ -1697,7 +1697,7 @@ On terminal #2, say
 
 ..  code-block:: tarantoolsession
 
-    $ tt connect '3301'
+    $ tt connect localhost:3301
     tarantool> cond:signal()
 
 Now look again at terminal #1. It will show that the waiting stopped, and the

--- a/doc/reference/reference_rock/vshard/vshard_router.rst
+++ b/doc/reference/reference_rock/vshard/vshard_router.rst
@@ -864,7 +864,7 @@ Router public API
         :param options:
 
             * ``timeout`` — a request timeout, in seconds. If the ``router`` cannot identify a
-          shard with the specified ``bucket_id``, it will retry until the timeout is reached.
+              shard with the specified ``bucket_id``, it will retry until the timeout is reached.
 
             * other :ref:`net.box options <net_box-options>`, such as ``is_async``,
               ``buffer``, ``on_push`` are also supported.
@@ -891,7 +891,7 @@ Router public API
         :param options:
 
             * ``timeout`` — a request timeout, in seconds. If the ``router`` cannot identify a
-          shard with the specified ``bucket_id``, it will retry until the timeout is reached.
+              shard with the specified ``bucket_id``, it will retry until the timeout is reached.
 
             * other :ref:`net.box options <net_box-options>`, such as ``is_async``,
               ``buffer``, ``on_push`` are also supported.
@@ -929,7 +929,7 @@ Router public API
         :param options:
 
             * ``timeout`` — a request timeout, in seconds. If the ``router`` cannot identify a
-          shard with the specified ``bucket_id``, it will retry until the timeout is reached.
+              shard with the specified ``bucket_id``, it will retry until the timeout is reached.
 
             * other :ref:`net.box options <net_box-options>`, such as ``is_async``,
               ``buffer``, ``on_push`` are also supported.
@@ -957,7 +957,7 @@ Router public API
         :param options:
 
             * ``timeout`` — a request timeout, in seconds. If the ``router`` cannot identify a
-          shard with the specified ``bucket_id``, it will retry until the timeout is reached.
+              shard with the specified ``bucket_id``, it will retry until the timeout is reached.
 
             * other :ref:`net.box options <net_box-options>`, such as ``is_async``,
               ``buffer``, ``on_push`` are also supported.

--- a/doc/reference/tooling/interactive_console.rst
+++ b/doc/reference/tooling/interactive_console.rst
@@ -6,8 +6,7 @@ Interactive console
 The interactive console is Tarantool's basic command-line interface for entering requests
 and seeing results.
 It is what users see when they start the server
-without an :ref:`instance file <admin-instance_file>`,
-or start :ref:`tarantoolctl <tarantoolctl>` with ``enter``.
+without an :ref:`instance file <admin-instance_file>`.
 The interactive console is often called the Lua console to distinguish it from the administrative console,
 but in fact it can handle both Lua and SQL input.
 

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -225,7 +225,7 @@ The ``tarantoolctl`` configuration file named ``.tarantoolctl``
 contains the configuration that ``tarantoolctl`` uses to
 override instance configuration. In other words, it contains system-wide
 configuration defaults. If ``tarantoolctl`` fails to find this file with
-the method described in section
+the method described in the section
 :ref:`Starting/stopping an instance <admin-start_stop_instance>`, it uses
 default settings.
 
@@ -264,7 +264,7 @@ where:
   | The place where the application log will go; ``tarantoolctl`` will add
     "/instance_name.log" to the name.
 * | ``username``
-  | The user that runs the Tarantool instance. This is the operating-system user
+  | The user that runs the Tarantool instance. This is the operating system user
     name rather than the Tarantool-client user name. Tarantool will change its
     effective user to this user after becoming a daemon.
 * | ``language``
@@ -380,7 +380,7 @@ Local configuration
 
 If you have a local ``tarantoolctl`` configuration, create a ``tt`` environment
 based on the existing ``.tarantoolctl`` configuration file. To do this, run
-``tt init`` in the directory where the file in located.
+``tt init`` in the directory where the file is located.
 
 Example:
 

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -7,7 +7,7 @@ Utility tarantoolctl (deprecated)
 
     ``tarantoolctl`` is deprecated in favor of :ref:`tt CLI <tt-cli>`.
     Find the instructions on switching from ``tarantoolctl`` to ``tt`` in
-    :ref:` Migration from tarantoolctl to tt <tarantoolctl-migration-to-tt>``.
+    :ref:`Migration from tarantoolctl to tt <tarantoolctl-migration-to-tt>``.
 
 ``tarantoolctl`` is a utility for administering Tarantool
 :ref:`instances <tarantoolctl-instance_management>`,
@@ -18,172 +18,6 @@ This utility is intended for use by administrators only.
 
 See also ``tarantoolctl`` usage examples in :ref:`Server administration <admin>`
 section.
-
-.. _tarantoolctl-migration-to-tt:
-
-Migration from tarantoolctl to tt
----------------------------------
-
-:ref:``tt <tt-cli>`` is a command-line utility for managing Tarantool applications
-that comes to replace ``tarantoolctl``. Starting from version 3.0, ``tarantoolctl``
-is no longer shipped as a part of Tarantool distribution; ``tt`` is the only
-recommended tool for managing Tarantool application from the command line.
-
-``tarantoolctl`` remains fully compatible with Tarantool 2.* versions. However,
-it doesn't receive major updates anymore.
-
-We recommend that you migrate from ``tarantoolctl`` to ``tt`` to ensure the full
-support and timely updates and fixes.
-
-System-wide configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tt`` supports system-wide environment configuration by default. If you have
-Tarantool instances managed by ``tarantoolctl`` in such an environment, you can
-switch to ``tt`` without additional migration steps or use ``tt`` along with ``tarantoolctl``.
-
-Example:
-
-..  code-block:: bash
-
-    $ sudo tt instances
-    List of enabled applications:
-    • example
-
-    $ tarantoolctl start example
-    Starting instance example...
-    Forwarding to 'systemctl start tarantool@example'
-
-    $ tarantoolctl status example
-    Forwarding to 'systemctl status tarantool@example'
-    ● tarantool@example.service - Tarantool Database Server
-        Loaded: loaded (/lib/systemd/system/tarantool@.service; enabled; vendor preset: enabled)
-        Active: active (running)
-        Docs: man:tarantool(1)
-        Main PID: 6698 (tarantool)
-    . . .
-
-    $ sudo tt status
-    • example: RUNNING. PID: 6698.
-
-    $ sudo tt connect example
-    • Connecting to the instance...
-    • Connected to /var/run/tarantool/example.control
-
-    /var/run/tarantool/example.control>
-
-    $ sudo tt stop example
-    • The Instance example (PID = 6698) has been terminated.
-
-    $ tarantoolctl status example
-    Forwarding to 'systemctl status tarantool@example'
-    ○ tarantool@example.service - Tarantool Database Server
-        Loaded: loaded (/lib/systemd/system/tarantool@.service; enabled; vendor preset: enabled)
-        Active: inactive (dead)
-
-Local configuration
-~~~~~~~~~~~~~~~~~~~
-
-If you have a local ``tarantoolctl`` configuration, create a ``tt`` environment
-based on the existing ``.tarantoolctl`` configuration file. To do this, run
-``tt init`` in the directory where the file in located.
-
-Example:
-
-..  code-block:: bash
-
-    $ cat .tarantoolctl
-    default_cfg = {
-        pid_file  = "./run/tarantool",
-        wal_dir   = "./lib/tarantool",
-        memtx_dir = "./lib/tarantool",
-        vinyl_dir = "./lib/tarantool",
-        log       = "./log/tarantool",
-        language  = "Lua",
-    }
-    instance_dir = "./instances.enabled"
-
-    $ tt init
-    • Found existing config '.tarantoolctl'
-    • Environment config is written to 'tt.yaml'
-
-After that, you can start manage Tarantool instances in this environment with ``tt``:
-
-..  code-block:: bash
-
-    $ tt start app1
-    • Starting an instance [app1]...
-
-    $ tt status app1
-    • app1: RUNNING. PID: 33837.
-
-    $ tt stop app1
-    • The Instance app1 (PID = 33837) has been terminated.
-
-    $ tt check app1
-    • Result of check: syntax of file '/home/user/instances.enabled/app1.lua' is OK
-
-Commands difference
-~~~~~~~~~~~~~~~~~~~
-
-Most ``tarantoolctl`` commands look the same in ``tt``: ``tarantoolctl start`` and
-``tt start``, ``tarantoolctl play`` and ``tt play``, and so on. To migrate such
-calls, it is usually enough to replace the utility name. There can be slight differences
-in command flags and format. For details on ``tt`` commands, see the
-:ref:`tt commands reference <tt-commands>`.
-
-The following commands are different in ``tt``:
-
-..  container:: table
-
-    ..  list-table::
-        :widths: 30 70
-        :header-rows: 1
-
-        *   -   ``tarantoolctl`` command
-            -   ``tt`` command
-        *   -   ``tarantoolctl enter``
-            -   ``tt connect``
-        *   -   ``tarantoolctl eval``
-            -   ``tt connect`` with ``-f`` flag
-
-..  note::
-
-    ``tt connect`` also covers ``tarantoolctl connect`` with the same syntax.
-
-Example:
-
-..  code-block:: bash
-
-    # tarantoolctl enter
-    $ tarantoolctl enter app1
-    connected to unix/:./run/tarantool/app1.control
-    unix/:./run/tarantool/app1.control>
-
-    $ tt connect app1
-    • Connecting to the instance...
-    • Connected to /home/user/run/tarantool/app1/app1.control
-
-    # tarantoolctl eval
-    $ tarantoolctl eval app1 eval.lua
-    connected to unix/:./run/tarantool/app1.control
-    ---
-    - 42
-    ...
-
-    # tarantoolctl connect
-    $ tarantoolctl connect localhost:3301
-    connected to localhost:3301
-    localhost:3301>
-
-    $ tt connect app1 -f eval.lua
-    ---
-    - 42
-    ...
-
-    $ tt connect localhost:3301
-    • Connecting to the instance...
-    • Connected to localhost:3301
 
 .. _tarantoolctl-command_format:
 
@@ -381,3 +215,169 @@ Supported options:
 
 * ``--server=server_name`` check this server first, then the usual list.
 * ``--only-server=server_name`` check this server only, ignore the usual list.
+
+.. _tarantoolctl-migration-to-tt:
+
+Migration from tarantoolctl to tt
+---------------------------------
+
+:ref:`tt <tt-cli>` is a command-line utility for managing Tarantool applications
+that comes to replace ``tarantoolctl``. Starting from version 3.0, ``tarantoolctl``
+is no longer shipped as a part of Tarantool distribution; ``tt`` is the only
+recommended tool for managing Tarantool applications from the command line.
+
+``tarantoolctl`` remains fully compatible with Tarantool 2.* versions. However,
+it doesn't receive major updates anymore.
+
+We recommend that you migrate from ``tarantoolctl`` to ``tt`` to ensure the full
+support and timely updates and fixes.
+
+System-wide configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tt`` supports system-wide environment configuration by default. If you have
+Tarantool instances managed by ``tarantoolctl`` in such an environment, you can
+switch to ``tt`` without additional migration steps or use ``tt`` along with ``tarantoolctl``.
+
+Example:
+
+..  code-block:: bash
+
+    $ sudo tt instances
+    List of enabled applications:
+    • example
+
+    $ tarantoolctl start example
+    Starting instance example...
+    Forwarding to 'systemctl start tarantool@example'
+
+    $ tarantoolctl status example
+    Forwarding to 'systemctl status tarantool@example'
+    ● tarantool@example.service - Tarantool Database Server
+        Loaded: loaded (/lib/systemd/system/tarantool@.service; enabled; vendor preset: enabled)
+        Active: active (running)
+        Docs: man:tarantool(1)
+        Main PID: 6698 (tarantool)
+    . . .
+
+    $ sudo tt status
+    • example: RUNNING. PID: 6698.
+
+    $ sudo tt connect example
+    • Connecting to the instance...
+    • Connected to /var/run/tarantool/example.control
+
+    /var/run/tarantool/example.control>
+
+    $ sudo tt stop example
+    • The Instance example (PID = 6698) has been terminated.
+
+    $ tarantoolctl status example
+    Forwarding to 'systemctl status tarantool@example'
+    ○ tarantool@example.service - Tarantool Database Server
+        Loaded: loaded (/lib/systemd/system/tarantool@.service; enabled; vendor preset: enabled)
+        Active: inactive (dead)
+
+Local configuration
+~~~~~~~~~~~~~~~~~~~
+
+If you have a local ``tarantoolctl`` configuration, create a ``tt`` environment
+based on the existing ``.tarantoolctl`` configuration file. To do this, run
+``tt init`` in the directory where the file in located.
+
+Example:
+
+..  code-block:: bash
+
+    $ cat .tarantoolctl
+    default_cfg = {
+        pid_file  = "./run/tarantool",
+        wal_dir   = "./lib/tarantool",
+        memtx_dir = "./lib/tarantool",
+        vinyl_dir = "./lib/tarantool",
+        log       = "./log/tarantool",
+        language  = "Lua",
+    }
+    instance_dir = "./instances.enabled"
+
+    $ tt init
+    • Found existing config '.tarantoolctl'
+    • Environment config is written to 'tt.yaml'
+
+After that, you can start manage Tarantool instances in this environment with ``tt``:
+
+..  code-block:: bash
+
+    $ tt start app1
+    • Starting an instance [app1]...
+
+    $ tt status app1
+    • app1: RUNNING. PID: 33837.
+
+    $ tt stop app1
+    • The Instance app1 (PID = 33837) has been terminated.
+
+    $ tt check app1
+    • Result of check: syntax of file '/home/user/instances.enabled/app1.lua' is OK
+
+Commands difference
+~~~~~~~~~~~~~~~~~~~
+
+Most ``tarantoolctl`` commands look the same in ``tt``: ``tarantoolctl start`` and
+``tt start``, ``tarantoolctl play`` and ``tt play``, and so on. To migrate such
+calls, it is usually enough to replace the utility name. There can be slight differences
+in command flags and format. For details on ``tt`` commands, see the
+:ref:`tt commands reference <tt-commands>`.
+
+The following commands are different in ``tt``:
+
+..  container:: table
+
+    ..  list-table::
+        :widths: 30 70
+        :header-rows: 1
+
+        *   -   ``tarantoolctl`` command
+            -   ``tt`` command
+        *   -   ``tarantoolctl enter``
+            -   ``tt connect``
+        *   -   ``tarantoolctl eval``
+            -   ``tt connect`` with ``-f`` flag
+
+..  note::
+
+    ``tt connect`` also covers ``tarantoolctl connect`` with the same syntax.
+
+Example:
+
+..  code-block:: bash
+
+    # tarantoolctl enter > tt connect
+    $ tarantoolctl enter app1
+    connected to unix/:./run/tarantool/app1.control
+    unix/:./run/tarantool/app1.control>
+
+    $ tt connect app1
+    • Connecting to the instance...
+    • Connected to /home/user/run/tarantool/app1/app1.control
+
+    # tarantoolctl eval > tt connect -f
+    $ tarantoolctl eval app1 eval.lua
+    connected to unix/:./run/tarantool/app1.control
+    ---
+    - 42
+    ...
+
+   $ tt connect app1 -f eval.lua
+    ---
+    - 42
+    ...
+
+    # tarantoolctl connect > tt connect
+    $ tarantoolctl connect localhost:3301
+    connected to localhost:3301
+    localhost:3301>
+
+    $ tt connect localhost:3301
+    • Connecting to the instance...
+    • Connected to localhost:3301

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -236,6 +236,7 @@ as part of Tarantool distribution -- see OS-specific default paths in
 :ref:`Notes for operating systems <admin-os_notes>`):
 
 .. code-block:: lua
+
    default_cfg = {
        pid_file  = "/var/run/tarantool",
        wal_dir   = "/var/lib/tarantool",
@@ -246,6 +247,7 @@ as part of Tarantool distribution -- see OS-specific default paths in
        language  = "Lua",
    }
    instance_dir = "/etc/tarantool/instances.enabled"
+
 where:
 
 * | ``pid_file``

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -216,6 +216,72 @@ Supported options:
 * ``--server=server_name`` check this server first, then the usual list.
 * ``--only-server=server_name`` check this server only, ignore the usual list.
 
+.. _tarantoolctl-config_file:
+
+tarantoolctl configuration file
+-------------------------------
+
+While instance files contain instance configuration, the ``tarantoolctl``
+configuration file contains the configuration that ``tarantoolctl`` uses to
+override instance configuration. In other words, it contains system-wide
+configuration defaults. If ``tarantoolctl`` fails to find this file with
+the method described in section
+:ref:`Starting/stopping an instance <admin-start_stop_instance>`, it uses
+default settings.
+
+Most of the parameters are similar to those used by
+:doc:`box.cfg{} </reference/reference_lua/box_cfg>`. Here are the default settings
+(possibly installed in ``/etc/default/tarantool`` or ``/etc/sysconfig/tarantool``
+as part of Tarantool distribution -- see OS-specific default paths in
+:ref:`Notes for operating systems <admin-os_notes>`):
+
+.. code-block:: lua
+   default_cfg = {
+       pid_file  = "/var/run/tarantool",
+       wal_dir   = "/var/lib/tarantool",
+       memtx_dir = "/var/lib/tarantool",
+       vinyl_dir = "/var/lib/tarantool",
+       log       = "/var/log/tarantool",
+       username  = "tarantool",
+       language  = "Lua",
+   }
+   instance_dir = "/etc/tarantool/instances.enabled"
+where:
+
+* | ``pid_file``
+  | Directory for the pid file and control-socket file; ``tarantoolctl`` will
+    add “/instance_name” to the directory name.
+* | ``wal_dir``
+  | Directory for write-ahead .xlog files; ``tarantoolctl`` will add
+    "/instance_name" to the directory name.
+* | ``memtx_dir``
+  | Directory for snapshot .snap files; ``tarantoolctl`` will add
+    "/instance_name" to the directory name.
+* | ``vinyl_dir``
+  | Directory for vinyl files; ``tarantoolctl`` will add "/instance_name" to the
+    directory name.
+* | ``log``
+  | The place where the application log will go; ``tarantoolctl`` will add
+    "/instance_name.log" to the name.
+* | ``username``
+  | The user that runs the Tarantool instance. This is the operating-system user
+    name rather than the Tarantool-client user name. Tarantool will change its
+    effective user to this user after becoming a daemon.
+* | ``language``
+  | The :ref:`interactive console <interactive_console>` language. Can be either ``Lua`` or ``SQL``.
+
+* | ``instance_dir``
+  | The directory where all instance files for this host are stored. Put
+    instance files in this directory, or create symbolic links.
+
+  The default instance directory depends on Tarantool's ``WITH_SYSVINIT``
+  build option: when ON, it is ``/etc/tarantool/instances.enabled``,
+  otherwise (OFF or not set) it is ``/etc/tarantool/instances.available``.
+  The latter case is typical for Tarantool builds for Linux distros with
+  ``systemd``.
+
+  To check the build options, say ``tarantool --version``.
+
 .. _tarantoolctl-migration-to-tt:
 
 Migration from tarantoolctl to tt

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -313,6 +313,39 @@ If you use a different log rotation program, you can invoke
 ``tarantoolctl logrotate`` command to request instances to reopen their log
 files after they were moved by the program of your choice.
 
+.. _tarantoolctl-freebsd:
+
+Using tarantooctl on FreeBSD
+----------------------------
+
+
+To make ``tarantoolctl`` work along with ``init.d`` utilities on FreeBSD, use
+paths other than those suggested in
+:ref:`Instance configuration <admin-instance_config>`. Instead of
+``/usr/share/tarantool/`` directory, use ``/usr/local/etc/tarantool/`` and
+create the following subdirectories:
+
+* ``default`` for ``tarantoolctl`` defaults (see example below),
+* ``instances.available`` for all available instance files, and
+* ``instances.enabled`` for instance files to be auto-started by sysvinit.
+
+Here is an example of ``tarantoolctl`` defaults on FreeBSD:
+
+.. code-block:: lua
+
+   default_cfg = {
+       pid_file   = "/var/run/tarantool", -- /var/run/tarantool/${INSTANCE}.pid
+       wal_dir    = "/var/db/tarantool", -- /var/db/tarantool/${INSTANCE}/
+       snap_dir   = "/var/db/tarantool", -- /var/db/tarantool/${INSTANCE}
+       vinyl_dir = "/var/db/tarantool", -- /var/db/tarantool/${INSTANCE}
+       logger     = "/var/log/tarantool", -- /var/log/tarantool/${INSTANCE}.log
+       username   = "admin"
+   }
+
+   -- instances.available - all available instances
+   -- instances.enabled - instances to autostart by sysvinit
+   instance_dir = "/usr/local/etc/tarantool/instances.available"
+
 .. _tarantoolctl-migration-to-tt:
 
 Migration from tarantoolctl to tt

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -401,7 +401,7 @@ Example:
     • Found existing config '.tarantoolctl'
     • Environment config is written to 'tt.yaml'
 
-After that, you can start manage Tarantool instances in this environment with ``tt``:
+After that, you can start managing Tarantool instances in this environment with ``tt``:
 
 ..  code-block:: bash
 

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -221,8 +221,8 @@ Supported options:
 tarantoolctl configuration file
 -------------------------------
 
-While instance files contain instance configuration, the ``tarantoolctl``
-configuration file contains the configuration that ``tarantoolctl`` uses to
+The ``tarantoolctl`` configuration file named ``.tarantoolctl``
+contains the configuration that ``tarantoolctl`` uses to
 override instance configuration. In other words, it contains system-wide
 configuration defaults. If ``tarantoolctl`` fails to find this file with
 the method described in section

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -7,7 +7,7 @@ Utility tarantoolctl (deprecated)
 
     ``tarantoolctl`` is deprecated in favor of :ref:`tt CLI <tt-cli>`.
     Find the instructions on switching from ``tarantoolctl`` to ``tt`` in
-    :ref:`Migration from tarantoolctl to tt <tarantoolctl-migration-to-tt>``.
+    :ref:`Migration from tarantoolctl to tt <tarantoolctl-migration-to-tt>`.
 
 ``tarantoolctl`` is a utility for administering Tarantool
 :ref:`instances <tarantoolctl-instance_management>`,

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -282,6 +282,37 @@ where:
 
   To check the build options, say ``tarantool --version``.
 
+.. _tarantoolctl-log-rotation:
+
+Log rotation in tarantooctl
+---------------------------
+
+With ``tarantoolctl``, :ref:`log rotation <admin-logs>` is pre-configured to use
+``logrotate`` program, which you must have installed.
+
+File ``/etc/logrotate.d/tarantool`` is part of the standard Tarantool
+distribution, and you can modify it to change the default behavior. This is what
+this file is usually like:
+
+.. code-block:: text
+
+   /var/log/tarantool/*.log {
+       daily
+       size 512k
+       missingok
+       rotate 10
+       compress
+       delaycompress
+       create 0640 tarantool adm
+       postrotate
+           /usr/bin/tt logrotate `basename ${1%%.*}`
+       endscript
+   }
+
+If you use a different log rotation program, you can invoke
+``tarantoolctl logrotate`` command to request instances to reopen their log
+files after they were moved by the program of your choice.
+
 .. _tarantoolctl-migration-to-tt:
 
 Migration from tarantoolctl to tt

--- a/doc/reference/tooling/tarantoolctl.rst
+++ b/doc/reference/tooling/tarantoolctl.rst
@@ -7,7 +7,7 @@ Utility tarantoolctl (deprecated)
 
     ``tarantoolctl`` is deprecated in favor of :ref:`tt CLI <tt-cli>`.
     Find the instructions on switching from ``tarantoolctl`` to ``tt`` in
-    :ref:` Migration from tarantooctl to tt <tarantoolctl-migration-to-tt>``.
+    :ref:` Migration from tarantoolctl to tt <tarantoolctl-migration-to-tt>``.
 
 ``tarantoolctl`` is a utility for administering Tarantool
 :ref:`instances <tarantoolctl-instance_management>`,
@@ -25,7 +25,7 @@ Migration from tarantoolctl to tt
 ---------------------------------
 
 :ref:``tt <tt-cli>`` is a command-line utility for managing Tarantool applications
-that comes to replace ``tarantoolctl``. Starting from version 3.0, ``tarantooctl``
+that comes to replace ``tarantoolctl``. Starting from version 3.0, ``tarantoolctl``
 is no longer shipped as a part of Tarantool distribution; ``tt`` is the only
 recommended tool for managing Tarantool application from the command line.
 
@@ -40,7 +40,7 @@ System-wide configuration
 
 ``tt`` supports system-wide environment configuration by default. If you have
 Tarantool instances managed by ``tarantoolctl`` in such an environment, you can
-switch to ``tt`` without additional migration steps or use ``tt`` along with ``tarantooctl``.
+switch to ``tt`` without additional migration steps or use ``tt`` along with ``tarantoolctl``.
 
 Example:
 
@@ -126,7 +126,7 @@ After that, you can start manage Tarantool instances in this environment with ``
 Commands difference
 ~~~~~~~~~~~~~~~~~~~
 
-Most ``tarantooctl`` commands look the same in ``tt``: ``tarantoolctl start`` and
+Most ``tarantoolctl`` commands look the same in ``tt``: ``tarantoolctl start`` and
 ``tt start``, ``tarantoolctl play`` and ``tt play``, and so on. To migrate such
 calls, it is usually enough to replace the utility name. There can be slight differences
 in command flags and format. For details on ``tt`` commands, see the
@@ -140,9 +140,9 @@ The following commands are different in ``tt``:
         :widths: 30 70
         :header-rows: 1
 
-        *   -   ``tarantooctl`` command
+        *   -   ``tarantoolctl`` command
             -   ``tt`` command
-        *   -   ``tarantooctl enter``
+        *   -   ``tarantoolctl enter``
             -   ``tt connect``
         *   -   ``tarantoolctl eval``
             -   ``tt connect`` with ``-f`` flag
@@ -155,7 +155,7 @@ Example:
 
 ..  code-block:: bash
 
-    # tarantooctl enter
+    # tarantoolctl enter
     $ tarantoolctl enter app1
     connected to unix/:./run/tarantool/app1.control
     unix/:./run/tarantool/app1.control>
@@ -164,14 +164,14 @@ Example:
     • Connecting to the instance...
     • Connected to /home/user/run/tarantool/app1/app1.control
 
-    # tarantooctl eval
+    # tarantoolctl eval
     $ tarantoolctl eval app1 eval.lua
     connected to unix/:./run/tarantool/app1.control
     ---
     - 42
     ...
 
-    # tarantooctl connect
+    # tarantoolctl connect
     $ tarantoolctl connect localhost:3301
     connected to localhost:3301
     localhost:3301>

--- a/doc/reference/tooling/tt_cli/cat.rst
+++ b/doc/reference/tooling/tt_cli/cat.rst
@@ -1,3 +1,5 @@
+.. _tt-cat:
+
 Printing the contents of .snap and .xlog files
 ==============================================
 

--- a/doc/reference/tooling/tt_cli/check.rst
+++ b/doc/reference/tooling/tt_cli/check.rst
@@ -1,3 +1,5 @@
+.. _tt-check:
+
 Checking an application file
 ============================
 

--- a/doc/reference/tooling/tt_cli/completion.rst
+++ b/doc/reference/tooling/tt_cli/completion.rst
@@ -1,3 +1,5 @@
+.. _tt-completion:
+
 Generating completion for tt
 ============================
 

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -71,6 +71,13 @@ app section
     Default: ``var/lib``.
 *   ``vinyl_dir`` -- the directory where vinyl files or subdirectories are stored.
     Default: ``var/lib``.
+
+    .. note::
+
+    In all directories specified in ``*_dir`` parameters, ``tt`` creates separate
+    directories for each instance in the environment. Their names match the instances'
+    names.
+
 *   ``log_maxsize`` -- the maximum size of the log file before it gets rotated,
     in megabytes. Default: 100.
 *   ``log_maxage`` -- the maximum age of log files in days. The age of a log

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -1,3 +1,5 @@
+.. _tt-config:
+
 Configuration
 =============
 

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -76,7 +76,7 @@ app section
 
         In all directories specified in ``*_dir`` parameters, ``tt`` creates a
         directory for each application and instance directories inside it.
-        Names is these directories match the names of applications and instances.
+        Names of these directories match the names of applications and instances.
 
 *   ``log_maxsize`` -- the maximum size of the log file before it gets rotated,
     in megabytes. Default: 100.

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -74,9 +74,9 @@ app section
 
     .. note::
 
-        In all directories specified in ``*_dir`` parameters, ``tt`` creates separate
-        directories for each instance in the environment. Their names match the instances'
-        names.
+        In all directories specified in ``*_dir`` parameters, ``tt`` creates a
+        directory for each application and instance directories inside it.
+        Names is these directories match the names of applications and instances.
 
 *   ``log_maxsize`` -- the maximum size of the log file before it gets rotated,
     in megabytes. Default: 100.

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -74,9 +74,9 @@ app section
 
     .. note::
 
-    In all directories specified in ``*_dir`` parameters, ``tt`` creates separate
-    directories for each instance in the environment. Their names match the instances'
-    names.
+        In all directories specified in ``*_dir`` parameters, ``tt`` creates separate
+        directories for each instance in the environment. Their names match the instances'
+        names.
 
 *   ``log_maxsize`` -- the maximum size of the log file before it gets rotated,
     in megabytes. Default: 100.

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -18,7 +18,7 @@ You can also pass the configuration file explicitly in the ``--cfg``
 
 The ``tt`` configuration file is a YAML file with the following content:
 
-..  code:: yaml
+..  code-block:: yaml
 
     tt:
       modules:

--- a/doc/reference/tooling/tt_cli/create.rst
+++ b/doc/reference/tooling/tt_cli/create.rst
@@ -72,7 +72,7 @@ All sections are optional.
 
 Example:
 
-..  code:: yaml
+..  code-block:: yaml
 
     description: Template description
     vars:
@@ -123,7 +123,7 @@ A variable can have the following attributes:
 
 Example:
 
-..  code:: yaml
+..  code-block:: yaml
 
     vars:
       - prompt: Cluster cookie

--- a/doc/reference/tooling/tt_cli/external_modules.rst
+++ b/doc/reference/tooling/tt_cli/external_modules.rst
@@ -35,7 +35,7 @@ Location
 External modules must be located in the modules directory specified in the
 :ref:`configuration file <tt-config_file>`:
 
-    ..  code:: yaml
+    ..  code-block:: yaml
 
         tt:
           modules:

--- a/doc/reference/tooling/tt_cli/external_modules.rst
+++ b/doc/reference/tooling/tt_cli/external_modules.rst
@@ -1,4 +1,4 @@
-.. _tt-external_modules::
+.. _tt-external_modules:
 
 Extending the tt functionality
 ==============================

--- a/doc/reference/tooling/tt_cli/external_modules.rst
+++ b/doc/reference/tooling/tt_cli/external_modules.rst
@@ -1,3 +1,5 @@
+.. _tt-external_modules::
+
 Extending the tt functionality
 ==============================
 

--- a/doc/reference/tooling/tt_cli/help.rst
+++ b/doc/reference/tooling/tt_cli/help.rst
@@ -1,3 +1,5 @@
+.. _tt-help:
+
 Displaying help for tt and its commands
 =======================================
 

--- a/doc/reference/tooling/tt_cli/index.rst
+++ b/doc/reference/tooling/tt_cli/index.rst
@@ -13,6 +13,17 @@ Here you can find its source code, the changelog, and usage examples.
 This section provides instructions on ``tt`` installation and configuration,
 concept explanation, and the ``tt`` command reference.
 
+.. toctree::
+    :maxdepth: 1
+    :numbered: 0
+
+    installation
+    configuration
+    arguments
+    commands
+    external_modules
+    multiple_instances
+
 tt environments
 ---------------
 
@@ -26,13 +37,13 @@ you can think of ``tt`` environments as their analog.
 each running on its own Tarantool version and configuration, on a single host in
 an isolated manner.
 
-To create a `tt`` environment in a directory, run :ref:`tt init <tt-init>` in it.
+To create a ``tt`` environment in a directory, run :ref:`tt init <tt-init>` in it.
 
 Multi-instance applications
 ---------------------------
 
 ``tt`` supports Tarantool applications that run on multiple instances. For example,
-you can write an application that includes different code for storage and router
+you can write an application that includes different source files for storage and router
 instances. With ``tt``, you can start and stop them in a single call, or manage
 each instance independently.
 
@@ -48,13 +59,3 @@ The instructions on migration to ``tt`` are provided on the corresponding docume
 pages: :ref:`tarantoolctl <tarantoolctl-migration-to-tt>` and :doc:`Cartridge CLI </book/cartridge/cartridge_cli/index>`.
 
 
-.. toctree::
-    :maxdepth: 1
-    :numbered: 0
-
-    installation
-    configuration
-    arguments
-    commands
-    external_modules
-    multiple_instances

--- a/doc/reference/tooling/tt_cli/index.rst
+++ b/doc/reference/tooling/tt_cli/index.rst
@@ -27,7 +27,7 @@ concept explanation, and the ``tt`` command reference.
 tt environments
 ---------------
 
-The key aspect of the ``tt`` usage is an *environment*. An ``tt`` environment
+The key aspect of the ``tt`` usage is an *environment*. A ``tt`` environment
 is a directory that includes a ``tt`` configuration, Tarantool installations,
 application files, and other resources. If you're familiar with `Python virtual
 environments <https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment>`_,

--- a/doc/reference/tooling/tt_cli/index.rst
+++ b/doc/reference/tooling/tt_cli/index.rst
@@ -7,15 +7,46 @@ tt CLI utility
 Tarantool-based applications. It covers a wide range of tasks -- from installing
 a specific Tarantool version to managing remote instances and developing applications.
 
-A multi-purpose tool for working with Tarantool from the command line, ``tt`` is
-a potential replacement for :ref:`tarantoolctl <tarantoolctl>`
-and :doc:`Cartridge CLI </book/cartridge/cartridge_cli/index>`.
-
 ``tt`` is developed in its own `GitHub repository <https://github.com/tarantool/tt>`_.
 Here you can find its source code, the changelog, and usage examples.
 
-In this section, you will find instructions on ``tt`` installation and configuration,
-concept explanation, and the command reference.
+This section provides instructions on ``tt`` installation and configuration,
+concept explanation, and the ``tt`` command reference.
+
+tt environments
+---------------
+
+The key aspect of the ``tt`` usage is an *environment*. An ``tt`` environment
+is a directory that includes a ``tt`` configuration, Tarantool installations,
+application files, and other resources. If you're familiar with `Python virtual
+environments <https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment>`_,
+you can think of ``tt`` environments as their analog.
+
+``tt`` environments enable independent management of multiple Tarantool applications,
+each running on its own Tarantool version and configuration, on a single host in
+an isolated manner.
+
+To create a `tt`` environment in a directory, run :ref:`tt init <tt-init>` in it.
+
+Multi-instance applications
+---------------------------
+
+``tt`` supports Tarantool applications that run on multiple instances. For example,
+you can write an application that includes different code for storage and router
+instances. With ``tt``, you can start and stop them in a single call, or manage
+each instance independently.
+
+Learn more about working with multi-instance applications in :ref:`Managing multiple instances <tt-multi-instances>`.
+
+Replacement for tarantooctl and Cartridge CLI
+---------------------------------------------
+
+A multi-purpose tool for working with Tarantool from the command line, ``tt`` has
+come to replace :ref:`tarantoolctl <tarantoolctl>`
+and :doc:`Cartridge CLI </book/cartridge/cartridge_cli/index>` command-line utilities.
+The instructions on migration to ``tt`` are provided on the corresponding documentation
+pages: :ref:`tarantoolctl <tarantoolctl-migration-to-tt>` and :doc:`Cartridge CLI </book/cartridge/cartridge_cli/index>`.
+
 
 .. toctree::
     :maxdepth: 1

--- a/doc/reference/tooling/tt_cli/index.rst
+++ b/doc/reference/tooling/tt_cli/index.rst
@@ -8,7 +8,7 @@ Tarantool-based applications. It covers a wide range of tasks -- from installing
 a specific Tarantool version to managing remote instances and developing applications.
 
 ``tt`` is developed in its own `GitHub repository <https://github.com/tarantool/tt>`_.
-Here you can find its source code, the changelog, and usage examples.
+Here you can find its source code, changelog, and releases information.
 
 This section provides instructions on ``tt`` installation and configuration,
 concept explanation, and the ``tt`` command reference.

--- a/doc/reference/tooling/tt_cli/logrotate.rst
+++ b/doc/reference/tooling/tt_cli/logrotate.rst
@@ -1,6 +1,6 @@
 .. _tt-logrotate:
 
-Rotate instance logs
+Rotating instance logs
 ====================
 
 ..  code-block:: bash

--- a/doc/reference/tooling/tt_cli/logrotate.rst
+++ b/doc/reference/tooling/tt_cli/logrotate.rst
@@ -1,7 +1,7 @@
 .. _tt-logrotate:
 
 Rotating instance logs
-====================
+======================
 
 ..  code-block:: bash
 

--- a/doc/reference/tooling/tt_cli/logrotate.rst
+++ b/doc/reference/tooling/tt_cli/logrotate.rst
@@ -1,3 +1,5 @@
+.. _tt-logrotate:
+
 Rotate instance logs
 ====================
 

--- a/doc/reference/tooling/tt_cli/multiple_instances.rst
+++ b/doc/reference/tooling/tt_cli/multiple_instances.rst
@@ -23,7 +23,7 @@ This directory should contain the following files:
 *   The application file named ``init.lua``.
 *   The instances configuration file ``instances.yml`` with instance names followed by colons:
 
-    ..  code:: yaml
+    ..  code-block:: yaml
 
         <instance_name1>:
         <instance_name2>:
@@ -67,7 +67,7 @@ contains the following files:
 
 *   ``instances.yml`` -- the instances configuration:
 
-    ..  code:: yaml
+    ..  code-block:: yaml
 
         master:
         replica:

--- a/doc/reference/tooling/tt_cli/play.rst
+++ b/doc/reference/tooling/tt_cli/play.rst
@@ -1,3 +1,5 @@
+.. _tt-play:
+
 Playing the contents of .snap and .xlog files to a Tarantool instance
 =====================================================================
 

--- a/doc/reference/tooling/tt_cli/restart.rst
+++ b/doc/reference/tooling/tt_cli/restart.rst
@@ -1,3 +1,5 @@
+.. _tt-restart:
+
 Restarting a Tarantool instance
 ===============================
 

--- a/doc/reference/tooling/tt_cli/rocks.rst
+++ b/doc/reference/tooling/tt_cli/rocks.rst
@@ -1,3 +1,5 @@
+.. _tt-rocks:
+
 Using the LuaRocks package manager
 ==================================
 

--- a/doc/reference/tooling/tt_cli/version.rst
+++ b/doc/reference/tooling/tt_cli/version.rst
@@ -1,3 +1,5 @@
+.. _tt-version:
+
 Displaying the tt version
 =========================
 


### PR DESCRIPTION
Resolves #3501 


Deployment: https://docs.d.tarantool.io/ru/doc/gh-3501-tarantoolctl-to-tt/

Affected pages (to check specific changes on staging):
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/daemon_supervision/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/disaster_recovery/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/instance_config/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/logs/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/modules/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/os_notes/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/replication/repl_recover/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/security/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/server_introspection/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/troubleshoot/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/book/admin/vshard_admin/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/concepts/data_model/migrations/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/dev_guide/internals/iproto/requests/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/how-to/app/creating_app/avro_schemas/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/how-to/sql/improving_mysql/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/how-to/vshard_quick/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/reference/configuration/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/reference/reference_lua/fiber/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/reference/tooling/interactive_console/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/reference/tooling/tarantoolctl/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/reference/tooling/tt_cli/
- https://docs.d.tarantool.io/en/doc/gh-3501-tarantoolctl-to-tt/reference/tooling/tt_cli/configuration/