### PR TITLE
SQL constraint changes

### DIFF
--- a/doc/code_snippets/test/sql/check_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/check_table_constraint_test.lua
@@ -1,0 +1,47 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+    cg.server:drop()
+end)
+
+g.test_space_is_updated = function(cg)
+    cg.server:exec(function()
+        box.execute([[
+            -- create_author_table_start
+            CREATE TABLE author (
+                id INTEGER PRIMARY KEY,
+                name STRING,
+                CONSTRAINT check_name_length CHECK (CHAR_LENGTH(name) > 4)
+            );
+            -- create_author_table_end
+        ]])
+        box.execute([[
+            -- insert_authors_start
+            INSERT INTO author VALUES (1, 'Leo Tolstoy'),
+                                      (2, 'Fyodor Dostoevsky');
+            -- insert_authors_end
+        ]])
+        local _, insert_author_err = box.execute([[
+            -- insert_short_name_start
+            INSERT INTO author VALUES (3, 'Alex');
+            /*
+            - Check constraint 'CHECK_NAME_LENGTH' failed for tuple
+            */
+            -- insert_short_name_end
+        ]])
+
+        -- Tests
+        t.assert_equals(insert_author_err:unpack().message, "Check constraint 'CHECK_NAME_LENGTH' failed for tuple")
+    end)
+end

--- a/doc/code_snippets/test/sql/primary_key_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/primary_key_table_constraint_test.lua
@@ -1,0 +1,72 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+    cg.server:drop()
+end)
+
+g.test_space_is_updated = function(cg)
+    cg.server:exec(function()
+        box.execute([[
+            -- create_author_table_start
+            CREATE TABLE author (
+                id INTEGER PRIMARY KEY,
+                name STRING NOT NULL
+            );
+            -- create_author_table_end
+        ]])
+        box.execute([[
+            -- insert_authors_start
+            INSERT INTO author VALUES (1, 'Leo Tolstoy'),
+                                      (2, 'Fyodor Dostoevsky');
+            -- insert_authors_end
+        ]])
+        local _, insert_author_err = box.execute([[
+            -- insert_duplicate_author_start
+            INSERT INTO author VALUES (2, 'Alexander Pushkin');
+            /*
+            - Duplicate key exists in unique index "pk_unnamed_AUTHOR_1" in space "AUTHOR" with
+              old tuple - [2, "Fyodor Dostoevsky"] and new tuple - [2, "Alexander Pushkin"]
+            */
+            -- insert_duplicate_author_end
+        ]])
+        box.execute([[
+            -- create_book_table_start
+            CREATE TABLE book (
+                id INTEGER,
+                title STRING NOT NULL,
+                PRIMARY KEY (id, title)
+            );
+            -- create_book_table_end
+        ]])
+        box.execute([[
+            -- insert_books_start
+            INSERT INTO book VALUES (1, 'War and Peace'),
+                                    (2, 'Crime and Punishment');
+            -- insert_books_end
+        ]])
+        local _, insert_book_err = box.execute([[
+            -- insert_duplicate_book_start
+            INSERT INTO book VALUES (2, 'Crime and Punishment');
+            /*
+            - Duplicate key exists in unique index "pk_unnamed_BOOK_1" in space "BOOK" with old
+              tuple - [2, "Crime and Punishment"] and new tuple - [2, "Crime and Punishment"]
+            */
+            -- insert_duplicate__book_end
+        ]])
+
+        -- Tests
+        t.assert_equals(insert_author_err:unpack().message, "Duplicate key exists in unique index \"pk_unnamed_AUTHOR_1\" in space \"AUTHOR\" with old tuple - [2, \"Fyodor Dostoevsky\"] and new tuple - [2, \"Alexander Pushkin\"]")
+        t.assert_equals(insert_book_err:unpack().message, "Duplicate key exists in unique index \"pk_unnamed_BOOK_1\" in space \"BOOK\" with old tuple - [2, \"Crime and Punishment\"] and new tuple - [2, \"Crime and Punishment\"]")
+    end)
+end

--- a/doc/code_snippets/test/sql/unique_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/unique_table_constraint_test.lua
@@ -1,0 +1,73 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+    cg.server:drop()
+end)
+
+g.test_space_is_updated = function(cg)
+    cg.server:exec(function()
+        box.execute([[
+            -- create_author_table_start
+            CREATE TABLE author (
+                id INTEGER PRIMARY KEY,
+                name STRING UNIQUE
+            );
+            -- create_author_table_end
+        ]])
+        box.execute([[
+            -- insert_authors_start
+            INSERT INTO author VALUES (1, 'Leo Tolstoy'),
+                                      (2, 'Fyodor Dostoevsky');
+            -- insert_authors_end
+        ]])
+        local _, insert_author_err = box.execute([[
+            -- insert_duplicate_author_start
+            INSERT INTO author VALUES (3, 'Leo Tolstoy');
+            /*
+            - Duplicate key exists in unique index "unique_unnamed_AUTHOR_2" in space "AUTHOR"
+              with old tuple - [1, "Leo Tolstoy"] and new tuple - [3, "Leo Tolstoy"]
+            */
+            -- insert_duplicate_author_end
+        ]])
+        box.execute([[
+            -- create_book_table_start
+            CREATE TABLE book (
+                id INTEGER PRIMARY KEY,
+                title STRING NOT NULL,
+                author_id INTEGER UNIQUE,
+                UNIQUE (title, author_id)
+            );
+            -- create_book_table_end
+        ]])
+        box.execute([[
+            -- insert_books_start
+            INSERT INTO book VALUES (1, 'War and Peace', 1),
+                                    (2, 'Crime and Punishment', 2);
+            -- insert_books_end
+        ]])
+        local _, insert_book_err = box.execute([[
+            -- insert_duplicate_book_start
+            INSERT INTO book VALUES (3, 'War and Peace', 1);
+            /*
+            - Duplicate key exists in unique index "unique_unnamed_BOOK_2" in space "BOOK" with
+              old tuple - [1, "War and Peace", 1] and new tuple - [3, "War and Peace", 1]
+            */
+            -- insert_duplicate__book_end
+        ]])
+
+        -- Tests
+        t.assert_equals(insert_author_err:unpack().message, "Duplicate key exists in unique index \"unique_unnamed_AUTHOR_2\" in space \"AUTHOR\" with old tuple - [1, \"Leo Tolstoy\"] and new tuple - [3, \"Leo Tolstoy\"]")
+        t.assert_equals(insert_book_err:unpack().message, "Duplicate key exists in unique index \"unique_unnamed_BOOK_2\" in space \"BOOK\" with old tuple - [1, \"War and Peace\", 1] and new tuple - [3, \"War and Peace\", 1]")
+    end)
+end


### PR DESCRIPTION
- Updated a table constraint syntax to make it more readable and added new testable examples for all constraint types:
   https://docs.d.tarantool.io/en/doc/sql-constraint-mechanism/reference/reference_sql/sql_statements_and_clauses/#table-constraint-definition
- Added a note about a foreign key's uniqueness checking:
   https://docs.d.tarantool.io/en/doc/sql-constraint-mechanism/reference/reference_sql/sql_statements_and_clauses/#table-constraint-definition-for-foreign-keys