### PR TITLE
ci: save PDF to customer zone

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       AWS_DEFAULT_REGION: ${{secrets.AWS_DEFAULT_REGION}}
       S3_ENDPOINT_URL: ${{secrets.S3_ENDPOINT_URL}}
       S3_UPLOAD_PATH: ${{secrets.S3_UPLOAD_PATH}}
+      S3_CZ_PATH: ${{ secrets.S3_DOCX_PATH }}
       TARANTOOL_UPDATE_KEY: ${{secrets.TARANTOOL_UPDATE_KEY}}
       TARANTOOL_UPDATE_URL: ${{secrets.TARANTOOL_UPDATE_URL}}
       DEPLOYMENT_NAME: latest

--- a/upload_output.sh
+++ b/upload_output.sh
@@ -19,9 +19,11 @@ aws s3 sync output/json/_build_ru/json/_images $S3_PATH/$BRANCH/images_ru --endp
 # upload pdf files
 if [ -f output/_latex_en/tarantool.pdf ]; then
   aws s3 cp --acl public-read output/_latex_en/tarantool.pdf $S3_PATH/$BRANCH/Tarantool-en.pdf --endpoint-url=$ENDPOINT_URL
+  aws s3 cp output/_latex_en/tarantool.pdf $S3_CZ_PATH/$BRANCH/tarantool-en.pdf --endpoint-url="$ENDPOINT_URL"
 fi
 if [ -f output/_latex_ru/tarantool.pdf ]; then
   aws s3 cp --acl public-read output/_latex_ru/tarantool.pdf $S3_PATH/$BRANCH/Tarantool-ru.pdf --endpoint-url=$ENDPOINT_URL
+  aws s3 cp output/_latex_ru/tarantool.pdf $S3_CZ_PATH/$BRANCH/tarantool-ru.pdf --endpoint-url="$ENDPOINT_URL"
 fi
 
 # upload singlehtml and assets


### PR DESCRIPTION
Save PDF version of the documentation to the customer zone of the `tarantool.io` website as well as URL set in the PR tarantool/tarantool.io#1440.

Resolves #3872