### PR TITLE
Add TCM overview

### DIFF
--- a/doc/reference/tooling/index.rst
+++ b/doc/reference/tooling/index.rst
@@ -7,8 +7,9 @@ to work with Tarantool.
 ..  toctree::
     :maxdepth: 1
 
-    interactive_console
     tt_cli/index
+    tcm/index
+    interactive_console
     tarantoolctl
     luajit_memprof
     luajit_getmetrics

--- a/doc/reference/tooling/tcm/index.rst
+++ b/doc/reference/tooling/tcm/index.rst
@@ -1,0 +1,34 @@
+:noindex:
+:fullwidth:
+
+..  _tcm:
+
+Tarantool Cluster Manager
+=========================
+
+..  admonition:: Enterprise Edition
+    :class: fact
+
+    |tcm_full_name| is a part of the `Enterprise Edition <https://www.tarantool.io/compare/>`_.
+
+|tcm_full_name| (|tcm|) is a web-based visual tool for configuring, managing, and
+monitoring Tarantool EE clusters. It provides a GUI for working with clusters
+and individual instances, from monitoring their state to executing commands interactively
+in an instance's console.
+
+|tcm| is a standalone application included in the Tarantool Enterprise Edition
+distribution package. It is shipped as an executable that is ready to run on Linux
+and macOS platforms.
+
+|tcm| works only with Tarantool EE clusters that use :ref:`etcd as a configuration storage <configuration_etcd>`.
+When you create or edit a cluster's configuration in |tcm|, it publishes the saved
+configuration to etcd. This ensures consistent and reliable configuration storage.
+A single |tcm| installation can connect to multiple Tarantool EE clusters and
+switch between them in one click.
+
+To provide enterprise-grade security, |tcm| features its own role-based access control.
+You can create users and assign them roles that include required permissions.
+For example, a user can be an administrator of a specific cluster or only have the right
+to read data. LDAP authorization is supported as well.
+
+..  TODO: table of contents

--- a/doc/reference/tooling/tcm/index.rst
+++ b/doc/reference/tooling/tcm/index.rst
@@ -1,6 +1,3 @@
-:noindex:
-:fullwidth:
-
 ..  _tcm:
 
 Tarantool Cluster Manager

--- a/prolog.rst
+++ b/prolog.rst
@@ -36,3 +36,9 @@
 
 .. |iproto_version| replace:: 3
 
+.. |tcm_full_name| replace:: Tarantool Cluster Manager
+
+.. |tcm| replace:: TCM
+
+.. |tcm_version| replace:: TCM
+

--- a/styles/Vocab/Tarantool/accept.txt
+++ b/styles/Vocab/Tarantool/accept.txt
@@ -46,3 +46,4 @@ vshard
 boolean
 failover
 rebalancer
+TCM


### PR DESCRIPTION
Resolves #3601 

- Add new section **Tarantool Cluster Manager** in **Tooling**
- Write a general TCM overview

Deployment: https://docs.d.tarantool.io/en/doc/gh-3601-tcm-section/reference/tooling/tcm/

**Important notes:**
1.   **The page location is temporary**. The whole TCM section will be moved in scope of 3.0 docs restructurization (#3817) to be more discoverable and fit into the [new structure](https://www.notion.so/tarantool/Tarantool-CE-c075d0db9ce24893beca704c145ae501?pvs=4#c59f608e129545c5ab8005f1ba3daa9d).
2. **The content will change too**. I plan to add more feature descriptions to the overview page when writing specific pages inside the TCM section.
