### PR TITLE
ci: added workflow to generate and upload docx

### DIFF
--- a/.github/workflows/upload-docx.yml
+++ b/.github/workflows/upload-docx.yml
@@ -1,0 +1,94 @@
+name: Generate DOCX
+
+on:
+  push:
+    branches:
+      - 'latest'
+      - '3.0'
+      - 'lastochka42/generate-docx'
+
+jobs:
+  generate-singlehtml:
+    runs-on: ubuntu-latest
+    container: tarantool/doc-builder:fat-4.3
+    steps:
+      - uses: actions/checkout@v3
+        id: checkout
+        with:
+          submodules: recursive
+
+      - name: generate singlehtml
+        run: |
+          cmake .
+          make pull-modules
+          make build-modules
+          make singlehtml
+          make singlehtml-ru
+
+      - name: save singlehtml-en
+        uses: actions/upload-artifact@v3
+        with:
+          name: singlehtml-en
+          path: output/html/en/singlehtml.html
+
+      - name: save singlehtml-ru
+        uses: actions/upload-artifact@v3
+        with:
+          name: singlehtml-ru
+          path: output/html/ru/singlehtml.html
+
+      - name: save pandoc filters from the repo
+        uses: actions/upload-artifact@v3
+        with:
+          name: pandoc
+          path: pandoc/filter-espd.py
+  
+  generate-docx:
+    needs: generate-singlehtml
+    runs-on: ubuntu-latest
+    container: ghcr.io/tarantool/pandoc-builder:latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      AWS_DEFAULT_REGION: ${{secrets.AWS_DEFAULT_REGION}}
+      S3_ENDPOINT_URL: ${{secrets.S3_ENDPOINT_URL}}
+      S3_UPLOAD_PATH: ${{secrets.S3_DOCX_PATH}}
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: generate docx-en
+        run: |
+          pandoc singlehtml-en/singlehtml.html \
+            --standalone \
+            --verbose \
+            --from html \
+            --to docx \
+            --output tarantool-en.docx \
+            --metadata lang=en \
+            --metadata toc-title='Table of content' \
+            --filter pandoc/filter-espd.py \
+            --table-of-contents \
+            --toc-depth=2
+
+      - name: generate docx-ru
+        run: |
+          pandoc singlehtml-ru/singlehtml.html \
+            --standalone \
+            --verbose \
+            --from html \
+            --to docx \
+            --output tarantool-ru.docx \
+            --metadata lang=ru \
+            --metadata toc-title='Оглавление' \
+            --filter pandoc/filter-espd.py \
+            --table-of-contents \
+            --toc-depth=2 
+
+      - name: Get branch name
+        run: echo "DEPLOYMENT_NAME=$(echo ${{ github.ref }} | sed -r 's|^.*/.*/(.*)$|\1|')" >> $GITHUB_ENV 
+
+      - name: upload docx
+        run: |
+          aws s3 cp tarantool-en.docx ${{ env.S3_UPLOAD_PATH }}/${{ env.DEPLOYMENT_NAME }}/ --endpoint-url=${{ env.S3_ENDPOINT_URL }}
+          aws s3 cp tarantool-ru.docx ${{ env.S3_UPLOAD_PATH }}/${{ env.DEPLOYMENT_NAME }}/ --endpoint-url=${{ env.S3_ENDPOINT_URL }}

--- a/pandoc/filter-espd.py
+++ b/pandoc/filter-espd.py
@@ -1,0 +1,112 @@
+#! /usr/bin/env python
+# encoding: utf-8
+from panflute import run_filter, debug
+from panflute import Link, Para, Str, Header, MetaInlines, Space, Div, HorizontalRule, \
+    BulletList, RawBlock, Span, Emph, Strong, Image, Block, Inline, ListContainer
+
+version = None
+
+pb = RawBlock(u"<w:p><w:r><w:br w:type=\"page\" /></w:r></w:p>", format=u"openxml")
+
+
+def handle_image(elem, doc):
+    if isinstance(elem.content, ListContainer):
+        attributes={'custom-style': 'image'}
+    return elem
+
+
+def handle_header(elem, doc):
+    """
+    Title page header
+    """
+    meta = MetaInlines(Str('Tarantool'))
+    return meta
+
+
+def handle_captions(elem, doc):
+    """
+    Image caption
+    """
+    if isinstance(elem.content[0], Span):
+        _span = elem.content[0]
+        classes = getattr(_span, 'classes', [])
+        if 'caption-text' in classes:
+            attrs = {'custom-style': 'image-caption'}
+            caption_block = Div(elem, attributes=attrs)
+            return caption_block
+        return elem
+
+
+def handle_link(elem, doc):
+    """
+    Transform html urls in docx format
+    """
+    elem.url = elem.url.replace('singlehtml.html', '')
+    return elem
+
+
+def handle_hr(elem, doc):
+    """
+    Remove hr
+    """
+    return []
+
+
+def handle_default(elem, doc):
+    with_classes = getattr(elem, 'classes', [])
+
+    if 'caption-text' in with_classes:
+        elem.attributes = {'custom-style': 'captiontext'}
+        return elem
+
+    if 'image' in with_classes:
+        elem.attributes = {'custom-style': 'image'}
+        return elem
+
+    if 'headerlink' in with_classes:
+        return []
+
+    if 'toc-backref' in with_classes:
+        """
+        Remove headers backrefs
+        """
+        return Span(*elem.content)
+
+    if 'local-toc' in with_classes:
+        """
+        Remove toctree from html template
+        """
+        return []
+
+    if len(with_classes) and with_classes[0] == 'breadcrumbs_and_search':
+        """
+        Remove breadcrumbs
+        """
+        return []
+
+    if len(with_classes) and 'admonition' in with_classes:
+        """
+        Customize admonition styles
+        """
+        elem.attributes = {'custom-style': 'admonitionlist'}
+        elem.content[0].content[0] = Strong(Str('Note'))
+        return elem
+
+
+def action(elem, doc):
+    switcher = {
+        Image: handle_image,
+        MetaInlines: handle_header,
+        Para: handle_captions,
+        Link: handle_link,
+        HorizontalRule: handle_hr,
+    }
+    switcher.get(type(elem), handle_default)(elem, doc)
+
+
+def main(doc=None):
+    return run_filter(action, doc=doc)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added workflow to generate the DOCX documentation and upload it to the S3 storage.

Because `pandoc` works only on Debian Bookworm and documentation build                                                                             
works only on Debian Bullseye, we use separate jobs in separate                                                                                    
containers to build `singlepage` and `pandoc`.

Resolves #3548