### PR TITLE
3.0: fix tests used in doc samples

### DIFF
--- a/doc/code_snippets/test/checks/checkers_test.lua
+++ b/doc/code_snippets/test/checks/checkers_test.lua
@@ -20,7 +20,7 @@ local is_uint64 = checkers.uint64(2048)
 -- is_int64/is_uint64 = true
 
 -- tuple checker
-local is_tuple = checkers.tuple(box.tuple.new(1, 'The Beatles', 1960))
+local is_tuple = checkers.tuple(box.tuple.new{1, 'The Beatles', 1960})
 -- is_tuple = true
 
 -- uuid checkers

--- a/doc/code_snippets/test/constraints/constraint_sql_expr_test.lua
+++ b/doc/code_snippets/test/constraints/constraint_sql_expr_test.lua
@@ -56,7 +56,7 @@ g.test_constraints = function(cg)
         -- Tests --
         t.assert_equals(customers:count(), 1)
         t.assert_equals(customers:get(1), { 1, "Alice", 30 })
-        t.assert_equals(age_err:unpack().message, 'Check constraint \'check_person\' failed for tuple')
-        t.assert_equals(name_err:unpack().message, 'Check constraint \'check_person\' failed for tuple')
+        t.assert_equals(age_err:unpack().message, 'Check constraint \'check_person\' failed for a tuple')
+        t.assert_equals(name_err:unpack().message, 'Check constraint \'check_person\' failed for a tuple')
     end)
 end

--- a/doc/code_snippets/test/constraints/constraint_sql_expr_test.lua
+++ b/doc/code_snippets/test/constraints/constraint_sql_expr_test.lua
@@ -42,14 +42,14 @@ g.test_constraints = function(cg)
         local _, age_err = pcall(function()
             -- insert_age_error_start
             customers:insert { 2, "Bob", 18 }
-            -- error: Check constraint 'check_person' failed for tuple
+            -- error: Check constraint 'check_person' failed for a tuple
             -- insert_age_error_end
         end)
 
         local _, name_err = pcall(function()
             -- insert_name_error_start
             customers:insert { 3, "Admin", 25 }
-            -- error: Check constraint 'check_person' failed for tuple
+            -- error: Check constraint 'check_person' failed for a tuple
             -- insert_name_error_end
         end)
 

--- a/doc/code_snippets/test/constraints/constraint_sql_expr_test.lua
+++ b/doc/code_snippets/test/constraints/constraint_sql_expr_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_constraints = function(cg)

--- a/doc/code_snippets/test/constraints/constraint_test.lua
+++ b/doc/code_snippets/test/constraints/constraint_test.lua
@@ -51,7 +51,7 @@ g.test_constraints = function(cg)
         t.assert_equals(customers:get(1), {1, "Alice", 30})
 
         -- Failed contstraint --
-        t.assert_error_msg_contains("Check constraint 'check_person' failed for tuple",
+        t.assert_error_msg_contains("Check constraint 'check_person' failed for a tuple",
                 function() customers:insert{2, "Bob", 230} end)
 
         -- Create one more tuple constraint --

--- a/doc/code_snippets/test/constraints/constraint_test.lua
+++ b/doc/code_snippets/test/constraints/constraint_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_constraints = function(cg)

--- a/doc/code_snippets/test/foreign_keys/field_foreign_key_test.lua
+++ b/doc/code_snippets/test/foreign_keys/field_foreign_key_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_foreign_keys = function(cg)

--- a/doc/code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
+++ b/doc/code_snippets/test/foreign_keys/tuple_foreign_key_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_foreign_keys = function(cg)

--- a/doc/code_snippets/test/indexes/create_index_field_number_test.lua
+++ b/doc/code_snippets/test/indexes/create_index_field_number_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_indexes = function(cg)

--- a/doc/code_snippets/test/indexes/create_index_func_multikey_test.lua
+++ b/doc/code_snippets/test/indexes/create_index_func_multikey_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_func_multikey_index = function(cg)

--- a/doc/code_snippets/test/indexes/create_index_func_test.lua
+++ b/doc/code_snippets/test/indexes/create_index_func_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_func_index = function(cg)

--- a/doc/code_snippets/test/indexes/create_index_json_path_test.lua
+++ b/doc/code_snippets/test/indexes/create_index_json_path_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_json_path_index = function(cg)

--- a/doc/code_snippets/test/indexes/create_index_key_parts_test.lua
+++ b/doc/code_snippets/test/indexes/create_index_key_parts_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_indexes = function(cg)

--- a/doc/code_snippets/test/indexes/index_aggr_functions_test.lua
+++ b/doc/code_snippets/test/indexes/index_aggr_functions_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_indexes = function(cg)

--- a/doc/code_snippets/test/indexes/index_custom_function_test.lua
+++ b/doc/code_snippets/test/indexes/index_custom_function_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_indexes = function(cg)

--- a/doc/code_snippets/test/indexes/index_select_test.lua
+++ b/doc/code_snippets/test/indexes/index_select_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_indexes = function(cg)

--- a/doc/code_snippets/test/logging/log_existing_c_modules_test.lua
+++ b/doc/code_snippets/test/logging/log_existing_c_modules_test.lua
@@ -31,8 +31,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 local function find_in_log(cg, str, must_be_present)

--- a/doc/code_snippets/test/logging/log_existing_modules_test.lua
+++ b/doc/code_snippets/test/logging/log_existing_modules_test.lua
@@ -39,8 +39,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 local function find_in_log(cg, str, must_be_present)

--- a/doc/code_snippets/test/logging/log_new_modules_test.lua
+++ b/doc/code_snippets/test/logging/log_new_modules_test.lua
@@ -43,8 +43,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 local function find_in_log(cg, str, must_be_present)

--- a/doc/code_snippets/test/logging/log_test.lua
+++ b/doc/code_snippets/test/logging/log_test.lua
@@ -30,8 +30,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 local function find_in_log(cg, str, must_be_present)

--- a/doc/code_snippets/test/msgpack/msgpack_object_index_test.lua
+++ b/doc/code_snippets/test/msgpack/msgpack_object_index_test.lua
@@ -2,7 +2,7 @@ local msgpack = require('msgpack')
 
 local mp_from_array = msgpack.object({ 10, 20, 30 })
 local mp_from_table = msgpack.object({ band_name = 'The Beatles', year = 1960 })
-local mp_from_tuple = msgpack.object(box.tuple.new(1, 'The Beatles', 1960))
+local mp_from_tuple = msgpack.object(box.tuple.new{1, 'The Beatles', 1960})
 
 -- Get MsgPack data by the specified index or key
 local mp_array_get_by_index = mp_from_array[1] -- Returns 10

--- a/doc/code_snippets/test/msgpack/msgpack_object_test.lua
+++ b/doc/code_snippets/test/msgpack/msgpack_object_test.lua
@@ -5,7 +5,7 @@ local mp_from_number = msgpack.object(123)
 local mp_from_string = msgpack.object('hello world')
 local mp_from_array = msgpack.object({ 10, 20, 30 })
 local mp_from_table = msgpack.object({ band_name = 'The Beatles', year = 1960 })
-local mp_from_tuple = msgpack.object(box.tuple.new(1, 'The Beatles', 1960))
+local mp_from_tuple = msgpack.object(box.tuple.new{1, 'The Beatles', 1960})
 
 -- Create a MsgPack object from a raw MsgPack string
 local raw_mp_string = msgpack.encode({ 10, 20, 30 })

--- a/doc/code_snippets/test/sequence/sequence_test.lua
+++ b/doc/code_snippets/test/sequence/sequence_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_sequence = function(cg)

--- a/doc/code_snippets/test/sql/array_access_test.lua
+++ b/doc/code_snippets/test/sql/array_access_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/sql/check_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/check_table_constraint_test.lua
@@ -36,12 +36,12 @@ g.test_space_is_updated = function(cg)
             -- insert_short_name_start
             INSERT INTO author VALUES (3, 'Alex');
             /*
-            - Check constraint 'CHECK_NAME_LENGTH' failed for tuple
+            - Check constraint 'check_name_length' failed for a tuple
             */
             -- insert_short_name_end
         ]])
 
         -- Tests
-        t.assert_equals(insert_author_err:unpack().message, "Check constraint 'CHECK_NAME_LENGTH' failed for tuple")
+        t.assert_equals(insert_author_err:unpack().message, "Check constraint 'check_name_length' failed for a tuple")
     end)
 end

--- a/doc/code_snippets/test/sql/check_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/check_table_constraint_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/sql/foreign_key_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/foreign_key_table_constraint_test.lua
@@ -53,7 +53,7 @@ g.test_space_is_updated = function(cg)
             -- insert_error_start
             INSERT INTO book VALUES (3, 'Eugene Onegin', 3);
             /*
-            - 'Foreign key constraint ''fk_unnamed_BOOK_1'' failed: foreign tuple was not found'
+            - 'Foreign key constraint ''fk_unnamed_book_1'' failed: foreign tuple was not found'
             */
             -- insert_error_end
         ]])
@@ -61,7 +61,7 @@ g.test_space_is_updated = function(cg)
             -- update_error_start
             UPDATE book SET author_id = 10 WHERE id = 1;
             /*
-            - 'Foreign key constraint ''fk_unnamed_BOOK_1'' failed: foreign tuple was not found'
+            - 'Foreign key constraint ''fk_unnamed_book_1'' failed: foreign tuple was not found'
             */
             -- update_error_end
         ]])
@@ -69,14 +69,14 @@ g.test_space_is_updated = function(cg)
             -- delete_error_start
             DELETE FROM author WHERE id = 2;
             /*
-            - 'Foreign key ''fk_unnamed_BOOK_1'' integrity check failed: tuple is referenced'
+            - 'Foreign key ''fk_unnamed_book_1'' integrity check failed: tuple is referenced'
             */
             -- delete_error_end
         ]])
 
         -- Tests
-        t.assert_equals(insert_err:unpack().message, "Foreign key constraint 'fk_unnamed_BOOK_1' failed: foreign tuple was not found")
-        t.assert_equals(update_err:unpack().message, "Foreign key constraint 'fk_unnamed_BOOK_1' failed: foreign tuple was not found")
-        t.assert_equals(delete_err:unpack().message, "Foreign key 'fk_unnamed_BOOK_1' integrity check failed: tuple is referenced")
+        t.assert_equals(insert_err:unpack().message, "Foreign key constraint 'fk_unnamed_book_1' failed: foreign tuple was not found")
+        t.assert_equals(update_err:unpack().message, "Foreign key constraint 'fk_unnamed_book_1' failed: foreign tuple was not found")
+        t.assert_equals(delete_err:unpack().message, "Foreign key 'fk_unnamed_book_1' integrity check failed: tuple is referenced")
     end)
 end

--- a/doc/code_snippets/test/sql/foreign_key_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/foreign_key_table_constraint_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/sql/map_access_test.lua
+++ b/doc/code_snippets/test/sql/map_access_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/sql/primary_key_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/primary_key_table_constraint_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/sql/primary_key_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/primary_key_table_constraint_test.lua
@@ -35,7 +35,7 @@ g.test_space_is_updated = function(cg)
             -- insert_duplicate_author_start
             INSERT INTO author VALUES (2, 'Alexander Pushkin');
             /*
-            - Duplicate key exists in unique index "pk_unnamed_AUTHOR_1" in space "AUTHOR" with
+            - Duplicate key exists in unique index "pk_unnamed_author_1" in space "author" with
               old tuple - [2, "Fyodor Dostoevsky"] and new tuple - [2, "Alexander Pushkin"]
             */
             -- insert_duplicate_author_end
@@ -59,14 +59,14 @@ g.test_space_is_updated = function(cg)
             -- insert_duplicate_book_start
             INSERT INTO book VALUES (2, 'Crime and Punishment');
             /*
-            - Duplicate key exists in unique index "pk_unnamed_BOOK_1" in space "BOOK" with old
+            - Duplicate key exists in unique index "pk_unnamed_book_1" in space "BOOK" with old
               tuple - [2, "Crime and Punishment"] and new tuple - [2, "Crime and Punishment"]
             */
             -- insert_duplicate__book_end
         ]])
 
         -- Tests
-        t.assert_equals(insert_author_err:unpack().message, "Duplicate key exists in unique index \"pk_unnamed_AUTHOR_1\" in space \"AUTHOR\" with old tuple - [2, \"Fyodor Dostoevsky\"] and new tuple - [2, \"Alexander Pushkin\"]")
-        t.assert_equals(insert_book_err:unpack().message, "Duplicate key exists in unique index \"pk_unnamed_BOOK_1\" in space \"BOOK\" with old tuple - [2, \"Crime and Punishment\"] and new tuple - [2, \"Crime and Punishment\"]")
+        t.assert_equals(insert_author_err:unpack().message, "Duplicate key exists in unique index \"pk_unnamed_author_1\" in space \"author\" with old tuple - [2, \"Fyodor Dostoevsky\"] and new tuple - [2, \"Alexander Pushkin\"]")
+        t.assert_equals(insert_book_err:unpack().message, "Duplicate key exists in unique index \"pk_unnamed_book_1\" in space \"book\" with old tuple - [2, \"Crime and Punishment\"] and new tuple - [2, \"Crime and Punishment\"]")
     end)
 end

--- a/doc/code_snippets/test/sql/unique_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/unique_table_constraint_test.lua
@@ -35,7 +35,7 @@ g.test_space_is_updated = function(cg)
             -- insert_duplicate_author_start
             INSERT INTO author VALUES (3, 'Leo Tolstoy');
             /*
-            - Duplicate key exists in unique index "unique_unnamed_AUTHOR_2" in space "AUTHOR"
+            - Duplicate key exists in unique index "unique_unnamed_author_2" in space "author"
               with old tuple - [1, "Leo Tolstoy"] and new tuple - [3, "Leo Tolstoy"]
             */
             -- insert_duplicate_author_end
@@ -60,14 +60,14 @@ g.test_space_is_updated = function(cg)
             -- insert_duplicate_book_start
             INSERT INTO book VALUES (3, 'War and Peace', 1);
             /*
-            - Duplicate key exists in unique index "unique_unnamed_BOOK_2" in space "BOOK" with
+            - Duplicate key exists in unique index "unique_unnamed_book_2" in space "book" with
               old tuple - [1, "War and Peace", 1] and new tuple - [3, "War and Peace", 1]
             */
             -- insert_duplicate__book_end
         ]])
 
         -- Tests
-        t.assert_equals(insert_author_err:unpack().message, "Duplicate key exists in unique index \"unique_unnamed_AUTHOR_2\" in space \"AUTHOR\" with old tuple - [1, \"Leo Tolstoy\"] and new tuple - [3, \"Leo Tolstoy\"]")
-        t.assert_equals(insert_book_err:unpack().message, "Duplicate key exists in unique index \"unique_unnamed_BOOK_2\" in space \"BOOK\" with old tuple - [1, \"War and Peace\", 1] and new tuple - [3, \"War and Peace\", 1]")
+        t.assert_equals(insert_author_err:unpack().message, "Duplicate key exists in unique index \"unique_unnamed_author_2\" in space \"author\" with old tuple - [1, \"Leo Tolstoy\"] and new tuple - [3, \"Leo Tolstoy\"]")
+        t.assert_equals(insert_book_err:unpack().message, "Duplicate key exists in unique index \"unique_unnamed_book_2\" in space \"book\" with old tuple - [1, \"War and Peace\", 1] and new tuple - [3, \"War and Peace\", 1]")
     end)
 end

--- a/doc/code_snippets/test/sql/unique_table_constraint_test.lua
+++ b/doc/code_snippets/test/sql/unique_table_constraint_test.lua
@@ -11,8 +11,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/transactions/box_atomic_test.lua
+++ b/doc/code_snippets/test/transactions/box_atomic_test.lua
@@ -19,8 +19,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/transactions/box_commit_test.lua
+++ b/doc/code_snippets/test/transactions/box_commit_test.lua
@@ -20,8 +20,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/transactions/box_on_commit_iterator_test.lua
+++ b/doc/code_snippets/test/transactions/box_on_commit_iterator_test.lua
@@ -20,8 +20,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/transactions/box_on_commit_test.lua
+++ b/doc/code_snippets/test/transactions/box_on_commit_test.lua
@@ -20,8 +20,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated = function(cg)

--- a/doc/code_snippets/test/transactions/box_rollback_savepoint_test.lua
+++ b/doc/code_snippets/test/transactions/box_rollback_savepoint_test.lua
@@ -20,8 +20,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_updated_partially = function(cg)

--- a/doc/code_snippets/test/transactions/box_rollback_test.lua
+++ b/doc/code_snippets/test/transactions/box_rollback_test.lua
@@ -20,8 +20,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 g.test_space_is_not_updated = function(cg)

--- a/doc/code_snippets/test/triggers/on_recovery_state_test.lua
+++ b/doc/code_snippets/test/triggers/on_recovery_state_test.lua
@@ -22,8 +22,8 @@ g.before_each(function(cg)
 end)
 
 g.after_each(function(cg)
-    cg.server:stop()
     cg.server:drop()
+    fio.rmtree(cg.server.workdir)
 end)
 
 local function find_in_log(cg, str, must_be_present)


### PR DESCRIPTION
Fixed several issues in tests related to changes in Luatest (version 1.0) and Tarantool 3.0:

Luatest
- Removing temp files.

Tarantool
- A message in constraint errors is changed.
- Names used in SQL samples are lower-case now.
- The `box.tuple.new` syntax is updated.

Examples of doc pages that reference fixed samples:
- https://docs.d.tarantool.io/en/doc/3.0-fix-tests/reference/reference_lua/checks/#lua-function.checkers.tuple
- https://docs.d.tarantool.io/en/doc/3.0-fix-tests/reference/reference_lua/box_schema/func_create/
- https://docs.d.tarantool.io/en/doc/3.0-fix-tests/reference/reference_sql/sql_statements_and_clauses/#table-constraint-definition-for-foreign-keys

<img width="865" alt="image" src="https://github.com/tarantool/doc/assets/38073144/7f97eb0c-cc0c-433a-b489-5e004cd76286">
