### PR TITLE
Add TCM config reference

### DIFF
--- a/doc/reference/tooling/tcm/index.rst
+++ b/doc/reference/tooling/tcm/index.rst
@@ -33,3 +33,5 @@ to read data. LDAP authorization is supported as well.
 
     tcm_access_control
     tcm_audit_log
+    tcm_configuration
+    tcm_configuration_reference

--- a/doc/reference/tooling/tcm/tcm_configuration.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration.rst
@@ -3,9 +3,9 @@
 Configuration
 =============
 
-.. TODO: write specific configuration tutorials for http, security, logging, and so on.
+.. TODO: write specific configuration tutorials for http, security, logging, and so on. (https://github.com/tarantool/doc/issues/3545)
 
-This topic describes the |tcm_full_name| configuration model. For the complete
+This topic describes how to configure |tcm_full_name|. For the complete
 list of |tcm| configuration parameters, see the :ref:`TCM configuration reference <tcm_configuration_reference>`.
 
 Configuration structure
@@ -97,7 +97,7 @@ Examples:
 -   ``TCM_HTTP_HOST`` is a variable for the ``http.host`` parameter.
 -   ``TCM_HTTP_WEBSESSION_COOKIE_NAME`` is a variable for the ``http.websession-cookie.name`` parameter.
 
-The example below shows how to start |tcm| passing configuration parameters in
+The example below shows how to start |tcm| with configuration parameters passed in
 environment variables:
 
 .. code-block:: console
@@ -118,7 +118,7 @@ hyphens (``-``). Examples:
 -   ``--http-host`` is an option for ``http.host``.
 -  ``--http-websession-cookie-name`` is an option for ``http.websession-cookie.name``.
 
-The example below shows how to start |tcm| passing configuration parameters in
+The example below shows how to start |tcm| with configuration parameters passed in
 command-line options:
 
 .. code-block:: console
@@ -146,7 +146,7 @@ You can combine different ways of |tcm| configuration for efficient management o
 multiple |tcm| installations:
 
 -   A single YAML file for all installations can contain the common configuration parts.
-    For example, the |tcm| configuration storage used for all installations or
+    For example, a single configuration storage that is used for all installations, or
     TLS settings.
 -   Environment variables that set specific parameters for each server, such as
     local directories and paths.
@@ -173,8 +173,7 @@ Most options have the Go's basic types: ``int`` and other numeric types, ``bool`
         request-size: 1572864 # int64
 
 Parameters that can take multiple values are arrays. In YAML, they are passed as
-YAML arrays: each item on a new line, starting with a dash. In environment variables
-and command line options, the items of such arrays are passed in a semicolon-separated string.
+YAML arrays: each item on a new line, starting with a dash.
 
 .. code-block:: yaml
 
@@ -184,6 +183,11 @@ and command line options, the items of such arrays are passed in a semicolon-sep
         endpoints: # array
             - https://192.168.0.1:2379 # item 1
             - https://192.168.0.2:2379 # item 2
+
+.. note::
+
+    In environment variables and command line options, such arrays are passed as
+    semicolon-separated strings of items.
 
 Parameters that set timeouts, TTLs, and other duration values, have the Go's `time.Duration <https://pkg.go.dev/time#Duration>`__
 type. Their values can be passed in time-formatted strings such as ``4h30m25s``.

--- a/doc/reference/tooling/tcm/tcm_configuration.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration.rst
@@ -53,7 +53,7 @@ YAML file
 |tcm| configuration can be stored in a YAML file. Its structure must reflect the
 configuration parameters hierarchy.
 
-The example below shows a shows a fragment of a |tcm| configuration file:
+The example below shows a fragment of a |tcm| configuration file:
 
 .. code-block:: yaml
 
@@ -197,7 +197,7 @@ type. Their values can be passed in time-formatted strings such as ``4h30m25s``.
 Finally, there are parameters whose values are constants defined in Go packages.
 For example, :ref:`http.websession-cookie.same-site <tcm_configuration_reference_http_websession-cookie_same-site>`
 values are constants from the Go's `http.SameSite <https://pkg.go.dev/net/http#SameSite>`__
-type. To find out the exact values available for such parameters, refer to `Go
+type. To find out the exact values available for such parameters, refer to the `Go
 packages documentation <https://pkg.go.dev/>`__.
 
 .. code-block:: yaml

--- a/doc/reference/tooling/tcm/tcm_configuration.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration.rst
@@ -160,8 +160,7 @@ Configuration parameter types
 types. Note that this is different from the :ref:`Tarantool configuration parameters <configuration_reference>`,
 which have Lua types.
 
-Most options have the Go's basic types: `bool`, `string`, `int`, and other numeric types.
-Their values are passed as strings:
+Most options have the Go's basic types: ``int`` and other numeric types, ``bool``, ``string``.
 
 .. code-block:: yaml
 
@@ -169,12 +168,12 @@ Their values are passed as strings:
         basic-auth:
             enabled: false # bool
         network: tcp # string
-        host: 127.0.0.1 #string
+        host: 127.0.0.1 # string
         port: 8080 # int
         request-size: 1572864 # int64
 
 Parameters that can take multiple values are arrays. In YAML, they are passed as
-YAML arrays (each item on a new line, starting with a dash). In environment variables
+YAML arrays: each item on a new line, starting with a dash. In environment variables
 and command line options, the items of such arrays are passed in a semicolon-separated string.
 
 .. code-block:: yaml
@@ -196,7 +195,7 @@ type. Their values can be passed in time-formatted strings such as ``4h30m25s``.
         tarantool-ping-timeout: 5s # duration
 
 Finally, there are parameters whose values are constants defined in Go packages.
-For example, :ref:`http.websession-cookie.same-site <tcm_configuration_reference_http_websession-cookie_same-site> `
+For example, :ref:`http.websession-cookie.same-site <tcm_configuration_reference_http_websession-cookie_same-site>`
 values are constants from the Go's `http.SameSite <https://pkg.go.dev/net/http#SameSite>`__
 type. To find out the exact values available for such parameters, refer to `Go
 packages documentation <https://pkg.go.dev/>`__.
@@ -204,16 +203,17 @@ packages documentation <https://pkg.go.dev/>`__.
 .. code-block:: yaml
 
     http:
-        tls:
-            cipher-suites:
-                - TLS_RSA_WITH_RC4_128_SHA # Go constant
+        websession-cookie:
+            same-site: SameSiteStrictMode
 
-Creating configuration template
--------------------------------
+Creating a configuration template
+---------------------------------
 
-You can create a YAML configuration template for |tcm| by running the ``tcm``
-executable with the ``generate-config`` option:
+You can create a YAML configuration template for |tcm| with all parameters and
+their default values using the ``generate-config`` option of the ``tcm`` executable.
+
+To write a default |tcm| configuration to the ``tcm.example.yml`` file, run:
 
 .. code-block:: console
 
-    tcm generate-config
+    tcm generate-config > tcm.example.yml.

--- a/doc/reference/tooling/tcm/tcm_configuration.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration.rst
@@ -1,0 +1,219 @@
+.. _tcm_configuration:
+
+Configuration
+=============
+
+.. TODO: write specific configuration tutorials for http, security, logging, and so on.
+
+This topic describes the |tcm_full_name| configuration model. For the complete
+list of |tcm| configuration parameters, see the :ref:`TCM configuration reference <tcm_configuration_reference>`.
+
+Configuration structure
+-----------------------
+
+|tcm_full_name| configuration is a set of parameters that define various aspects
+of |tcm| functioning. Parameters are grouped by the particular aspect that they
+affect. There are the following groups:
+
+*   HTTP
+*   logging
+*   configuration storage
+*   security
+*   add-ons
+*   limits
+*   |tcm| running mode
+
+Parameter groups can be nested. For example, in the ``http`` group there are
+``tls`` and ``websession-cookie`` groups, which define TLS encryption and
+cookie settings.
+
+Parameter names are the full paths from the top-level group to the specific parameter.
+For example:
+
+*   ``http.host`` is the ``host`` parameter that is defined directly in the ``http`` group.
+*   ``http.tls.enabled`` is the ``enabled`` parameter that is defined in the ``tls``
+    nested group within ``http``.
+
+.. _tcm_configuration_ways:
+
+Ways to pass configuration parameters
+-------------------------------------
+
+There are three ways to pass |tcm| configuration parameters:
+
+-   a YAML file
+-   environment variables
+-   command-line options of the |tcm| executable
+
+.. _tcm_configuration_ways_yaml:
+
+YAML file
+~~~~~~~~~
+
+|tcm| configuration can be stored in a YAML file. Its structure must reflect the
+configuration parameters hierarchy.
+
+The example below shows a shows a fragment of a |tcm| configuration file:
+
+.. code-block:: yaml
+
+    # a fragment of a YAML configuration file
+    cluster: # top-level group
+        on-air-limit: 4096
+        connection-rate-limit: 512
+        tarantool-timeout: 10s
+        tarantool-ping-timeout: 5s
+    http: # top-level group
+        basic-auth: # nested group
+            enabled: false
+        network: tcp
+        host: 127.0.0.1
+        port: 8080
+        request-size: 1572864
+        websocket: # nested group
+            read-buffer-size: 16384
+            write-buffer-size: 16384
+            keepalive-ping-interval: 20s
+            handshake-timeout: 10s
+            init-timeout: 15s
+
+To start |tcm| with a YAML configuration, pass the location of the configuration
+file in the ``-c`` command-line option:
+
+.. code-block:: console
+
+    tcm -c=config.yml
+
+.. _tcm_configuration_ways_env:
+
+Environment variables
+~~~~~~~~~~~~~~~~~~~~~
+
+|tcm| can take values of its configuration parameters from environment variables.
+The variable names start with ``TCM_``. Then goes the full path to the parameter,
+converted to upper case. All delimiters are replaced with underscores (``_``).
+Examples:
+
+-   ``TCM_HTTP_HOST`` is a variable for the ``http.host`` parameter.
+-   ``TCM_HTTP_WEBSESSION_COOKIE_NAME`` is a variable for the ``http.websession-cookie.name`` parameter.
+
+The example below shows how to start |tcm| passing configuration parameters in
+environment variables:
+
+.. code-block:: console
+
+    export TCM_HTTP_HOST=0.0.0.0
+    export TCM_HTTP_PORT=8888
+    tcm
+
+.. _tcm_configuration_ways_cli:
+
+Command-line arguments
+~~~~~~~~~~~~~~~~~~~~~~
+
+The |tcm| executable has ``--`` command-line options for each configuration parameter.
+Their names reflect the full path to the parameter, with all delimiters replaced by
+hyphens (``-``). Examples:
+
+-   ``--http-host`` is an option for ``http.host``.
+-  ``--http-websession-cookie-name`` is an option for ``http.websession-cookie.name``.
+
+The example below shows how to start |tcm| passing configuration parameters in
+command-line options:
+
+.. code-block:: console
+
+    ./tcm --storage.etcd.embed.enabled --addon.enabled --http.host=0.0.0.0 --http.port=8888
+
+
+..  _tcm_configuration_precedence:
+
+Configuration precedence
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+|tcm| configuration options are applied from multiple sources with the following precedence,
+from highest to lowest:
+
+#.  ``tcm`` executable arguments.
+#.  `TCM_*` environment variables.
+#.  Configuration from a YAML file.
+
+If the same option is defined in two or more locations, the option with the highest
+precedence is applied. For options that aren't defined in any location, the default
+values are used.
+
+You can combine different ways of |tcm| configuration for efficient management of
+multiple |tcm| installations:
+
+-   A single YAML file for all installations can contain the common configuration parts.
+    For example, the |tcm| configuration storage used for all installations or
+    TLS settings.
+-   Environment variables that set specific parameters for each server, such as
+    local directories and paths.
+-   Command-line options for parameters that must be unique for different |tcm| instances
+    running on a single server. For example, ``http.port``.
+
+Configuration parameter types
+-----------------------------
+
+|tcm| configuration parameters have the `Go <https://go.dev/>`__ language
+types. Note that this is different from the :ref:`Tarantool configuration parameters <configuration_reference>`,
+which have Lua types.
+
+Most options have the Go's basic types: `bool`, `string`, `int`, and other numeric types.
+Their values are passed as strings:
+
+.. code-block:: yaml
+
+    http:
+        basic-auth:
+            enabled: false # bool
+        network: tcp # string
+        host: 127.0.0.1 #string
+        port: 8080 # int
+        request-size: 1572864 # int64
+
+Parameters that can take multiple values are arrays. In YAML, they are passed as
+YAML arrays (each item on a new line, starting with a dash). In environment variables
+and command line options, the items of such arrays are passed in a semicolon-separated string.
+
+.. code-block:: yaml
+
+    storage:
+    provider: etcd
+    etcd:
+        endpoints: # array
+            - https://192.168.0.1:2379 # item 1
+            - https://192.168.0.2:2379 # item 2
+
+Parameters that set timeouts, TTLs, and other duration values, have the Go's `time.Duration <https://pkg.go.dev/time#Duration>`__
+type. Their values can be passed in time-formatted strings such as ``4h30m25s``.
+
+.. code-block:: yaml
+
+    cluster:
+        tarantool-timeout: 10s # duration
+        tarantool-ping-timeout: 5s # duration
+
+Finally, there are parameters whose values are constants defined in Go packages.
+For example, :ref:`http.websession-cookie.same-site <tcm_configuration_reference_http_websession-cookie_same-site> `
+values are constants from the Go's `http.SameSite <https://pkg.go.dev/net/http#SameSite>`__
+type. To find out the exact values available for such parameters, refer to `Go
+packages documentation <https://pkg.go.dev/>`__.
+
+.. code-block:: yaml
+
+    http:
+        tls:
+            cipher-suites:
+                - TLS_RSA_WITH_RC4_128_SHA # Go constant
+
+Creating configuration template
+-------------------------------
+
+You can create a YAML configuration template for |tcm| by running the ``tcm``
+executable with the ``generate-config`` option:
+
+.. code-block:: console
+
+    tcm generate-config

--- a/doc/reference/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration_reference.rst
@@ -1474,8 +1474,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.prefix
 
-    A prefix for the TCM configuration parameters in a Tarantool cluster used as
-    a configuration storage.
+    A prefix for the TCM configuration parameters in the Tarantool |tcm| configuration storage.
 
     |
     | Type: string
@@ -1488,8 +1487,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.addr
 
-    The URI for connecting to the Tarantool cluster used as
-    a configuration storage.
+    The URI for connecting to the Tarantool |tcm| configuration storage.
 
     |
     | Type: string
@@ -1515,8 +1513,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.timeout
 
-    A timeout for connecting to the Tarantool cluster used as
-    a configuration storage.
+    A connection timeout for the Tarantool |tcm| configuration storage.
 
     |
     | Type: time.Duration
@@ -1528,7 +1525,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.reconnect
 
-    ?? TBD
+    A reconnect timeout for the Tarantool |tcm| configuration storage.
 
     |
     | Type: time.Duration
@@ -1540,8 +1537,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.max-reconnects
 
-    Maximum number of reconnects attempts to the Tarantool cluster used as
-    a configuration storage.
+    Maximum number of reconnect attempts for the Tarantool |tcm| configuration storage.
 
     |
     | Type: int
@@ -1553,8 +1549,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.user
 
-    A username for connecting to the Tarantool cluster used as
-    a configuration storage.
+    A username for connecting to the Tarantool |tcm| configuration storage.
 
     |
     | Type: string
@@ -1566,8 +1561,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.pass
 
-    A password for connecting to the Tarantool cluster used as
-    a configuration storage.
+    A password for connecting to the Tarantool |tcm| configuration storage.
 
     |
     | Type: string
@@ -1579,8 +1573,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.rate-limit
 
-    A rate limit for connecting to the Tarantool cluster used as
-    a configuration storage.
+    A rate limit for connecting to the Tarantool |tcm| configuration storage.
 
     |
     | Type: int
@@ -1642,7 +1635,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.ssl.key-file
 
-    A path to a TLS private key file to use for connecting to Tarantool |tcm|
+    A path to a TLS private key file to use for connecting to the Tarantool |tcm|
     configuration storage.
 
     See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
@@ -1657,7 +1650,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.ssl.cert-file
 
-    A path to an SSL certificate to use for connecting to Tarantool |tcm|
+    A path to an SSL certificate to use for connecting to the Tarantool |tcm|
     configuration storage.
 
     See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
@@ -1672,7 +1665,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.ssl.ca-file
 
-    A path to a trusted CA certificate to use for connecting to Tarantool |tcm|
+    A path to a trusted CA certificate to use for connecting to the Tarantool |tcm|
     configuration storage.
 
     See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
@@ -1687,7 +1680,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.ssl.ciphers
 
-    A list of SSL cipher suites that can be used for connecting to a Tarantool |tcm|
+    A list of SSL cipher suites that can be used for connecting to the Tarantool |tcm|
     configuration storage. Possible values are listed in :ref:`Supported ciphers <enterprise-iproto-encryption-ciphers>`.
 
     See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
@@ -1702,7 +1695,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.ssl.password
 
-    A password for an encrypted private SSL key to use for connecting to a Tarantool |tcm|
+    A password for an encrypted private SSL key to use for connecting to the Tarantool |tcm|
     configuration storage.
 
     See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
@@ -1716,8 +1709,8 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.ssl.password-file
 
-    A text file with one or more passwords for encrypted private SSL keys to use
-    for connecting to a Tarantool |tcm| configuration storage.
+    A text file with passwords for encrypted private SSL keys to use
+    for connecting to the Tarantool |tcm| configuration storage.
 
     |
     | Type: string

--- a/doc/reference/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration_reference.rst
@@ -21,8 +21,8 @@ There are the following groups of |tcm| configuration parameters:
 cluster
 -------
 
-The ``cluster`` group defines parameters of connection between |tcm|
-and Tarantool clusters.
+The ``cluster`` group defines parameters of |tcm| interaction with connected
+Tarantool clusters.
 
 -   :ref:`on-air-limit <tcm_configuration_reference_cluster_on-air-limit>`
 -   :ref:`connection-rate-limit <tcm_configuration_reference_cluster_connection-rate-limit>`
@@ -33,7 +33,7 @@ and Tarantool clusters.
 
 .. confval:: cluster.on-air-limit
 
-    ? TBD
+    The maximum number of on-air requests from |tcm| to all connected clusters.
 
     |
     | Type: int64
@@ -41,12 +41,11 @@ and Tarantool clusters.
     | Environment variable: TCM_CLUSTER_ON_AIR_LIMIT
     | Command-line option: --cluster_on_air_limit
 
-
 .. _tcm_configuration_reference_cluster_connection-rate-limit:
 
 .. confval:: cluster.connection-rate-limit
 
-    ? TBD
+    A rate limit for connections to Tarantool instances.
 
     |
     | Type: uint
@@ -58,7 +57,7 @@ and Tarantool clusters.
 
 .. confval:: cluster.tarantool-timeout
 
-    ? TBD
+    A timeout for receiving a response from Tarantool instances.
 
     |
     | Type: time.Duration
@@ -70,7 +69,7 @@ and Tarantool clusters.
 
 .. confval:: cluster.tarantool-ping-timeout
 
-    ? TBD
+    A timeout for receiving a ping response from Tarantool instances.
 
     |
     | Type: time.Duration
@@ -678,7 +677,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
 
 .. confval:: http.api-timeout
 
-    The timeout for getting response from clusters.
+    The stateboard update timeout.
 
     |
     | Type: time.Duration
@@ -690,7 +689,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
 
 .. confval:: http.api-update-interval
 
-    The interval for querying cluster information.
+    The stateboard update interval.
 
     |
     | Type: time.Duration
@@ -714,7 +713,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
 
 .. confval:: http.show-stack-trace
 
-    Include the error stack trace into |tcm| responses.
+    Whether error stack traces are shown in the web UI.
 
     |
     | Type: bool
@@ -726,7 +725,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
 
 .. confval:: http.trace
 
-    ? Include what info exactly?
+    Whether all query tracing information is written in logs.
 
     |
     | Type: bool
@@ -1500,11 +1499,17 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.auth
 
-    ?? TBD
+    An authentication method for the Tarantool |tcm| configuration storage.
+
+    Possible values are the Go's `go-tarantool/Auth <https://pkg.go.dev/github.com/tarantool/go-tarantool#Auth>`__ constants:
+
+    -   ``AutoAuth`` (0)
+    -   ``ChapSha1Auth``
+    -   ``PapSha256Auth``
 
     |
     | Type: int
-    | Default: o
+    | Default: 0
     | Environment variable: TCM_STORAGE_TARANTOOL_AUTH
     | Command-line option: --storage-tarantool-auth
 
@@ -1513,7 +1518,9 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.timeout
 
-    A connection timeout for the Tarantool |tcm| configuration storage.
+    A request timeout for the Tarantool |tcm| configuration storage.
+
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
 
     |
     | Type: time.Duration
@@ -1525,7 +1532,9 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.reconnect
 
-    A reconnect timeout for the Tarantool |tcm| configuration storage.
+    A timeout between reconnect attempts for the Tarantool |tcm| configuration storage.
+
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
 
     |
     | Type: time.Duration
@@ -1537,7 +1546,9 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.max-reconnects
 
-    Maximum number of reconnect attempts for the Tarantool |tcm| configuration storage.
+    The maximum number of reconnect attempts for the Tarantool |tcm| configuration storage.
+
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
 
     |
     | Type: int
@@ -1551,6 +1562,8 @@ etcd cluster is not available or not needed.
 
     A username for connecting to the Tarantool |tcm| configuration storage.
 
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+
     |
     | Type: string
     | Default: ""
@@ -1562,6 +1575,8 @@ etcd cluster is not available or not needed.
 .. confval:: storage.tarantool.pass
 
     A password for connecting to the Tarantool |tcm| configuration storage.
+
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
 
     |
     | Type: string
@@ -1575,6 +1590,8 @@ etcd cluster is not available or not needed.
 
     A rate limit for connecting to the Tarantool |tcm| configuration storage.
 
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+
     |
     | Type: int
     | Default: 0
@@ -1587,6 +1604,8 @@ etcd cluster is not available or not needed.
 
     A action to perform when the :ref:`<tcm_configuration_reference_storage_tarantool_rate-limit>` is reached.
 
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+
     |
     | Type: int
     | Default: 0
@@ -1598,7 +1617,10 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.concurrency
 
-    ?? TBD.
+    An amount of separate mutexes for request queues and buffers inside of a connection
+    to the Tarantool |tcm| configuration storage.
+
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
 
     |
     | Type: int
@@ -1610,7 +1632,9 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.skip-schema
 
-    ?? TBD
+    Whether the schema is loaded from the Tarantool |tcm| configuration storage.
+
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
 
     |
     | Type: bool
@@ -1622,14 +1646,15 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.transport
 
-    ? TBD
+    The connection type for the Tarantool |tcm| configuration storage.
+
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
 
     |
-    | Type: bool
-    | Default: true
+    | Type: string
+    | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_TRANSPORT
     | Command-line option: --storage-tarantool-transport
-
 
 .. _tcm_configuration_reference_storage_tarantool_ssl_key-file:
 
@@ -1781,8 +1806,7 @@ The ``addon`` section defines the |tcm|
 
 .. confval:: addon.dev-addons-dir
 
-    Additional add-on directories for development purposes, separated by commas.
-    ? Maybe convert to semicolon
+    Additional add-on directories for development purposes, separated by semicolons (``;``).
 
     |
     | Type: []string
@@ -1901,7 +1925,12 @@ The ``security`` section defines the security parameters of |tcm|.
 
 .. confval:: security.auth
 
-    ?? separator is ;
+    Ways to log into |tcm|.
+
+    Possible values:
+
+    - ``local``
+    - ``ldap``
 
     |
     | Type: []string
@@ -1913,7 +1942,7 @@ The ``security`` section defines the security parameters of |tcm|.
 
 .. confval:: security.hash-cost
 
-    ?? separator is ;
+    A hash cost for hashing users' passwords.
 
     |
     | Type: int
@@ -1925,7 +1954,8 @@ The ``security`` section defines the security parameters of |tcm|.
 
 .. confval:: security.encryption-key
 
-    ?? separator is ;
+    An encryption key for passwords used by |tcm| for accessing Tarantool
+    and etcd clusters.
 
     |
     | Type: string
@@ -1937,7 +1967,8 @@ The ``security`` section defines the security parameters of |tcm|.
 
 .. confval:: security.encryption-key-file
 
-    ?? separator is ;
+    A path to the file with the encryption key for passwords used by |tcm| for accessing Tarantool
+    and etcd clusters.
 
     |
     | Type: string
@@ -1950,7 +1981,7 @@ The ``security`` section defines the security parameters of |tcm|.
 .. confval:: security.bootstrap-password
 
     A password for the first login of the ``admin`` user. Must be changed after the
-    successful login.
+    successful login. Only for testing purposes.
 
     |
     | Type: string
@@ -1958,29 +1989,30 @@ The ``security`` section defines the security parameters of |tcm|.
     | Environment variable: TCM_SECURITY_BOOTSTRAP_PASSWORD
     | Command-line option: --security-bootstrap-password
 
-.. _tcm_configuration_security_integrity-check:
-
-.. confval:: security.integrity-check
-
-    ? TBD
-
-    |
-    | Type: bool
-    | Default: false
-    | Environment variable: TCM_SECURITY_INTEGRITY_CHECK
-    | Command-line option: --security-integrity-check
-
 .. _tcm_configuration_security_signature-private-key-file:
 
 .. confval:: security.signature-private-key-file
 
-    ? TBD
+    A path to a file with the private key to sign |tcm| data.
 
     |
     | Type: string
     | Default: ""
     | Environment variable: TCM_SECURITY_SIGNATURE_PRIVATE_KEY_FILE
     | Command-line option: --security-signature-private-key-file
+
+.. _tcm_configuration_security_integrity-check:
+
+.. confval:: security.integrity-check
+
+    Whether to check the digital signature. If ``true``, the error is raised
+    in case an incorrect signature is detected.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_SECURITY_INTEGRITY_CHECK
+    | Command-line option: --security-integrity-check
 
 .. mode
 

--- a/doc/reference/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration_reference.rst
@@ -1,0 +1,1780 @@
+.. _tcm_configuration_reference:
+
+Configuration reference
+=======================
+
+This topic describes :ref:`configuration parameters <tcm_configuration>` of |tcm_full_name|.
+
+There are the following groups of |tcm| configuration parameters:
+
+- :ref:`cluster <tcm_configuration_reference_cluster>`
+- :ref:`http <tcm_configuration_reference_http>`
+- :ref:`log <tcm_configuration_reference_log>`
+- :ref:`storage <tcm_configuration_reference_storage>`
+- :ref:`addon <tcm_configuration_reference_addon>`
+- :ref:`limits <tcm_configuration_reference_limits>`
+- :ref:`security <tcm_configuration_reference_security>`
+- :ref:`mode <tcm_configuration_reference_mode>`
+
+.. _tcm_configuration_reference_cluster:
+
+cluster
+-------
+
+The ``cluster`` group defines parameters of connection between |tcm|
+and Tarantool clusters.
+
+-   :ref:`on-air-limit <tcm_configuration_reference_cluster_on-air-limit>`
+-   :ref:`connection-rate-limit <tcm_configuration_reference_cluster_connection-rate-limit>`
+-   :ref:`tarantool-timeout <tcm_configuration_reference_cluster_tarantool-timeout>`
+-   :ref:`tarantool-ping-timeout <tcm_configuration_reference_cluster_tarantool-ping-timeout>`
+
+.. _tcm_configuration_reference_cluster_on-air-limit:
+
+.. confval:: cluster.on-air-limit
+
+    ? TBD
+
+    |
+    | Type: int64
+    | Default: 4096
+    | Environment variable: TCM_CLUSTER_ON_AIR_LIMIT
+    | Command-line option: --cluster_on_air_limit
+
+
+.. _tcm_configuration_reference_cluster_connection-rate-limit:
+
+.. confval:: cluster.connection-rate-limit
+
+    ? TBD
+
+    |
+    | Type: uint
+    | Default: 512
+    | Environment variable: TCM_CLUSTER_CONNECTION_RATE_LIMIT
+    | Command-line option: --cluster-connection-rate-limit
+
+.. _tcm_configuration_reference_cluster_tarantool-timeout:
+
+.. confval:: cluster.tarantool-timeout
+
+    ? TBD
+
+    |
+    | Type: time.Duration
+    | Default: 10s
+    | Environment variable: TCM_CLUSTER_TARANTOOL_TIMEOUT
+    | Command-line option: --cluster-tarantool-timeout
+
+.. _tcm_configuration_reference_cluster_tarantool-ping-timeout:
+
+.. confval:: cluster.tarantool-ping-timeout
+
+    ? TBD
+
+    |
+    | Type: time.Duration
+    | Default: 5s
+    | Environment variable: TCM_CLUSTER_TARANTOOL_PING_TIMEOUT
+    | Command-line option: --cluster-tarantool-ping-timeout
+
+.. _tcm_configuration_reference_http:
+
+http
+----
+
+The ``http`` group defines parameters of HTTP connections between |tcm| and clients.
+
+-   :ref:`http.basic_auth.enabled <tcm_configuration_reference_http_basic-auth_enabled>`
+-   :ref:`http.network <tcm_configuration_reference_http_network>`
+-   :ref:`http.host <tcm_configuration_reference_http_host>`
+-   :ref:`http.port <tcm_configuration_reference_http_port>`
+-   :ref:`http.request-size <tcm_configuration_reference_http_request-size>`
+-   :ref:`http.websocket.read-buffer-size <tcm_configuration_reference_http_websocket_read-buffer-size>`
+-   :ref:`http.websocket.write-buffer-size <tcm_configuration_reference_http_websocket_write-buffer-size>`
+-   :ref:`http.websocket.keepalive-ping-interval <tcm_configuration_reference_http_websocket_keepalive-ping-interval>`
+-   :ref:`http.websocket.handshake-timeout <tcm_configuration_reference_http_websocket_handshake-timeout>`
+-   :ref:`http.websocket.init-timeout <tcm_configuration_reference_http_websocket_init-timeout>`
+-   :ref:`http.websession-cookie.name <tcm_configuration_reference_http_websession-cookie_name>`
+-   :ref:`http.websession-cookie.path <tcm_configuration_reference_http_websession-cookie_path>`
+-   :ref:`http.websession-cookie.domain <tcm_configuration_reference_http_websession-cookie_domain>`
+-   :ref:`http.websession-cookie.ttl <tcm_configuration_reference_http_websession-cookie_ttl>`
+-   :ref:`http.websession-cookie.secure <tcm_configuration_reference_http_websession-cookie_secure>`
+-   :ref:`http.websession-cookie.http-only <tcm_configuration_reference_http_websession-cookie_http-only>`
+-   :ref:`http.websession-cookie.same-site <tcm_configuration_reference_http_websession-cookie_same-site>`
+-   :ref:`http.cors.enabled <tcm_configuration_reference_http_cors_enabled>`
+-   :ref:`http.cors.allowed-origins <tcm_configuration_reference_http_cors_allowed-origins>`
+-   :ref:`http.cors.allowed-methods <tcm_configuration_reference_http_cors_allowed-methods>`
+-   :ref:`http.cors.allowed-headers <tcm_configuration_reference_http_cors_allowed-headers>`
+-   :ref:`http.cors.exposed-headers <tcm_configuration_reference_http_cors_exposed-headers>`
+-   :ref:`http.cors.allow-credentials <tcm_configuration_reference_http_cors_allow-credentials>`
+-   :ref:`http.cors.debug <tcm_configuration_reference_http_cors_debug>`
+-   :ref:`http.metrics-endpoint <tcm_configuration_reference_http_metrics-endpoint>`
+-   :ref:`http.tls.enabled <tcm_configuration_reference_http_tls_enabled>`
+-   :ref:`http.tls.cert-file <tcm_configuration_reference_http_tls_cert-file>`
+-   :ref:`http.tls.key-file <tcm_configuration_reference_http_tls_key-file>`
+-   :ref:`http.tls.server <tcm_configuration_reference_http_tls_server>`
+-   :ref:`http.tls.min-version <tcm_configuration_reference_http_tls_min-version>`
+-   :ref:`http.tls.max-version <tcm_configuration_reference_http_tls_max-version>`
+-   :ref:`http.tls.curve-preferences <tcm_configuration_reference_http_tls_curve-preferences>`
+-   :ref:`http.tls.cipher-suites <tcm_configuration_reference_http_tls_cipher-suites>`
+-   :ref:`http.read-timeout <tcm_configuration_reference_http_read-timeout>`
+-   :ref:`http.read-header-timeout <tcm_configuration_reference_http_read-header-timeout>`
+-   :ref:`http.write-timeout <tcm_configuration_reference_http_write-timeout>`
+-   :ref:`http.idle-timeout <tcm_configuration_reference_http_idle-timeout>`
+-   :ref:`http.idle-timeout <tcm_configuration_reference_http_idle-timeout>`
+-   :ref:`http.disable-general-options-handler <tcm_configuration_reference_http_disable-general-options-handler>`
+-   :ref:`http.max-header-bytes <tcm_configuration_reference_http_max-header-bytes>`
+-   :ref:`http.api-timeout <tcm_configuration_reference_http_api-timeout>`
+-   :ref:`http.api-update-interval <tcm_configuration_reference_http_api-update-interval>`
+-   :ref:`http.frontend-dir <tcm_configuration_reference_http_frontend-dir>`
+-   :ref:`http.show-stack-trace <tcm_configuration_reference_http_show-stack-trace>`
+-   :ref:`http.trace <tcm_configuration_reference_http_trace>`
+-   :ref:`http.max-static-size <tcm_configuration_reference_http_max-static-size>`
+-   :ref:`http.graphql.complexity <tcm_configuration_reference_http_graphql_complexity>`
+
+
+.. _tcm_configuration_reference_http_basic-auth_enabled:
+
+.. confval:: http.basic_auth.enabled
+
+    Whether to use the `HTTP basic authentication <https://www.ietf.org/rfc/rfc2617.txt>`__.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_HTTP_BASIC_AUTH_ENABLED
+    | Command-line option: --http-basic-auth-enabled
+
+.. _tcm_configuration_reference_http_network:
+
+.. confval:: http.network
+
+    An addressing scheme that |tcm| uses.
+
+    Possible values:
+
+    -   ``tcp``: IPv4 address
+    -   ``tcp6``: IPv6 address
+    -   ``unix``: Unix domain socket
+
+    |
+    | Type: string
+    | Default: tcp
+    | Environment variable: TCM_HTTP_NETWORK
+    | Command-line option: --http-network
+
+.. _tcm_configuration_reference_http_host:
+
+.. confval:: http.host
+
+    A host name on which |tcm| serves.
+
+    |
+    | Type: string
+    | Default: 127.0.0.1
+    | Environment variable: TCM_HTTP_HOST
+    | Command-line option: --http-host
+
+
+.. _tcm_configuration_reference_http_port:
+
+.. confval:: http.port
+
+    A port on which |tcm| serves.
+
+    |
+    | Type: int
+    | Default: 8080
+    | Environment variable: TCM_HTTP_PORT
+    | Command-line option: --http-port
+
+
+.. _tcm_configuration_reference_http_request-size:
+
+.. confval:: http.request-size
+
+    The maximum size of a client HTTP request to |tcm|, in bytes.
+
+    |
+    | Type: int64
+    | Default: 1572864
+    | Environment variable: TCM_HTTP_REQUEST_SIZE
+    | Command-line option: --http-request-size
+
+.. _tcm_configuration_reference_http_websocket_read-buffer-size:
+
+.. confval:: http.websocket.read-buffer-size
+
+    The size of the read buffer for `WebSocket <https://developer.mozilla.org/en-US/docs/Glossary/WebSockets>`__
+    connections, in bytes.
+
+    |
+    | Type: int
+    | Default: 16384
+    | Environment variable: TCM_HTTP_WEBSOCKET_READ_BUFFER_SIZE
+    | Command-line option: --http-websocket-read-buffer-size
+
+.. _tcm_configuration_reference_http_websocket_write-buffer-size:
+
+.. confval:: http.websocket.write-buffer-size
+
+    The size of the write buffer for `WebSocket <https://developer.mozilla.org/en-US/docs/Glossary/WebSockets>`__
+    connections, in bytes.
+
+    |
+    | Type: int
+    | Default: 16384
+    | Environment variable: TCM_HTTP_WEBSOCKET_WRITE_BUFFER_SIZE
+    | Command-line option: --http-websocket-write-buffer-size
+
+.. _tcm_configuration_reference_http_websocket_keepalive-ping-interval:
+
+.. confval:: http.websocket.keepalive-ping-interval
+
+    The time interval for sending `WebSocket <https://developer.mozilla.org/en-US/docs/Glossary/WebSockets>`__
+    keepalive pings.
+
+    |
+    | Type: time.Duration
+    | Default: 20s
+    | Environment variable: TCM_HTTP_WEBSOCKET_KEEPALIVE_PING_INTERVAL
+    | Command-line option: --http-websocket-keepalive-ping-interval
+
+.. _tcm_configuration_reference_http_websocket_handshake-timeout:
+
+.. confval:: http.websocket.handshake-timeout
+
+    The time limit for completing a `WebSocket <https://developer.mozilla.org/en-US/docs/Glossary/WebSockets>`__
+    opening handshake with a client.
+
+    |
+    | Type: time.Duration
+    | Default: 10s
+    | Environment variable: TCM_HTTP_WEBSOCKET_HANDSHAKE_TIMEOUT
+    | Command-line option: --http-websocket-handshake-timeout
+
+.. _tcm_configuration_reference_http_websocket_init-timeout:
+
+.. confval:: http.websocket.init-timeout
+
+    The time limit for establishing a `WebSocket <https://developer.mozilla.org/en-US/docs/Glossary/WebSockets>`__
+    connection with a client.
+
+    |
+    | Type: time.Duration
+    | Default: 15s
+    | Environment variable: TCM_HTTP_WEBSOCKET_INIT_TIMEOUT
+    | Command-line option: --http-websocket-init-timeout
+
+.. _tcm_configuration_reference_http_websession-cookie_name:
+
+.. confval:: http.websession-cookie.name
+
+    The name of the cookie that |tcm| sends to clients.
+
+    This value is used as the cookie name in the `Set-Cookie <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie>`__
+    HTTP response header.
+
+    |
+    | Type: string
+    | Default: tcm
+    | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_NAME
+    | Command-line option: --http-websession-cookie-name
+
+.. _tcm_configuration_reference_http_websession-cookie_path:
+
+.. confval:: http.websession-cookie.path
+
+    The URL path that must be present in the requested URL in order to send the cookie.
+
+    This value is used in the ``Path`` attribute of the `Set-Cookie <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie>`__
+    HTTP response header.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_PATH
+    | Command-line option: --http-websession-cookie-path
+
+.. _tcm_configuration_reference_http_websession-cookie_domain:
+
+.. confval:: http.websession-cookie.domain
+
+    The domain to which the cookie can be sent.
+
+    This value is used in the ``Domain`` attribute of the `Set-Cookie <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie>`__
+    HTTP response header.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_DOMAIN
+    | Command-line option: --http-websession-cookie-domain
+
+.. _tcm_configuration_reference_http_websession-cookie_ttl:
+
+.. confval:: http.websession-cookie.ttl
+
+    The maximum lifetime of the |tcm| cookie.
+
+    This value is used in the ``Max-Age`` attribute of the `Set-Cookie <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie>`__
+    HTTP response header.
+
+    |
+    | Type: time.Duration
+    | Default: 2h0m0s
+    | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_TTL
+    | Command-line option: --http-websession-cookie-ttl
+
+.. _tcm_configuration_reference_http_websession-cookie_secure:
+
+.. confval:: http.websession-cookie.secure
+
+    Indicates whether the cookie can be sent only over the HTTPS protocol.
+    In this case, it's never sent over the unencrypted HTTP, therefore preventing
+    man-in-the-middle attacks.
+
+    When ``true``, the ``Secure`` attribute is added to the `Set-Cookie <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie>`__
+    HTTP response header.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_SECURE
+    | Command-line option: --http-websession-cookie-secure
+
+.. _tcm_configuration_reference_http_websession-cookie_http-only:
+
+.. confval:: http.websession-cookie.http-only
+
+    Indicates that the cookie can't be accessed from the JavaScript
+    `Document.cookie <https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie>`__ API.
+    This help mitigate cross-site scripting attacks.
+
+    When ``true``, the ``HttpOnly`` attribute is added to the `Set-Cookie <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie>`__
+    HTTP response header.
+
+    |
+    | Type: bool
+    | Default: true
+    | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_HTTP_ONLY
+    | Command-line option: --http-websession-cookie-http-only
+
+.. _tcm_configuration_reference_http_websession-cookie_same-site:
+
+.. confval:: http.websession-cookie.same-site
+
+    Indicates if it is possible to send the |tcm| cookie along with cross-site
+    requests. Possible values are the Go's `http.SameSite <https://pkg.go.dev/net/http#SameSite>`__ constants:
+
+    -   ``SameSiteDefaultMode``
+    -   ``SameSiteLaxMode``
+    -   ``SameSiteStrictMode``
+    -   ``SameSiteNoneMode``
+
+    For details on ``SameSite`` modes, see the `Set-Cookie header documentation <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value>`__
+    in the MDN web docs.
+
+    This value is used in the ``SameSite`` attribute of the `Set-Cookie <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie>`__
+    HTTP response header.
+
+    |
+    | Type: http.SameSite
+    | Default: SameSiteDefaultMode
+    | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_SAME_SITE
+    | Command-line option: --http-websession-cookie-same-site
+
+.. _tcm_configuration_reference_http_cors_enabled:
+
+.. confval:: http.cors.enabled
+
+    Indicates whether to use the `Cross-Origin Resource Sharing <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`__
+    (*CORS*).
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_HTTP_CORS_ENABLED
+    | Command-line option: --http-cors-enabled
+
+.. _tcm_configuration_reference_http_cors_allowed-origins:
+
+.. confval:: http.cors.allowed-origins
+
+    The `origins <https://developer.mozilla.org/en-US/docs/Glossary/Origin>`__
+    with which the HTTP response can be shared, separated by semicolons.
+
+    The specified values are sent in the `Access-Control-Allow-Origin <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin>`__
+    HTTP response headers.
+
+    |
+    | Type: []string
+    | Default: []
+    | Environment variable: TCM_HTTP_CORS_ALLOWED_ORIGINS
+    | Command-line option: --http-cors-allowed-origins
+
+.. _tcm_configuration_reference_http_cors_allowed-methods:
+
+.. confval:: http.cors.allowed-methods
+
+    HTTP request methods that are allowed when accessing a resource,
+    separated by semicolons.
+
+    The specified values are sent in the `Access-Control-Allow-Methods <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods>`__
+    HTTP header of a response to a `CORS preflight request <https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request>`__.
+
+    |
+    | Type: []string
+    | Default: []
+    | Environment variable: TCM_HTTP_CORS_ALLOWED_METHODS
+    | Command-line option: --http-cors-allowed-methods
+
+.. _tcm_configuration_reference_http_cors_allowed-headers:
+
+.. confval:: http.cors.allowed-headers
+
+    HTTP headers that are allowed during the actual request, separated by semicolons.
+
+    The specified values are sent in the `Access-Control-Allow-Headers <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers>`__
+    HTTP header of a response to a `CORS preflight request <https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request>`__.
+
+    |
+    | Type: []string
+    | Default: []
+    | Environment variable: TCM_HTTP_CORS_ALLOWED_HEADERS
+    | Command-line option: --http-cors-allowed-headers
+
+.. _tcm_configuration_reference_http_cors_exposed-headers:
+
+.. confval:: http.cors.exposed-headers
+
+    Response headers that should be made available to scripts running in the browser,
+    in response to a cross-origin request, separated by semicolons.
+
+    The specified values are sent in the `Access-Control-Expose-Headers <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers>`__
+    HTTP response headers.
+
+    |
+    | Type: []string
+    | Default: []
+    | Environment variable: TCM_HTTP_CORS_EXPOSED_HEADERS
+    | Command-line option: --http-cors-exposed-headers
+
+.. _tcm_configuration_reference_http_cors_allow-credentials:
+
+.. confval:: http.cors.allow-credentials
+
+    Whether to expose the response to the frontend JavaScript code when the `request's
+    credentials <https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials>`__
+    mode is ``include``.
+
+    When ``true``, the `Access-Control-Allow-Credentials <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials>`__
+    HTTP response header is sent.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_HTTP_CORS_ALLOW_CREDENTIALS
+    | Command-line option: --http-cors-allow-credentials
+
+.. _tcm_configuration_reference_http_cors_debug:
+
+.. confval:: http.cors.debug
+
+    For debug purposes.
+
+    |
+    | Type: bool
+    | Default: false
+
+.. _tcm_configuration_reference_http_metrics-endpoint:
+
+.. confval:: http.metrics-endpoint
+
+    The HTTP endpoint for |tcm| metrics in the `Prometheus <https://prometheus.io/>`__ format.
+
+    |
+    | Type: string
+    | Default: /metrics
+    | Environment variable: TCM_HTTP_METRICS_ENDPOINT
+    | Command-line option: --http-metrics-endpoint
+
+.. _tcm_configuration_reference_http_tls_enabled:
+
+.. confval:: http.tls.enabled
+
+    Indicates whether TLS is enabled for client connections to |tcm|.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_HTTP_TLS_ENABLED
+    | Command-line option: --http-tls-enabled
+
+.. _tcm_configuration_reference_http_tls_cert-file:
+
+.. confval:: http.tls.cert-file
+
+    A path to a TLS certificate file. Mandatory when TLS is enabled.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_HTTP_TLS_CERT_FILE
+    | Command-line option: --http-tls-cert-file
+
+.. _tcm_configuration_reference_http_tls_key-file:
+
+.. confval:: http.tls.key-file
+
+    A path to a TLS private key file. Mandatory when TLS is enabled.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_HTTP_TLS_KEY_FILE
+    | Command-line option: --http-tls-key-file
+
+.. _tcm_configuration_reference_http_tls_server:
+
+.. confval:: http.tls.server
+
+    The TSL server.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_HTTP_TLS_SERVER
+    | Command-line option: --http-tls-server
+
+.. _tcm_configuration_reference_http_tls_min-version:
+
+.. confval:: http.tls.min-version
+
+    The minimum version of the TLS protocol. ? 0 == any?
+
+    |
+    | Type: uint16
+    | Default: 0
+    | Environment variable: TCM_HTTP_TLS_MIN_VERSION
+    | Command-line option: --http-tls-min-version
+
+.. _tcm_configuration_reference_http_tls_max-version:
+
+.. confval:: http.tls.max-version
+
+    The maximum version of the TLS protocol.
+
+    |
+    | Type: uint16
+    | Default: 0
+    | Environment variable: TCM_HTTP_TLS_MAX_VERSION
+    | Command-line option: --http-tls-max-version
+
+.. _tcm_configuration_reference_http_tls_curve-preferences:
+
+.. confval:: http.tls.curve-preferences
+
+    Elliptic curves that are used for TLS connections.
+    Possible values are the Go's `tls.CurveID <https://pkg.go.dev/crypto/tls#CurveID>`__ constants:
+
+    -   ``CurveP256``
+    -   ``CurveP384``
+    -   ``CurveP521``
+    -   ``X25519``
+
+    |
+    | Type: []tls.CurveID
+    | Default: []
+    | Environment variable: TCM_HTTP_TLS_CURVE_PREFERENCES
+    | Command-line option: --http-tls-curve-preferences
+
+.. _tcm_configuration_reference_http_tls_cipher-suites:
+
+.. confval:: http.tls.cipher-suites
+
+    Enabled TLS cipher suites. Possible values are the Golang `tls.TLS_* <https://pkg.go.dev/crypto/tls#pkg-constants>`__ constants.
+
+    |
+    | Type: []uint16
+    | Default: []
+    | Environment variable: TCM_HTTP_TLS_CIPHER_SUITES
+    | Command-line option: --http-tls-cipher-suites
+
+.. _tcm_configuration_reference_http_read-timeout:
+
+.. confval:: http.read-timeout
+
+    A timeout for reading an incoming request.
+
+    |
+    | Type: time.Duration
+    | Default: 30s
+    | Environment variable: TCM_HTTP_READ_TIMEOUT
+    | Command-line option: --http-read-timeout
+
+.. _tcm_configuration_reference_http_read-header-timeout:
+
+.. confval:: http.read-header-timeout
+
+    A timeout for reading headers of an incoming request.
+
+    |
+    | Type: time.Duration
+    | Default: 30s
+    | Environment variable: TCM_HTTP_READ_HEADER_TIMEOUT
+    | Command-line option: --http-read-header-timeout
+
+.. _tcm_configuration_reference_http_write-timeout:
+
+.. confval:: http.write-timeout
+
+    A timeout for writing a response.
+
+    |
+    | Type: time.Duration
+    | Default: 30s
+    | Environment variable: TCM_HTTP_WRITE_TIMEOUT
+    | Command-line option: --http-write-timeout
+
+.. _tcm_configuration_reference_http_idle-timeout:
+
+.. confval:: http.idle-timeout
+
+    The timeout for idle connections.
+
+    |
+    | Type: time.Duration
+    | Default: 30s
+    | Environment variable: TCM_HTTP_IDLE_TIMEOUT
+    | Command-line option: --http-idle-timeout
+
+.. _tcm_configuration_reference_http_disable-general-options-handler:
+
+.. confval:: http.disable-general-options-handler
+
+    Whether the client requests with the ``OPTIONS`` HTTP method are allowed.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_HTTP_DISABLE_GENERAL_OPTIONS_HANDLER
+    | Command-line option: --http-disable-general-options-handler
+
+.. _tcm_configuration_reference_http_max-header-bytes:
+
+.. confval:: http.max-header-bytes
+
+    The maximum size of a header in a client's request to |TCM|, in bytes.
+
+    |
+    | Type: int
+    | Default: 0
+    | Environment variable: TCM_HTTP_MAX_HEADER_BYTES
+    | Command-line option: --http-max-header-bytes
+
+.. _tcm_configuration_reference_http_api-timeout:
+
+.. confval:: http.api-timeout
+
+    The timeout for getting response from clusters.
+
+    |
+    | Type: time.Duration
+    | Default: 8s
+    | Environment variable: TCM_HTTP_API_TIMEOUT
+    | Command-line option: --http-api-timeout
+
+.. _tcm_configuration_reference_http_api-update-interval:
+
+.. confval:: http.api-update-interval
+
+    The interval for querying cluster information.
+
+    |
+    | Type: time.Duration
+    | Default: 5s
+    | Environment variable: TCM_HTTP_API_UPDATE_INTERVAL
+    | Command-line option: --http-api-update-interval
+
+.. _tcm_configuration_reference_http_frontend-dir:
+
+.. confval:: http.frontend-dir
+
+    The directory with custom |tcm| frontend files (for development purposes).
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_HTTP_FRONTEND_DIR
+    | Command-line option: --http-frontend-dir
+
+.. _tcm_configuration_reference_http_show-stack-trace:
+
+.. confval:: http.show-stack-trace
+
+    Include the error stack trace into |tcm| responses.
+
+    |
+    | Type: bool
+    | Default: true
+    | Environment variable: TCM_HTTP_SHOW_STACK_TRACE
+    | Command-line option: --http-show-stack-trace
+
+.. _tcm_configuration_reference_http_trace:
+
+.. confval:: http.trace
+
+    ? Include what info exactly?
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_HTTP_TRACE
+    | Command-line option: --http-trace
+
+.. _tcm_configuration_reference_http_max-static-size:
+
+.. confval:: http.max-static-size
+
+    The maximum size of a static content sent to |TCM|, in bytes.
+
+    |
+    | Type: int
+    | Default: 104857600
+    | Environment variable: TCM_HTTP_MAX_STATIC_SIZE
+    | Command-line option: --http-max-static-size
+
+.. _tcm_configuration_reference_http_graphql_complexity:
+
+.. confval:: http.graphql.complexity
+
+    The maximum `complexity <https://typegraphql.com/docs/complexity.html>`__ of
+    GraphQL queries that |tcm| processes. If this value is exceeded, |tcm|
+    returns an error.
+
+    |
+    | Type: int
+    | Default: 40
+    | Environment variable: TCM_HTTP_GRAPHQL_COMPLEXITY
+    | Command-line option: --http-graphql-complexity
+
+
+.. log configuration
+
+.. _tcm_configuration_reference_log:
+
+log
+---
+
+The ``log`` section defines the |tcm|  logging parameters.
+
+-   :ref:`log.default.add-source <tcm_configuration_reference_log_default_add-source>`
+-   :ref:`log.default.show-stack-trace <tcm_configuration_reference_log_default_show-stack-trace>`
+-   :ref:`log.default.level <tcm_configuration_reference_log_default_level>`
+-   :ref:`log.default.format <tcm_configuration_reference_log_default_format>`
+-   :ref:`log.default.output <tcm_configuration_reference_log_default_output>`
+-   :ref:`log.default.no-colorized <tcm_configuration_reference_log_default_no-colorized>`
+-   :ref:`log.default.file.name <tcm_configuration_reference_log_default_file_name>`
+-   :ref:`log.default.file.maxsize <tcm_configuration_reference_log_default_file_maxsize>`
+-   :ref:`log.default.file.maxage <tcm_configuration_reference_log_default_file_maxage>`
+-   :ref:`log.default.file.maxbackups <tcm_configuration_reference_log_default_file_maxbackups>`
+-   :ref:`log.default.file.compress <tcm_configuration_reference_log_default_file_compress>`
+-   :ref:`log.default.syslog.protocol <tcm_configuration_reference_log_default_syslog_protocol>`
+-   :ref:`log.default.syslog.output <tcm_configuration_reference_log_default_syslog_output>`
+-   :ref:`log.default.syslog.priority <tcm_configuration_reference_log_default_syslog_priority>`
+-   :ref:`log.default.syslog.facility <tcm_configuration_reference_log_default_syslog_facility>`
+-   :ref:`log.default.syslog.tag <tcm_configuration_reference_log_default_syslog_tag>`
+-   :ref:`log.default.syslog.timeout <tcm_configuration_reference_log_default_syslog_timeout>`
+-   :ref:`log.outputs <tcm_configuration_reference_log_outputs>`
+
+.. _tcm_configuration_reference_log_default_add-source:
+
+.. confval:: log.default.add-source
+
+    ? Add sources to the |tcm| logs.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_LOG_DEFAULT_ADD_SOURCE
+    | Command-line option: --log-default-add-source
+
+.. _tcm_configuration_reference_log_default_show-stack-trace:
+
+.. confval:: log.default.show-stack-trace
+
+    Add stack traces to the |tcm| log.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_LOG_DEFAULT_SHOW_STACK_TRACE
+    | Command-line option: --log-default-show-stack-trace
+
+.. _tcm_configuration_reference_log_default_level:
+
+.. confval:: log.default.level
+
+    The default |tcm| logging level.
+
+    ? сheck: Possible values:
+
+    *   ``VERBOSE``
+    *   ``INFO``
+    *   ``WARN``
+    *   ``ALARM``
+
+    |
+    | Type: string
+    | Default: INFO
+    | Environment variable: TCM_LOG_DEFAULT_LEVEL
+    | Command-line option: --log-default-level
+
+.. _tcm_configuration_reference_log_default_format:
+
+.. confval:: log.default.format
+
+    |tcm| log entries format.
+
+    Possible values:
+
+    *   ``struct``
+    *   ``json``
+
+    |
+    | Type: string
+    | Default: struct
+    | Environment variable: TCM_LOG_DEFAULT_FORMAT
+    | Command-line option: --log-default-format
+
+.. _tcm_configuration_reference_log_default_output:
+
+.. confval:: log.default.output
+
+    The output used for |tcm| log.
+
+    Possible values:
+
+    *   ``stdout``
+    *   ``stderr``
+    *   ``file``
+    *   ``syslog``
+
+    |
+    | Type: string
+    | Default: stdout
+    | Environment variable: TCM_LOG_DEFAULT_OUTPUT
+    | Command-line option: --log-default-output
+
+.. _tcm_configuration_reference_log_default_no-colorized:
+
+.. confval:: log.default.no-colorized
+
+    Whether the stdout logs are not colorized.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_LOG_DEFAULT_NO_COLORIZED
+    | Command-line option: --log-default-no-colorized
+
+.. _tcm_configuration_reference_log_default_file_name:
+
+.. confval:: log.default.file.name
+
+    The name of the |tcm| log file.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_LOG_DEFAULT_FILE_NAME
+    | Command-line option: --log-default-file-name
+
+.. _tcm_configuration_reference_log_default_file_maxsize:
+
+.. confval:: log.default.file.maxsize
+
+    The maximum size of the |tcm| log file, in bytes.
+
+    ? check ``0``- unlimited.
+
+    |
+    | Type: int
+    | Default: 0
+    | Environment variable: TCM_LOG_DEFAULT_FILE_MAXSIZE
+    | Command-line option: --log-default-file-maxsize
+
+.. _tcm_configuration_reference_log_default_file_maxage:
+
+.. confval:: log.default.file.maxage
+
+    The maximum age of a |tcm| log file, in days.
+
+    ? check ``0``- unlimited.
+
+    |
+    | Type: int
+    | Default: 0
+    | Environment variable: TCM_LOG_DEFAULT_FILE_MAXAGE
+    | Command-line option: --log-default-file-maxage
+
+.. _tcm_configuration_reference_log_default_file_maxbackups:
+
+.. confval:: log.default.file.maxbackups
+
+    The maximum number of users in |tcm|.
+
+    |
+    | Type: int
+    | Default: 0
+    | Environment variable: TCM_LOG_DEFAULT_FILE_MAXBACKUPS
+    | Command-line option: --log-default-file-maxbackups
+
+.. _tcm_configuration_reference_log_default_file_compress:
+
+.. confval:: log.default.file.compress
+
+    Indicated that |tcm| compresses log files upon rotation.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_LOG_DEFAULT_FILE_COMPRESS
+    | Command-line option: --log-default-file-compress
+
+.. _tcm_configuration_reference_log_default_syslog_protocol:
+
+.. confval:: log.default.syslog.protocol
+
+    The network protocol used for connecting to the syslog server.
+
+    ? possible values:
+
+    - ``tcp``
+    - ``udp``
+
+    |
+    | Type: string
+    | Default: tcp
+    | Environment variable: TCM_LOG_DEFAULT_SYSLOG_PROTOCOL
+    | Command-line option: --log-default-syslog-protocol
+
+.. _tcm_configuration_reference_log_default_syslog_output:
+
+.. confval:: log.default.syslog.output
+
+    The syslog server URI.
+
+    |
+    | Type: string
+    | Default: 127.0.0.1:5514
+    | Environment variable: TCM_LOG_DEFAULT_SYSLOG_OUTPUT
+    | Command-line option: --log-default-syslog-output
+
+.. _tcm_configuration_reference_log_default_syslog_priority:
+
+.. confval:: log.default.syslog.priority
+
+    The syslog severity level.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_LOG_DEFAULT_SYSLOG_PRIORITY
+    | Command-line option: --log-default-syslog-priority
+
+.. _tcm_configuration_reference_log_default_syslog_facility:
+
+.. confval:: log.default.syslog.facility
+
+    The syslog facility.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_LOG_DEFAULT_SYSLOG_FACILITY
+    | Command-line option: --log-default-syslog-facility
+
+.. _tcm_configuration_reference_log_default_syslog_tag:
+
+.. confval:: log.default.syslog.tag
+
+    The syslog tag.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_LOG_DEFAULT_SYSLOG_TAG
+    | Command-line option: --log-default-syslog-tag
+
+.. _tcm_configuration_reference_log_default_syslog_timeout:
+
+.. confval:: log.default.syslog.timeout
+
+    The timeout for connecting to the syslog server.
+
+    |
+    | Type: time.Duration
+    | Default: 10s
+    | Environment variable: TCM_LOG_DEFAULT_SYSLOG_TIMEOUT
+    | Command-line option: --log-default-syslog-timeout
+
+.. _tcm_configuration_reference_log_outputs:
+
+.. confval:: log.outputs
+
+    An array of log outputs that |tcm| uses **in addition** to the default one
+    that is defined by the ``log.default.*`` parameters. Each array item can include
+    the parameters of the ``log.default`` group. If a parameter is skipped, its
+    value is taken from ``log.default``.
+
+    |
+    | Type: []LogOuputConfig
+    | Default: []
+    | Environment variable: TCM_LOG_OUTPUTS
+    | Command-line option: --log-outputs
+
+
+.. storage configuration
+
+.. _tcm_configuration_reference_storage:
+
+storage
+-------
+
+The ``storage`` section defines the parameters of the configuration storage that
+|tcm| uses for connected clusters.
+
+-   :ref:`storage.provider <tcm_configuration_reference_storage_provider>`
+
+etcd storage parameters:
+
+-   :ref:`storage.etcd.prefix <tcm_configuration_reference_storage_etcd_prefix>`
+-   :ref:`storage.etcd.endpoints <tcm_configuration_reference_storage_etcd_endpoints>`
+-   :ref:`storage.etcd.dial-timeout <tcm_configuration_reference_storage_etcd_dial-timeout>`
+-   :ref:`storage.etcd.auto-sync-interval <tcm_configuration_reference_storage_etcd_auto-sync-interval>`
+-   :ref:`storage.etcd.dial-keep-alive-time <tcm_configuration_reference_storage_etcd_dial-keep-alive-time>`
+-   :ref:`storage.etcd.dial-keep-alive-timeout <tcm_configuration_reference_storage_etcd_dial-keep-alive-timeout>`
+-   :ref:`storage.etcd.bootstrap-timeout <tcm_configuration_reference_storage_etcd_bootstrap-timeout>`
+-   :ref:`storage.etcd.max-call-send-msg-size <tcm_configuration_reference_storage_etcd_max-call-send-msg-size>`
+-   :ref:`storage.etcd.username <tcm_configuration_reference_storage_etcd_username>`
+-   :ref:`storage.etcd.password <tcm_configuration_reference_storage_etcd_password>`
+-   :ref:`storage.etcd.tls <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.tls.enabled <tcm_configuration_reference_storage_etcd_tls_enabled>`
+-   :ref:`storage.etcd.tls.auto <tcm_configuration_reference_storage_etcd_tls_auto>`
+-   :ref:`storage.etcd.tls.cert-file <tcm_configuration_reference_storage_etcd_tls_cert-file>`
+-   :ref:`storage.etcd.tls.key-file <tcm_configuration_reference_storage_etcd_tls_key-file>`
+-   :ref:`storage.etcd.tls.trusted-ca-file <tcm_configuration_reference_storage_etcd_tls_trusted-ca-file>`
+-   :ref:`storage.etcd.tls.client-cert-auth <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.tls.crl-file: <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.tls.insecure-skip-verify <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.tls.skip-client-san-verify <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.tls.server-name <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.tls.cipher-suites <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.tls.allowed-cn <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.tls.allowed-hostname <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.tls.empty-cn <tcm_configuration_reference_storage_etcd_tls>`
+-   :ref:`storage.etcd.permit-without-stream <tcm_configuration_reference_storage_etcd_permit-without-stream>`
+-   :ref:`storage.etcd.embed.enabled <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.endpoints <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.advertises <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.enabled <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.auto <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.cert-file <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.key-file <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.trusted-ca-file <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.client-cert-auth <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.crl-file <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.insecure-skip-verify <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.skip-client-san-verify <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.server-name <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.cipher-suites <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.allowed-cn <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.allowed-hostname <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.tls.empty-cn <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-endpoints <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-advertises <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.enabled <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.auto <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.cert-file <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.key-file <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.trusted-ca-file <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.client-cert-auth <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.crl-file <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.insecure-skip-verify <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.skip-client-san-verify <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.server-name <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.cipher-suites <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.allowed-cn <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.allowed-hostname <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.peer-tls.empty-cn <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.grpc-keep-alive-timeout <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.grpc-keep-alive-interval <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.grpc-keep-alive-min-time <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.workdir <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.waldir <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.max-request-bytes <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.debug <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.start-timeout <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.log-level <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.initial-cluster <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.initial-cluster-token <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.name <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.initial-cluster-state <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd.embed.self-signed-cert-validity <tcm_configuration_reference_storage_etcd_embed>`
+-   :ref:`storage.etcd. <tcm_configuration_reference_storage_etcd_>`
+
+
+Tarantool storage parameters:
+
+-   :ref:`storage.tarantool.prefix <tcm_configuration_reference_storage_tarantool_prefix>`
+-   :ref:`storage.tarantool.addr <tcm_configuration_reference_storage_tarantool_addr>`
+-   :ref:`storage.tarantool.auth <tcm_configuration_reference_storage_tarantool_timeout>`
+-   :ref:`storage.tarantool.reconnect <tcm_configuration_reference_storage_tarantool_reconnect>`
+-   :ref:`storage.tarantool.max_reconnect <tcm_configuration_reference_storage_tarantool_max_reconnect>`
+-   :ref:`storage.tarantool.user <tcm_configuration_reference_storage_tarantool_user>`
+-   :ref:`storage.tarantool.pass <tcm_configuration_reference_storage_tarantool_pass>`
+-   :ref:`storage.tarantool.rate-limit <tcm_configuration_reference_storage_tarantool_rate-limit>`
+-   :ref:`storage.tarantool.rate-limit-action <tcm_configuration_reference_storage_tarantool_rate-limit-action>`
+-   :ref:`storage.tarantool.concurrency <tcm_configuration_reference_storage_tarantool_concurrency>`
+-   :ref:`storage.tarantool.skip-schema <tcm_configuration_reference_storage_tarantool_skip-schema>`
+-   :ref:`storage.tarantool.transport <tcm_configuration_reference_storage_tarantool_transport>`
+-   :ref:`storage.tarantool.ssl.key-file <tcm_configuration_reference_storage_tarantool_ssl_key-file>`
+-   :ref:`storage.tarantool.ssl.cert-file <tcm_configuration_reference_storage_tarantool_ssl_cert-file>`
+-   :ref:`storage.tarantool.ssl.ca-file <tcm_configuration_reference_storage_tarantool_ssl_ca-file>`
+-   :ref:`storage.tarantool.ssl.ciphers <tcm_configuration_reference_storage_tarantool_ssl_ciphers>`
+-   :ref:`storage.tarantool.ssl.password <tcm_configuration_reference_storage_tarantool_ssl_password>`
+-   :ref:`storage.tarantool.required-protocol-info.auth <tcm_configuration_reference_storage_tarantool_required-protocol-info_auth>`
+-   :ref:`storage.tarantool.required-protocol-info.version <tcm_configuration_reference_storage_tarantool_required-protocol-info_version>`
+-   :ref:`storage.tarantool.required-protocol-info.features <tcm_configuration_reference_storage_tarantool_required-protocol-info_features>`
+-   :ref:`storage.tarantool.embed.enabled <tcm_configuration_reference_storage_tarantool_embed>`
+-   :ref:`storage.tarantool.embed.workdir <tcm_configuration_reference_storage_tarantool_embed>`
+-   :ref:`storage.tarantool.embed.executable <tcm_configuration_reference_storage_tarantool_embed>`
+-   :ref:`storage.tarantool.embed.config-filename <tcm_configuration_reference_storage_tarantool_embed>`
+-   :ref:`storage.tarantool.embed.config <tcm_configuration_reference_storage_tarantool_embed>`
+-   :ref:`storage.tarantool.embed.args <tcm_configuration_reference_storage_tarantool_embed>`
+-   :ref:`storage.tarantool.embed.env <tcm_configuration_reference_storage_tarantool_embed>`
+
+
+.. _tcm_configuration_reference_storage_provider:
+
+
+.. confval:: storage.provider
+
+    The type of the storage used for storing |tcm| configuration.
+
+    Possible values:
+    -   ``etcd``
+    -   ``tarantool``
+
+    |
+    | Type: string
+    | Default: etcd
+    | Environment variable: TCM_STORAGE_PROVIDER
+    | Command-line option: --storage-provider
+
+.. _tcm_configuration_reference_storage_etcd_prefix:
+
+.. confval:: storage.etcd.prefix
+
+    A prefix for the |tcm| configuration parameters in etcd.
+
+    |
+    | Type: string
+    | Default: "/tcm"
+    | Environment variable: TCM_STORAGE_ETCD_PREFIX
+    | Command-line option: --storage-etcd-prefix
+
+
+.. _tcm_configuration_reference_storage_etcd_endpoints:
+
+.. confval:: storage.etcd.endpoints
+
+    An array of node URIs of the etcd cluster where the |tcm| configuration is stored,
+    separated by semicolons (``;``).
+
+    |
+    | Type: []string
+    | Default: [http://127.0.0.1:2379]
+    | Environment variable: TCM_STORAGE_ETCD_ENDPOINTS
+    | Command-line option: --storage-etcd-endpoints
+
+
+.. _tcm_configuration_reference_storage_etcd_dial-timeout:
+
+.. confval:: storage.etcd.dial-timeout
+
+    A etcd dial timeout.
+
+    |
+    | Type: time.Duration
+    | Default: 10s
+    | Environment variable: TCM_STORAGE_ETCD_DIAL_TIMEOUT
+    | Command-line option: --storage-etcd-dial-timeout
+
+
+.. _tcm_configuration_reference_storage_etcd_auto-sync-interval:
+
+.. confval:: storage.etcd.auto-sync-interval
+
+    An automated sync interval.
+    0 - disabled?
+
+    |
+    | Type: time.Duration
+    | Default: 0s
+    | Environment variable: TCM_STORAGE_ETCD_AUTO_SYNC_INTERVAL
+    | Command-line option: --storage-etcd-auto-sync-interval
+
+.. _tcm_configuration_reference_storage_etcd_dial-keep-alive-time:
+
+.. confval:: storage.etcd.dial-keep-alive-time
+
+    A dial keep-alive time.
+
+    |
+    | Type: time.Duration
+    | Default: 30s
+    | Environment variable: TCM_STORAGE_ETCD_DIAL_KEEP_ALIVE_TIME
+    | Command-line option: --storage-etcd-dial-keep-alive-time
+
+.. _tcm_configuration_reference_storage_etcd_dial-keep-alive-timeout:
+
+.. confval:: storage.etcd.dial-keep-alive-timeout
+
+    A dial keep-alive timeout.
+
+    |
+    | Type: time.Duration
+    | Default: 30s
+    | Environment variable: TCM_STORAGE_ETCD_DIAL_KEEP_ALIVE_TIMEOUT
+    | Command-line option: --storage-etcd-dial-keep-alive-timeout
+
+.. _tcm_configuration_reference_storage_etcd_bootstrap-timeout:
+
+.. confval:: storage.etcd.bootstrap-timeout
+
+    A bootstrap timeout.
+
+    |
+    | Type: time.Duration
+    | Default: 30s
+    | Environment variable: TCM_STORAGE_ETCD_BOOTSTRAP_TIMEOUT
+    | Command-line option: --storage-etcd-bootstrap-timeout
+
+.. _tcm_configuration_reference_storage_etcd_max-call-send-msg-size:
+
+.. confval:: storage.etcd.max-call-send-msg-size
+
+    The maximum size of a transaction between |tcm| and etcd, in bytes.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_MAX_CALL_SEND_MSG_SIZE
+    | Command-line option: --storage-etcd-max-call-send-msg-size
+
+.. _tcm_configuration_reference_storage_etcd_username:
+
+.. confval:: storage.etcd.username
+
+    A username for accessing the etcd storage.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_USERNAME
+    | Command-line option: --storage-etcd-username
+
+.. _tcm_configuration_reference_storage_etcd_password:
+
+.. confval:: storage.etcd.password
+
+    A password for accessing the etcd storage.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_PASSWORD
+    | Command-line option: --storage-etcd-password
+
+.. _tcm_configuration_reference_storage_etcd_tls_enabled:
+
+.. confval:: storage.etcd.tls.enabled
+
+    Indicates whether TLS is enabled for etcd connections.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_STORAGE_ETCD_TLS_ENABLED
+    | Command-line option: --storage-etcd-tls-enabled
+
+.. _tcm_configuration_reference_storage_etcd_tls_auto:
+
+.. confval:: storage.etcd.tls.auto
+
+    Use generated certificates for etcd connections.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_STORAGE_ETCD_TLS_AUTO
+    | Command-line option: --storage-etcd-tls-auto
+
+.. _tcm_configuration_reference_storage_etcd_tls_cert-file:
+
+.. confval:: storage.etcd.tls.cert-file
+
+    A path to a TLS certificate file to use for etcd connections.
+    Mandatory when the TLS connection to etcd is enabled.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_TLS_CERT_FILE
+    | Command-line option: --storage-etcd-tls-cert-file
+
+.. _tcm_configuration_reference_storage_etcd_tls_key-file:
+
+.. confval:: storage.etcd.tls.key-file
+
+    A path to a TLS private key file to use for etcd connections.
+    Mandatory when the TLS connection to etcd is enabled.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_TLS_KEY_FILE
+    | Command-line option: --storage-etcd-tls-key-file
+
+.. _tcm_configuration_reference_storage_etcd_tls_trusted-ca-file:
+
+.. confval:: storage.etcd.tls.trusted-ca-file
+
+    A path to a trusted CA certificate file to use for etcd connections.
+    Mandatory when the TLS connection to etcd is enabled.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_TLS_TRUSTED_CA_FILE
+    | Command-line option: --storage-etcd-tls-trusted-ca-file
+
+.. _tcm_configuration_reference_storage_etcd_tls_client-cert-auth:
+
+.. confval:: storage.etcd.tls.client-cert-auth
+
+    Indicates whether client cert authentication is enabled.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_STORAGE_ETCD_TLS_CLIENT_CERT_AUTH
+    | Command-line option: --storage-etcd-tls-client-cert-auth
+
+.. _tcm_configuration_reference_storage_etcd_tls_crl-file:
+
+.. confval:: storage.etcd.tls.crl-file
+
+    A path to the client certificate revocation list file.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_TLS_CRL_FILE
+    | Command-line option: --storage-etcd-tls-crl-file
+
+.. _tcm_configuration_reference_storage_etcd_tls_insecure-skip-verify:
+
+.. confval:: storage.etcd.tls.insecure-skip-verify
+
+    Skip checking client certificate in etcd connections.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_STORAGE_ETCD_TLS_INSECURE_SKIP_VERIFY
+    | Command-line option: --storage-etcd-tls-insecure-skip-verify
+
+.. _tcm_configuration_reference_storage_etcd_tls_skip-client-san-verify:
+
+.. confval:: storage.etcd.tls.skip-client-san-verify
+
+    Skip verification of SAN field in client certificate for etcd connections.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_STORAGE_ETCD_TLS_SKIP_CLIENT_SAN_VERIFY
+    | Command-line option: --storage-etcd-tls-skip-client-san-verify
+
+.. _tcm_configuration_reference_storage_etcd_tls_server-name:
+
+.. confval:: storage.etcd.tls.server-name
+
+    Name of the TLS server for etcd connections.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_TLS_SERVER_NAME
+    | Command-line option: --storage-etcd-tls-server-name
+
+.. _tcm_configuration_reference_storage_etcd_tls_cipher-suites:
+
+.. confval:: storage.etcd.tls.cipher-suites
+
+    TLS cipher suites for etcd connections. Possible values are the Golang `tls.TLS_* <https://pkg.go.dev/crypto/tls#pkg-constants>`__ constants.
+
+    |
+    | Type: []uint16
+    | Default: []
+    | Environment variable: TCM_STORAGE_ETCD_TLS_CIPHER_SUITES
+    | Command-line option: --storage-etcd-tls-cipher-suites
+
+.. _tcm_configuration_reference_storage_etcd_tls_allowed-cn:
+
+.. confval:: storage.etcd.tls.allowed-cn
+
+    An allowed common name for authentication in etcd connections.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_TLS_ALLOWED_CN
+    | Command-line option: --storage-etcd-tls-allowed-cn
+
+.. _tcm_configuration_reference_storage_etcd_tls_allowed-hostname:
+
+.. confval:: storage.etcd.tls.allowed-hostname
+
+    An allowed TLS certificate name for authentication in etcd connections.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_ETCD_TLS_ALLOWED_HOSTNAME
+    | Command-line option: --storage-etcd-tls-allowed-hostname
+
+.. _tcm_configuration_reference_storage_etcd_tls_empty-cn:
+
+.. confval:: storage.etcd.tls.empty-cn
+
+    Whether the empty common name is allowed in etcd connections.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_STORAGE_ETCD_TLS_EMPTY_CN
+    | Command-line option: --storage-etcd-tls-empty-cn
+
+.. _tcm_configuration_reference_storage_etcd_embed:
+
+storage.etcd.embed.*
+--------------------
+
+The ``storage.etcd.embed`` group parameters define the configuration of the
+embedded etcd cluster that can used as a |tcm| configuration storage.
+This cluster can be used for development purposes when the production or testing
+etcd cluster is not available or not needed.
+
+
+.. _tcm_configuration_reference_storage_tarantool_prefix:
+
+.. confval:: storage.tarantool.prefix
+
+    A
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_TARANTOOL_PREFIX
+    | Command-line option: --storage-tarantool-prefix
+
+
+.. _tcm_configuration_reference_storage_tarantool_embed:
+
+storage.tarantool.embed.*
+-------------------------
+
+The ``storage.tarantool.embed`` group parameters define the configuration of the
+embedded Tarantool cluster that can used as a |tcm| configuration storage.
+This cluster can be used for development purposes when the production or testing
+cluster is not available or not needed.
+
+
+
+.. _tcm_configuration_reference_addon:
+
+
+addon
+-----
+
+The ``addon`` section defines the |tcm|
+
+-   :ref:`addon.enabled <tcm_configuration_reference_addon_enabled>`
+-   :ref:`addon.addons-dir <tcm_configuration_reference_addon_addons-dir>`
+-   :ref:`addon.max-upload-size <tcm_configuration_reference_addon_max-upload-size>`
+-   :ref:`addon.dev-addons-dir <tcm_configuration_reference_addon_dev-addons-dir>`
+
+.. _tcm_configuration_reference_addon_enabled:
+
+.. confval:: addon.enabled
+
+    Whether to enable the add-on functionality in |tcm|.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_ADDON_ENABLED
+    | Command-line option: --addon-enabled
+
+.. _tcm_configuration_reference_addon_addons-dir:
+
+.. confval:: addon.addons-dir
+
+    The directory where add-on files are stored.
+
+    |
+    | Type: string
+    | Default: addons
+    | Environment variable: TCM_ADDON_ADDONS_DIR
+    | Command-line option: --addon-addons-dir
+
+.. _tcm_configuration_reference_addon_max-upload-size:
+
+.. confval:: addon.max-upload-size
+
+    The maximum size of addon to upload to |tcm|, in bytes.
+
+    |
+    | Type: int64
+    | Default: 104857600
+    | Environment variable: TCM_ADDON_MAX_UPLOAD_SIZE
+    | Command-line option: --addon-max-upload-size
+
+.. _tcm_configuration_reference_addon_dev-addons-dir:
+
+.. confval:: addon.dev-addons-dir
+
+    Additional add-on directories for development purposes, separated by commas.
+    ? Maybe convert to semicolon
+
+    |
+    | Type: []string
+    | Default: []
+    | Environment variable: TCM_ADDON_DEV_ADDONS_DIR
+    | Command-line option: --addon-dev-addons-dir
+
+.. limits configuration
+
+.. _tcm_configuration_reference_limits:
+
+limits
+------
+
+The ``limits`` section defines limits on various |tcm| objects and relations
+between them.
+
+-   :ref:`limits.users-count <tcm_configuration_reference_limits_users-count>`
+-   :ref:`limits.clusters-count <tcm_configuration_reference_limits_clusters-count>`
+-   :ref:`limits.roles-count <tcm_configuration_reference_limits_roles-count>`
+-   :ref:`limits.user-secrets-count <tcm_configuration_reference_limits_user-secrets-count>`
+-   :ref:`limits.user-websessions-count <tcm_configuration_reference_limits_user-websessions-count>`
+-   :ref:`limits.linked-cluster-users <tcm_configuration_reference_limits_linked-cluster-users>`
+
+.. _tcm_configuration_reference_limits_users-count:
+
+.. confval:: limits.users-count
+
+    The maximum number of users in |tcm|.
+
+    |
+    | Type: int
+    | Default: 1000
+    | Environment variable: TCM_LIMITS_USERS_COUNT
+    | Command-line option: --limits-users-count
+
+.. _tcm_configuration_reference_limits_clusters-count:
+
+.. confval:: limits.clusters-count
+
+    The maximum number of clusters in |tcm|.
+
+    |
+    | Type: int
+    | Default: 10
+    | Environment variable: TCM_LIMITS_CLUSTERS_COUNT
+    | Command-line option: --limits-clusters-count
+
+.. _tcm_configuration_reference_limits_roles-count:
+
+.. confval:: limits.roles-count
+
+    The maximum number of roles in |tcm|.
+
+    |
+    | Type: int
+    | Default: 100
+    | Environment variable: TCM_LIMITS_ROLES_COUNT
+    | Command-line option: --limits-roles-count
+
+.. _tcm_configuration_reference_limits_user-secrets-count:
+
+.. confval:: limits.user-secrets-count
+
+    The maximum number secrets that a |tcm| user can have.
+
+    |
+    | Type: int
+    | Default: 10
+    | Environment variable: TCM_LIMITS_USER_SECRETS_COUNT
+    | Command-line option: --limits-user-secrets-count
+
+.. _tcm_configuration_reference_limits_user-websessions-count:
+
+.. confval:: limits.user-websessions-count
+
+    The maximum number of open sessions that a |tcm| user can have.
+
+    |
+    | Type: int
+    | Default: 10
+    | Environment variable: TCM_LIMITS_USER_WEBSESSIONS_COUNT
+    | Command-line option: --limits-user-websessions-count
+
+.. _tcm_configuration_reference_limits_linked-cluster-users:
+
+.. confval:: limits.linked-cluster-users
+
+    The maximum number of clusters to which a single user can have access.
+
+    |
+    | Type: int
+    | Default: 10
+    | Environment variable: TCM_LIMITS_LINKED_CLUSTER_USERS
+    | Command-line option: --limits-linked-cluster-users
+
+
+.. security parameters
+
+.. _tcm_configuration_reference_security:
+
+security
+--------
+
+The ``security`` section defines the security parameters of |tcm|.
+
+-   :ref:`security.auth <tcm_configuration_reference_security_auth>`
+-   :ref:`security.hash-cost <tcm_configuration_reference_security_hash-cost>`
+-   :ref:`security.encryption-key <tcm_configuration_reference_security_encryption-key>`
+-   :ref:`security.encryption-key-file <tcm_configuration_reference_security_encryption-key-file_>`
+-   :ref:`security.bootstrap-password <tcm_configuration_reference_security_bootstrap-password>`
+-   :ref:`security.integrity-check <tcm_configuration_reference_security_integrity-check>`
+-   :ref:`security.signature-private-key-file <tcm_configuration_reference_security_signature-private-key-file>`
+
+.. _tcm_configuration_reference_security_auth:
+
+.. confval:: security.auth
+
+    ?? separator is ;
+
+    |
+    | Type: []string
+    | Default: [local]
+    | Environment variable: TCM_SECURITY_AUTH
+    | Command-line option: --security-auth
+
+.. _tcm_configuration_reference_security_hash-cost:
+
+.. confval:: security.hash-cost
+
+    ?? separator is ;
+
+    |
+    | Type: int
+    | Default: 12
+    | Environment variable: TCM_SECURITY_HASH_COST
+    | Command-line option: --security-hash-cost
+
+.. _tcm_configuration_reference_security_encryption-key:
+
+.. confval:: security.encryption-key
+
+    ?? separator is ;
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_SECURITY_ENCRYPTION_KEY
+    | Command-line option: --security-encryption-key
+
+.. _tcm_configuration_reference_security_encryption-key-file:
+
+.. confval:: security.encryption-key-file
+
+    ?? separator is ;
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_SECURITY_ENCRYPTION_KEY_FILE
+    | Command-line option: --security-encryption-key-file
+
+.. _tcm_configuration_reference_security_bootstrap-password:
+
+.. confval:: security.bootstrap-password
+
+    A password for the first login of the ``admin`` user. Must be changed after the
+    successful login.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_SECURITY_BOOTSTRAP_PASSWORD
+    | Command-line option: --security-bootstrap-password
+
+.. _tcm_configuration_security_integrity-check:
+
+.. confval:: security.integrity-check
+
+    ? TBD
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_SECURITY_INTEGRITY_CHECK
+    | Command-line option: --security-integrity-check
+
+.. _tcm_configuration_security_signature-private-key-file:
+
+.. confval:: security.signature-private-key-file
+
+    ? TBD
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_SECURITY_SIGNATURE_PRIVATE_KEY_FILE
+    | Command-line option: --security-signature-private-key-file
+
+.. mode
+
+.. _tcm_configuration_reference_mode:
+
+mode
+----
+
+.. confval:: mode
+
+    The |tcm| mode: ``production``, ``development``, or ``test``.
+
+    |
+    | Type: string
+    | Default: production
+    | Environment variable: TCM_MODE
+    | Command-line option: --mode
+

--- a/doc/reference/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration_reference.rst
@@ -349,7 +349,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
 
     Indicates that the cookie can't be accessed from the JavaScript
     `Document.cookie <https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie>`__ API.
-    This help mitigate cross-site scripting attacks.
+    This helps mitigate cross-site scripting attacks.
 
     When ``true``, the ``HttpOnly`` attribute is added to the `Set-Cookie <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie>`__
     HTTP response header.
@@ -944,7 +944,7 @@ The ``log`` section defines the |tcm|  logging parameters.
 .. confval:: log.default.syslog.protocol
 
     The network protocol used for connecting to the syslog server. Typically,
-    it's ``tcp``,``udp`, or ``unix``. All possible values are listed in the Go's
+    it's ``tcp``,``udp``, or ``unix``. All possible values are listed in the Go's
     `net.Dial <https://pkg.go.dev/net#Dial>`__ documentation.
 
     |
@@ -1197,7 +1197,7 @@ Tarantool storage parameters:
 
 .. confval:: storage.etcd.dial-timeout
 
-    A etcd dial timeout.
+    An etcd dial timeout.
 
     |
     | Type: time.Duration
@@ -1602,7 +1602,7 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.rate-limit-action
 
-    A action to perform when the :ref:`<tcm_configuration_reference_storage_tarantool_rate-limit>` is reached.
+    An action to perform when the :ref:`<tcm_configuration_reference_storage_tarantool_rate-limit>` is reached.
 
     See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
 

--- a/doc/reference/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration_reference.rst
@@ -39,7 +39,7 @@ Tarantool clusters.
     | Type: int64
     | Default: 4096
     | Environment variable: TCM_CLUSTER_ON_AIR_LIMIT
-    | Command-line option: ``cluster_on_air_limit``
+    | Command-line option: ``--cluster-on-air-limit``
 
 .. _tcm_configuration_reference_cluster_connection-rate-limit:
 
@@ -51,7 +51,7 @@ Tarantool clusters.
     | Type: uint
     | Default: 512
     | Environment variable: TCM_CLUSTER_CONNECTION_RATE_LIMIT
-    | Command-line option: ``cluster-connection-rate-limit``
+    | Command-line option: ``--cluster-connection-rate-limit``
 
 .. _tcm_configuration_reference_cluster_tarantool-timeout:
 

--- a/doc/reference/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration_reference.rst
@@ -39,7 +39,7 @@ Tarantool clusters.
     | Type: int64
     | Default: 4096
     | Environment variable: TCM_CLUSTER_ON_AIR_LIMIT
-    | Command-line option: --cluster_on_air_limit
+    | Command-line option: ``cluster_on_air_limit``
 
 .. _tcm_configuration_reference_cluster_connection-rate-limit:
 
@@ -51,7 +51,7 @@ Tarantool clusters.
     | Type: uint
     | Default: 512
     | Environment variable: TCM_CLUSTER_CONNECTION_RATE_LIMIT
-    | Command-line option: --cluster-connection-rate-limit
+    | Command-line option: ``cluster-connection-rate-limit``
 
 .. _tcm_configuration_reference_cluster_tarantool-timeout:
 
@@ -63,7 +63,7 @@ Tarantool clusters.
     | Type: time.Duration
     | Default: 10s
     | Environment variable: TCM_CLUSTER_TARANTOOL_TIMEOUT
-    | Command-line option: --cluster-tarantool-timeout
+    | Command-line option: ``--cluster-tarantool-timeout``
 
 .. _tcm_configuration_reference_cluster_tarantool-ping-timeout:
 
@@ -75,7 +75,7 @@ Tarantool clusters.
     | Type: time.Duration
     | Default: 5s
     | Environment variable: TCM_CLUSTER_TARANTOOL_PING_TIMEOUT
-    | Command-line option: --cluster-tarantool-ping-timeout
+    | Command-line option: ``--cluster-tarantool-ping-timeout``
 
 .. _tcm_configuration_reference_http:
 
@@ -143,7 +143,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: bool
     | Default: false
     | Environment variable: TCM_HTTP_BASIC_AUTH_ENABLED
-    | Command-line option: --http-basic-auth-enabled
+    | Command-line option: ``--http-basic-auth-enabled``
 
 .. _tcm_configuration_reference_http_network:
 
@@ -161,7 +161,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: tcp
     | Environment variable: TCM_HTTP_NETWORK
-    | Command-line option: --http-network
+    | Command-line option: ``--http-network``
 
 .. _tcm_configuration_reference_http_host:
 
@@ -173,7 +173,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: 127.0.0.1
     | Environment variable: TCM_HTTP_HOST
-    | Command-line option: --http-host
+    | Command-line option: ``--http-host``
 
 
 .. _tcm_configuration_reference_http_port:
@@ -186,46 +186,46 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: int
     | Default: 8080
     | Environment variable: TCM_HTTP_PORT
-    | Command-line option: --http-port
+    | Command-line option: ``--http-port``
 
 
 .. _tcm_configuration_reference_http_request-size:
 
 .. confval:: http.request-size
 
-    The maximum size of a client HTTP request to |tcm|, in bytes.
+    The maximum size (in bytes) of a client HTTP request to |tcm|.
 
     |
     | Type: int64
     | Default: 1572864
     | Environment variable: TCM_HTTP_REQUEST_SIZE
-    | Command-line option: --http-request-size
+    | Command-line option: ``--http-request-size``
 
 .. _tcm_configuration_reference_http_websocket_read-buffer-size:
 
 .. confval:: http.websocket.read-buffer-size
 
-    The size of the read buffer for `WebSocket <https://developer.mozilla.org/en-US/docs/Glossary/WebSockets>`__
-    connections, in bytes.
+    The size (in bytes) of the read buffer for `WebSocket <https://developer.mozilla.org/en-US/docs/Glossary/WebSockets>`__
+    connections.
 
     |
     | Type: int
     | Default: 16384
     | Environment variable: TCM_HTTP_WEBSOCKET_READ_BUFFER_SIZE
-    | Command-line option: --http-websocket-read-buffer-size
+    | Command-line option: ``--http-websocket-read-buffer-size``
 
 .. _tcm_configuration_reference_http_websocket_write-buffer-size:
 
 .. confval:: http.websocket.write-buffer-size
 
-    The size of the write buffer for `WebSocket <https://developer.mozilla.org/en-US/docs/Glossary/WebSockets>`__
-    connections, in bytes.
+    The size (in bytes) of the write buffer for `WebSocket <https://developer.mozilla.org/en-US/docs/Glossary/WebSockets>`__
+    connections.
 
     |
     | Type: int
     | Default: 16384
     | Environment variable: TCM_HTTP_WEBSOCKET_WRITE_BUFFER_SIZE
-    | Command-line option: --http-websocket-write-buffer-size
+    | Command-line option: ``--http-websocket-write-buffer-size``
 
 .. _tcm_configuration_reference_http_websocket_keepalive-ping-interval:
 
@@ -238,7 +238,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 20s
     | Environment variable: TCM_HTTP_WEBSOCKET_KEEPALIVE_PING_INTERVAL
-    | Command-line option: --http-websocket-keepalive-ping-interval
+    | Command-line option: ``--http-websocket-keepalive-ping-interval``
 
 .. _tcm_configuration_reference_http_websocket_handshake-timeout:
 
@@ -251,7 +251,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 10s
     | Environment variable: TCM_HTTP_WEBSOCKET_HANDSHAKE_TIMEOUT
-    | Command-line option: --http-websocket-handshake-timeout
+    | Command-line option: ``--http-websocket-handshake-timeout``
 
 .. _tcm_configuration_reference_http_websocket_init-timeout:
 
@@ -264,7 +264,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 15s
     | Environment variable: TCM_HTTP_WEBSOCKET_INIT_TIMEOUT
-    | Command-line option: --http-websocket-init-timeout
+    | Command-line option: ``--http-websocket-init-timeout``
 
 .. _tcm_configuration_reference_http_websession-cookie_name:
 
@@ -279,7 +279,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: tcm
     | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_NAME
-    | Command-line option: --http-websession-cookie-name
+    | Command-line option: ``--http-websession-cookie-name``
 
 .. _tcm_configuration_reference_http_websession-cookie_path:
 
@@ -294,7 +294,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: ""
     | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_PATH
-    | Command-line option: --http-websession-cookie-path
+    | Command-line option: ``--http-websession-cookie-path``
 
 .. _tcm_configuration_reference_http_websession-cookie_domain:
 
@@ -309,7 +309,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: ""
     | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_DOMAIN
-    | Command-line option: --http-websession-cookie-domain
+    | Command-line option: ``--http-websession-cookie-domain``
 
 .. _tcm_configuration_reference_http_websession-cookie_ttl:
 
@@ -324,7 +324,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 2h0m0s
     | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_TTL
-    | Command-line option: --http-websession-cookie-ttl
+    | Command-line option: ``--http-websession-cookie-ttl``
 
 .. _tcm_configuration_reference_http_websession-cookie_secure:
 
@@ -341,7 +341,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: bool
     | Default: false
     | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_SECURE
-    | Command-line option: --http-websession-cookie-secure
+    | Command-line option: ``--http-websession-cookie-secure``
 
 .. _tcm_configuration_reference_http_websession-cookie_http-only:
 
@@ -358,7 +358,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: bool
     | Default: true
     | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_HTTP_ONLY
-    | Command-line option: --http-websession-cookie-http-only
+    | Command-line option: ``--http-websession-cookie-http-only``
 
 .. _tcm_configuration_reference_http_websession-cookie_same-site:
 
@@ -382,7 +382,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: http.SameSite
     | Default: SameSiteDefaultMode
     | Environment variable: TCM_HTTP_WEBSESSION_COOKIE_SAME_SITE
-    | Command-line option: --http-websession-cookie-same-site
+    | Command-line option: ``--http-websession-cookie-same-site``
 
 .. _tcm_configuration_reference_http_cors_enabled:
 
@@ -395,7 +395,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: bool
     | Default: false
     | Environment variable: TCM_HTTP_CORS_ENABLED
-    | Command-line option: --http-cors-enabled
+    | Command-line option: ``--http-cors-enabled``
 
 .. _tcm_configuration_reference_http_cors_allowed-origins:
 
@@ -411,7 +411,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: []string
     | Default: []
     | Environment variable: TCM_HTTP_CORS_ALLOWED_ORIGINS
-    | Command-line option: --http-cors-allowed-origins
+    | Command-line option: ``--http-cors-allowed-origins``
 
 .. _tcm_configuration_reference_http_cors_allowed-methods:
 
@@ -427,7 +427,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: []string
     | Default: []
     | Environment variable: TCM_HTTP_CORS_ALLOWED_METHODS
-    | Command-line option: --http-cors-allowed-methods
+    | Command-line option: ``--http-cors-allowed-methods``
 
 .. _tcm_configuration_reference_http_cors_allowed-headers:
 
@@ -442,7 +442,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: []string
     | Default: []
     | Environment variable: TCM_HTTP_CORS_ALLOWED_HEADERS
-    | Command-line option: --http-cors-allowed-headers
+    | Command-line option: ``--http-cors-allowed-headers``
 
 .. _tcm_configuration_reference_http_cors_exposed-headers:
 
@@ -458,7 +458,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: []string
     | Default: []
     | Environment variable: TCM_HTTP_CORS_EXPOSED_HEADERS
-    | Command-line option: --http-cors-exposed-headers
+    | Command-line option: ``--http-cors-exposed-headers``
 
 .. _tcm_configuration_reference_http_cors_allow-credentials:
 
@@ -475,7 +475,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: bool
     | Default: false
     | Environment variable: TCM_HTTP_CORS_ALLOW_CREDENTIALS
-    | Command-line option: --http-cors-allow-credentials
+    | Command-line option: ``--http-cors-allow-credentials``
 
 .. _tcm_configuration_reference_http_cors_debug:
 
@@ -497,7 +497,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: /metrics
     | Environment variable: TCM_HTTP_METRICS_ENDPOINT
-    | Command-line option: --http-metrics-endpoint
+    | Command-line option: ``--http-metrics-endpoint``
 
 .. _tcm_configuration_reference_http_tls_enabled:
 
@@ -509,7 +509,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: bool
     | Default: false
     | Environment variable: TCM_HTTP_TLS_ENABLED
-    | Command-line option: --http-tls-enabled
+    | Command-line option: ``--http-tls-enabled``
 
 .. _tcm_configuration_reference_http_tls_cert-file:
 
@@ -521,7 +521,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: ""
     | Environment variable: TCM_HTTP_TLS_CERT_FILE
-    | Command-line option: --http-tls-cert-file
+    | Command-line option: ``--http-tls-cert-file``
 
 .. _tcm_configuration_reference_http_tls_key-file:
 
@@ -533,7 +533,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: ""
     | Environment variable: TCM_HTTP_TLS_KEY_FILE
-    | Command-line option: --http-tls-key-file
+    | Command-line option: ``--http-tls-key-file``
 
 .. _tcm_configuration_reference_http_tls_server:
 
@@ -545,7 +545,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: ""
     | Environment variable: TCM_HTTP_TLS_SERVER
-    | Command-line option: --http-tls-server
+    | Command-line option: ``--http-tls-server``
 
 .. _tcm_configuration_reference_http_tls_min-version:
 
@@ -557,7 +557,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: uint16
     | Default: 0
     | Environment variable: TCM_HTTP_TLS_MIN_VERSION
-    | Command-line option: --http-tls-min-version
+    | Command-line option: ``--http-tls-min-version``
 
 .. _tcm_configuration_reference_http_tls_max-version:
 
@@ -569,7 +569,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: uint16
     | Default: 0
     | Environment variable: TCM_HTTP_TLS_MAX_VERSION
-    | Command-line option: --http-tls-max-version
+    | Command-line option: ``--http-tls-max-version``
 
 .. _tcm_configuration_reference_http_tls_curve-preferences:
 
@@ -587,7 +587,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: []tls.CurveID
     | Default: []
     | Environment variable: TCM_HTTP_TLS_CURVE_PREFERENCES
-    | Command-line option: --http-tls-curve-preferences
+    | Command-line option: ``--http-tls-curve-preferences``
 
 .. _tcm_configuration_reference_http_tls_cipher-suites:
 
@@ -599,7 +599,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: []uint16
     | Default: []
     | Environment variable: TCM_HTTP_TLS_CIPHER_SUITES
-    | Command-line option: --http-tls-cipher-suites
+    | Command-line option: ``--http-tls-cipher-suites``
 
 .. _tcm_configuration_reference_http_read-timeout:
 
@@ -611,7 +611,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 30s
     | Environment variable: TCM_HTTP_READ_TIMEOUT
-    | Command-line option: --http-read-timeout
+    | Command-line option: ``--http-read-timeout``
 
 .. _tcm_configuration_reference_http_read-header-timeout:
 
@@ -623,7 +623,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 30s
     | Environment variable: TCM_HTTP_READ_HEADER_TIMEOUT
-    | Command-line option: --http-read-header-timeout
+    | Command-line option: ``--http-read-header-timeout``
 
 .. _tcm_configuration_reference_http_write-timeout:
 
@@ -635,7 +635,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 30s
     | Environment variable: TCM_HTTP_WRITE_TIMEOUT
-    | Command-line option: --http-write-timeout
+    | Command-line option: ``--http-write-timeout``
 
 .. _tcm_configuration_reference_http_idle-timeout:
 
@@ -647,7 +647,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 30s
     | Environment variable: TCM_HTTP_IDLE_TIMEOUT
-    | Command-line option: --http-idle-timeout
+    | Command-line option: ``--http-idle-timeout``
 
 .. _tcm_configuration_reference_http_disable-general-options-handler:
 
@@ -659,19 +659,19 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: bool
     | Default: false
     | Environment variable: TCM_HTTP_DISABLE_GENERAL_OPTIONS_HANDLER
-    | Command-line option: --http-disable-general-options-handler
+    | Command-line option: ``--http-disable-general-options-handler``
 
 .. _tcm_configuration_reference_http_max-header-bytes:
 
 .. confval:: http.max-header-bytes
 
-    The maximum size of a header in a client's request to |TCM|, in bytes.
+    The maximum size (in bytes) of a header in a client's request to |TCM|.
 
     |
     | Type: int
     | Default: 0
     | Environment variable: TCM_HTTP_MAX_HEADER_BYTES
-    | Command-line option: --http-max-header-bytes
+    | Command-line option: ``--http-max-header-bytes``
 
 .. _tcm_configuration_reference_http_api-timeout:
 
@@ -683,7 +683,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 8s
     | Environment variable: TCM_HTTP_API_TIMEOUT
-    | Command-line option: --http-api-timeout
+    | Command-line option: ``--http-api-timeout``
 
 .. _tcm_configuration_reference_http_api-update-interval:
 
@@ -695,7 +695,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: time.Duration
     | Default: 5s
     | Environment variable: TCM_HTTP_API_UPDATE_INTERVAL
-    | Command-line option: --http-api-update-interval
+    | Command-line option: ``--http-api-update-interval``
 
 .. _tcm_configuration_reference_http_frontend-dir:
 
@@ -707,7 +707,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: string
     | Default: ""
     | Environment variable: TCM_HTTP_FRONTEND_DIR
-    | Command-line option: --http-frontend-dir
+    | Command-line option: ``--http-frontend-dir``
 
 .. _tcm_configuration_reference_http_show-stack-trace:
 
@@ -719,7 +719,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: bool
     | Default: true
     | Environment variable: TCM_HTTP_SHOW_STACK_TRACE
-    | Command-line option: --http-show-stack-trace
+    | Command-line option: ``--http-show-stack-trace``
 
 .. _tcm_configuration_reference_http_trace:
 
@@ -731,19 +731,19 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: bool
     | Default: false
     | Environment variable: TCM_HTTP_TRACE
-    | Command-line option: --http-trace
+    | Command-line option: ``--http-trace``
 
 .. _tcm_configuration_reference_http_max-static-size:
 
 .. confval:: http.max-static-size
 
-    The maximum size of a static content sent to |TCM|, in bytes.
+    The maximum size (in bytes) of a static content sent to |TCM|.
 
     |
     | Type: int
     | Default: 104857600
     | Environment variable: TCM_HTTP_MAX_STATIC_SIZE
-    | Command-line option: --http-max-static-size
+    | Command-line option: ``--http-max-static-size``
 
 .. _tcm_configuration_reference_http_graphql_complexity:
 
@@ -757,7 +757,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
     | Type: int
     | Default: 40
     | Environment variable: TCM_HTTP_GRAPHQL_COMPLEXITY
-    | Command-line option: --http-graphql-complexity
+    | Command-line option: ``--http-graphql-complexity``
 
 
 .. log configuration
@@ -798,7 +798,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: bool
     | Default: false
     | Environment variable: TCM_LOG_DEFAULT_ADD_SOURCE
-    | Command-line option: --log-default-add-source
+    | Command-line option: ``--log-default-add-source``
 
 .. _tcm_configuration_reference_log_default_show-stack-trace:
 
@@ -810,7 +810,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: bool
     | Default: false
     | Environment variable: TCM_LOG_DEFAULT_SHOW_STACK_TRACE
-    | Command-line option: --log-default-show-stack-trace
+    | Command-line option: ``--log-default-show-stack-trace``
 
 .. _tcm_configuration_reference_log_default_level:
 
@@ -829,7 +829,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: string
     | Default: INFO
     | Environment variable: TCM_LOG_DEFAULT_LEVEL
-    | Command-line option: --log-default-level
+    | Command-line option: ``--log-default-level``
 
 .. _tcm_configuration_reference_log_default_format:
 
@@ -846,7 +846,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: string
     | Default: struct
     | Environment variable: TCM_LOG_DEFAULT_FORMAT
-    | Command-line option: --log-default-format
+    | Command-line option: ``--log-default-format``
 
 .. _tcm_configuration_reference_log_default_output:
 
@@ -865,7 +865,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: string
     | Default: stdout
     | Environment variable: TCM_LOG_DEFAULT_OUTPUT
-    | Command-line option: --log-default-output
+    | Command-line option: ``--log-default-output``
 
 .. _tcm_configuration_reference_log_default_no-colorized:
 
@@ -877,7 +877,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: bool
     | Default: false
     | Environment variable: TCM_LOG_DEFAULT_NO_COLORIZED
-    | Command-line option: --log-default-no-colorized
+    | Command-line option: ``--log-default-no-colorized``
 
 .. _tcm_configuration_reference_log_default_file_name:
 
@@ -889,19 +889,19 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: string
     | Default: ""
     | Environment variable: TCM_LOG_DEFAULT_FILE_NAME
-    | Command-line option: --log-default-file-name
+    | Command-line option: ``--log-default-file-name``
 
 .. _tcm_configuration_reference_log_default_file_maxsize:
 
 .. confval:: log.default.file.maxsize
 
-    The maximum size of the |tcm| log file, in bytes.
+    The maximum size (in bytes) of the |tcm| log file.
 
     |
     | Type: int
     | Default: 0
     | Environment variable: TCM_LOG_DEFAULT_FILE_MAXSIZE
-    | Command-line option: --log-default-file-maxsize
+    | Command-line option: ``--log-default-file-maxsize``
 
 .. _tcm_configuration_reference_log_default_file_maxage:
 
@@ -913,7 +913,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: int
     | Default: 0
     | Environment variable: TCM_LOG_DEFAULT_FILE_MAXAGE
-    | Command-line option: --log-default-file-maxage
+    | Command-line option: ``--log-default-file-maxage``
 
 .. _tcm_configuration_reference_log_default_file_maxbackups:
 
@@ -925,7 +925,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: int
     | Default: 0
     | Environment variable: TCM_LOG_DEFAULT_FILE_MAXBACKUPS
-    | Command-line option: --log-default-file-maxbackups
+    | Command-line option: ``--log-default-file-maxbackups``
 
 .. _tcm_configuration_reference_log_default_file_compress:
 
@@ -937,21 +937,21 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: bool
     | Default: false
     | Environment variable: TCM_LOG_DEFAULT_FILE_COMPRESS
-    | Command-line option: --log-default-file-compress
+    | Command-line option: ``--log-default-file-compress``
 
 .. _tcm_configuration_reference_log_default_syslog_protocol:
 
 .. confval:: log.default.syslog.protocol
 
     The network protocol used for connecting to the syslog server. Typically,
-    it's ``tcp``,``udp``, or ``unix``. All possible values are listed in the Go's
+    it's ``tcp``, ``udp``, or ``unix``. All possible values are listed in the Go's
     `net.Dial <https://pkg.go.dev/net#Dial>`__ documentation.
 
     |
     | Type: string
     | Default: tcp
     | Environment variable: TCM_LOG_DEFAULT_SYSLOG_PROTOCOL
-    | Command-line option: --log-default-syslog-protocol
+    | Command-line option: ``--log-default-syslog-protocol``
 
 .. _tcm_configuration_reference_log_default_syslog_output:
 
@@ -963,7 +963,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: string
     | Default: 127.0.0.1:5514
     | Environment variable: TCM_LOG_DEFAULT_SYSLOG_OUTPUT
-    | Command-line option: --log-default-syslog-output
+    | Command-line option: ``--log-default-syslog-output``
 
 .. _tcm_configuration_reference_log_default_syslog_priority:
 
@@ -975,7 +975,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: string
     | Default: ""
     | Environment variable: TCM_LOG_DEFAULT_SYSLOG_PRIORITY
-    | Command-line option: --log-default-syslog-priority
+    | Command-line option: ``--log-default-syslog-priority``
 
 .. _tcm_configuration_reference_log_default_syslog_facility:
 
@@ -987,7 +987,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: string
     | Default: ""
     | Environment variable: TCM_LOG_DEFAULT_SYSLOG_FACILITY
-    | Command-line option: --log-default-syslog-facility
+    | Command-line option: ``--log-default-syslog-facility``
 
 .. _tcm_configuration_reference_log_default_syslog_tag:
 
@@ -999,7 +999,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: string
     | Default: ""
     | Environment variable: TCM_LOG_DEFAULT_SYSLOG_TAG
-    | Command-line option: --log-default-syslog-tag
+    | Command-line option: ``--log-default-syslog-tag``
 
 .. _tcm_configuration_reference_log_default_syslog_timeout:
 
@@ -1011,7 +1011,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: time.Duration
     | Default: 10s
     | Environment variable: TCM_LOG_DEFAULT_SYSLOG_TIMEOUT
-    | Command-line option: --log-default-syslog-timeout
+    | Command-line option: ``--log-default-syslog-timeout``
 
 .. _tcm_configuration_reference_log_outputs:
 
@@ -1026,7 +1026,7 @@ The ``log`` section defines the |tcm|  logging parameters.
     | Type: []LogOuputConfig
     | Default: []
     | Environment variable: TCM_LOG_OUTPUTS
-    | Command-line option: --log-outputs
+    | Command-line option: ``--log-outputs``
 
 
 .. storage configuration
@@ -1164,7 +1164,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: etcd
     | Environment variable: TCM_STORAGE_PROVIDER
-    | Command-line option: --storage-provider
+    | Command-line option: ``--storage-provider``
 
 .. _tcm_configuration_reference_storage_etcd_prefix:
 
@@ -1176,7 +1176,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: "/tcm"
     | Environment variable: TCM_STORAGE_ETCD_PREFIX
-    | Command-line option: --storage-etcd-prefix
+    | Command-line option: ``--storage-etcd-prefix``
 
 
 .. _tcm_configuration_reference_storage_etcd_endpoints:
@@ -1190,7 +1190,7 @@ Tarantool storage parameters:
     | Type: []string
     | Default: ["http://127.0.0.1:2379"]
     | Environment variable: TCM_STORAGE_ETCD_ENDPOINTS
-    | Command-line option: --storage-etcd-endpoints
+    | Command-line option: ``--storage-etcd-endpoints``
 
 
 .. _tcm_configuration_reference_storage_etcd_dial-timeout:
@@ -1203,8 +1203,8 @@ Tarantool storage parameters:
     | Type: time.Duration
     | Default: 10s
     | Environment variable: TCM_STORAGE_ETCD_DIAL_TIMEOUT
-    | Command-line option: --storage-etcd-dial-timeout
-
+    | Command-line option: ``--storage-etcd-dial-timeout``
+``
 
 .. _tcm_configuration_reference_storage_etcd_auto-sync-interval:
 
@@ -1216,7 +1216,7 @@ Tarantool storage parameters:
     | Type: time.Duration
     | Default: 0s
     | Environment variable: TCM_STORAGE_ETCD_AUTO_SYNC_INTERVAL
-    | Command-line option: --storage-etcd-auto-sync-interval
+    | Command-line option: ``--storage-etcd-auto-sync-interval``
 
 .. _tcm_configuration_reference_storage_etcd_dial-keep-alive-time:
 
@@ -1228,7 +1228,7 @@ Tarantool storage parameters:
     | Type: time.Duration
     | Default: 30s
     | Environment variable: TCM_STORAGE_ETCD_DIAL_KEEP_ALIVE_TIME
-    | Command-line option: --storage-etcd-dial-keep-alive-time
+    | Command-line option: ``--storage-etcd-dial-keep-alive-time``
 
 .. _tcm_configuration_reference_storage_etcd_dial-keep-alive-timeout:
 
@@ -1240,7 +1240,7 @@ Tarantool storage parameters:
     | Type: time.Duration
     | Default: 30s
     | Environment variable: TCM_STORAGE_ETCD_DIAL_KEEP_ALIVE_TIMEOUT
-    | Command-line option: --storage-etcd-dial-keep-alive-timeout
+    | Command-line option: ``--storage-etcd-dial-keep-alive-timeout``
 
 .. _tcm_configuration_reference_storage_etcd_bootstrap-timeout:
 
@@ -1252,19 +1252,19 @@ Tarantool storage parameters:
     | Type: time.Duration
     | Default: 30s
     | Environment variable: TCM_STORAGE_ETCD_BOOTSTRAP_TIMEOUT
-    | Command-line option: --storage-etcd-bootstrap-timeout
+    | Command-line option: ``--storage-etcd-bootstrap-timeout``
 
 .. _tcm_configuration_reference_storage_etcd_max-call-send-msg-size:
 
 .. confval:: storage.etcd.max-call-send-msg-size
 
-    The maximum size of a transaction between |tcm| and etcd, in bytes.
+    The maximum size (in bytes) of a transaction between |tcm| and etcd.
 
     |
     | Type: int
     | Default: 2097152
     | Environment variable: TCM_STORAGE_ETCD_MAX_CALL_SEND_MSG_SIZE
-    | Command-line option: --storage-etcd-max-call-send-msg-size
+    | Command-line option: ``--storage-etcd-max-call-send-msg-size``
 
 .. _tcm_configuration_reference_storage_etcd_username:
 
@@ -1276,7 +1276,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_ETCD_USERNAME
-    | Command-line option: --storage-etcd-username
+    | Command-line option: ``--storage-etcd-username``
 
 .. _tcm_configuration_reference_storage_etcd_password:
 
@@ -1288,7 +1288,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_ETCD_PASSWORD
-    | Command-line option: --storage-etcd-password
+    | Command-line option: ``--storage-etcd-password``
 
 .. _tcm_configuration_reference_storage_etcd_tls_enabled:
 
@@ -1300,7 +1300,7 @@ Tarantool storage parameters:
     | Type: bool
     | Default: false
     | Environment variable: TCM_STORAGE_ETCD_TLS_ENABLED
-    | Command-line option: --storage-etcd-tls-enabled
+    | Command-line option: ``--storage-etcd-tls-enabled``
 
 .. _tcm_configuration_reference_storage_etcd_tls_auto:
 
@@ -1312,7 +1312,7 @@ Tarantool storage parameters:
     | Type: bool
     | Default: false
     | Environment variable: TCM_STORAGE_ETCD_TLS_AUTO
-    | Command-line option: --storage-etcd-tls-auto
+    | Command-line option: ``--storage-etcd-tls-auto``
 
 .. _tcm_configuration_reference_storage_etcd_tls_cert-file:
 
@@ -1324,7 +1324,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_ETCD_TLS_CERT_FILE
-    | Command-line option: --storage-etcd-tls-cert-file
+    | Command-line option: ``--storage-etcd-tls-cert-file``
 
 .. _tcm_configuration_reference_storage_etcd_tls_key-file:
 
@@ -1336,7 +1336,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_ETCD_TLS_KEY_FILE
-    | Command-line option: --storage-etcd-tls-key-file
+    | Command-line option: ``--storage-etcd-tls-key-file``
 
 .. _tcm_configuration_reference_storage_etcd_tls_trusted-ca-file:
 
@@ -1348,7 +1348,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_ETCD_TLS_TRUSTED_CA_FILE
-    | Command-line option: --storage-etcd-tls-trusted-ca-file
+    | Command-line option: ``--storage-etcd-tls-trusted-ca-file``
 
 .. _tcm_configuration_reference_storage_etcd_tls_client-cert-auth:
 
@@ -1360,7 +1360,7 @@ Tarantool storage parameters:
     | Type: bool
     | Default: false
     | Environment variable: TCM_STORAGE_ETCD_TLS_CLIENT_CERT_AUTH
-    | Command-line option: --storage-etcd-tls-client-cert-auth
+    | Command-line option: ``--storage-etcd-tls-client-cert-auth``
 
 .. _tcm_configuration_reference_storage_etcd_tls_crl-file:
 
@@ -1372,7 +1372,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_ETCD_TLS_CRL_FILE
-    | Command-line option: --storage-etcd-tls-crl-file
+    | Command-line option: ``--storage-etcd-tls-crl-file``
 
 .. _tcm_configuration_reference_storage_etcd_tls_insecure-skip-verify:
 
@@ -1384,7 +1384,7 @@ Tarantool storage parameters:
     | Type: bool
     | Default: false
     | Environment variable: TCM_STORAGE_ETCD_TLS_INSECURE_SKIP_VERIFY
-    | Command-line option: --storage-etcd-tls-insecure-skip-verify
+    | Command-line option: ``--storage-etcd-tls-insecure-skip-verify``
 
 .. _tcm_configuration_reference_storage_etcd_tls_skip-client-san-verify:
 
@@ -1396,7 +1396,7 @@ Tarantool storage parameters:
     | Type: bool
     | Default: false
     | Environment variable: TCM_STORAGE_ETCD_TLS_SKIP_CLIENT_SAN_VERIFY
-    | Command-line option: --storage-etcd-tls-skip-client-san-verify
+    | Command-line option: ``--storage-etcd-tls-skip-client-san-verify``
 
 .. _tcm_configuration_reference_storage_etcd_tls_server-name:
 
@@ -1408,7 +1408,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_ETCD_TLS_SERVER_NAME
-    | Command-line option: --storage-etcd-tls-server-name
+    | Command-line option: ``--storage-etcd-tls-server-name``
 
 .. _tcm_configuration_reference_storage_etcd_tls_cipher-suites:
 
@@ -1420,7 +1420,7 @@ Tarantool storage parameters:
     | Type: []uint16
     | Default: []
     | Environment variable: TCM_STORAGE_ETCD_TLS_CIPHER_SUITES
-    | Command-line option: --storage-etcd-tls-cipher-suites
+    | Command-line option: ``--storage-etcd-tls-cipher-suites``
 
 .. _tcm_configuration_reference_storage_etcd_tls_allowed-cn:
 
@@ -1432,7 +1432,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_ETCD_TLS_ALLOWED_CN
-    | Command-line option: --storage-etcd-tls-allowed-cn
+    | Command-line option: ``--storage-etcd-tls-allowed-cn``
 
 .. _tcm_configuration_reference_storage_etcd_tls_allowed-hostname:
 
@@ -1444,7 +1444,7 @@ Tarantool storage parameters:
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_ETCD_TLS_ALLOWED_HOSTNAME
-    | Command-line option: --storage-etcd-tls-allowed-hostname
+    | Command-line option: ``--storage-etcd-tls-allowed-hostname``
 
 .. _tcm_configuration_reference_storage_etcd_tls_empty-cn:
 
@@ -1456,7 +1456,7 @@ Tarantool storage parameters:
     | Type: bool
     | Default: false
     | Environment variable: TCM_STORAGE_ETCD_TLS_EMPTY_CN
-    | Command-line option: --storage-etcd-tls-empty-cn
+    | Command-line option: ``--storage-etcd-tls-empty-cn``
 
 .. _tcm_configuration_reference_storage_etcd_embed:
 
@@ -1479,7 +1479,7 @@ etcd cluster is not available or not needed.
     | Type: string
     | Default: "_tcm:
     | Environment variable: TCM_STORAGE_TARANTOOL_PREFIX
-    | Command-line option: --storage-tarantool-prefix
+    | Command-line option: ``--storage-tarantool-prefix``
 
 
 .. _tcm_configuration_reference_storage_tarantool_addr:
@@ -1492,7 +1492,7 @@ etcd cluster is not available or not needed.
     | Type: string
     | Default: "unix/:/tmp/tnt_config_instance.sock"
     | Environment variable: TCM_STORAGE_TARANTOOL_ADDR
-    | Command-line option: --storage-tarantool-ADDR
+    | Command-line option: ``--storage-tarantool-ADDR``
 
 
 .. _tcm_configuration_reference_storage_tarantool_auth:
@@ -1511,7 +1511,7 @@ etcd cluster is not available or not needed.
     | Type: int
     | Default: 0
     | Environment variable: TCM_STORAGE_TARANTOOL_AUTH
-    | Command-line option: --storage-tarantool-auth
+    | Command-line option: ``--storage-tarantool-auth``
 
 
 .. _tcm_configuration_reference_storage_tarantool_timeout:
@@ -1520,13 +1520,13 @@ etcd cluster is not available or not needed.
 
     A request timeout for the Tarantool |tcm| configuration storage.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: time.Duration
     | Default: 0s
     | Environment variable: TCM_STORAGE_TARANTOOL_TIMEOUT
-    | Command-line option: --storage-tarantool-timeout
+    | Command-line option: ``--storage-tarantool-timeout``
 
 .. _tcm_configuration_reference_storage_tarantool_reconnect:
 
@@ -1534,13 +1534,13 @@ etcd cluster is not available or not needed.
 
     A timeout between reconnect attempts for the Tarantool |tcm| configuration storage.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: time.Duration
     | Default: 0s
     | Environment variable: TCM_STORAGE_TARANTOOL_RECONNECT
-    | Command-line option: --storage-tarantool-reconnect
+    | Command-line option: ``--storage-tarantool-reconnect``
 
 .. _tcm_configuration_reference_storage_tarantool_max-reconnects:
 
@@ -1548,13 +1548,13 @@ etcd cluster is not available or not needed.
 
     The maximum number of reconnect attempts for the Tarantool |tcm| configuration storage.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: int
     | Default: 0
     | Environment variable: TCM_STORAGE_TARANTOOL_MAX_RECONNECTS
-    | Command-line option: --storage-tarantool-max-reconnects
+    | Command-line option: ``--storage-tarantool-max-reconnects``
 
 .. _tcm_configuration_reference_storage_tarantool_user:
 
@@ -1562,13 +1562,13 @@ etcd cluster is not available or not needed.
 
     A username for connecting to the Tarantool |tcm| configuration storage.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_USER
-    | Command-line option: --storage-tarantool-user
+    | Command-line option: ``--storage-tarantool-user``
 
 .. _tcm_configuration_reference_storage_tarantool_pass:
 
@@ -1576,13 +1576,13 @@ etcd cluster is not available or not needed.
 
     A password for connecting to the Tarantool |tcm| configuration storage.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_PASS
-    | Command-line option: --storage-tarantool-pass
+    | Command-line option: ``--storage-tarantool-pass``
 
 .. _tcm_configuration_reference_storage_tarantool_rate-limit:
 
@@ -1590,13 +1590,13 @@ etcd cluster is not available or not needed.
 
     A rate limit for connecting to the Tarantool |tcm| configuration storage.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: int
     | Default: 0
     | Environment variable: TCM_STORAGE_TARANTOOL_RATE_LIMIT
-    | Command-line option: --storage-tarantool-rate-limit
+    | Command-line option: ``--storage-tarantool-rate-limit``
 
 .. _tcm_configuration_reference_storage_tarantool_rate-limit-action:
 
@@ -1604,13 +1604,13 @@ etcd cluster is not available or not needed.
 
     An action to perform when the :ref:`<tcm_configuration_reference_storage_tarantool_rate-limit>` is reached.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: int
     | Default: 0
     | Environment variable: TCM_STORAGE_TARANTOOL_RATE_LIMIT_ACTION
-    | Command-line option: --storage-tarantool-rate-limit-action
+    | Command-line option: ``--storage-tarantool-rate-limit-action``
 
 
 .. _tcm_configuration_reference_storage_tarantool_concurrency:
@@ -1620,13 +1620,13 @@ etcd cluster is not available or not needed.
     An amount of separate mutexes for request queues and buffers inside of a connection
     to the Tarantool |tcm| configuration storage.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: int
     | Default: 0
     | Environment variable: TCM_STORAGE_TARANTOOL_CONCURRENCY
-    | Command-line option: --storage-tarantool-concurrency
+    | Command-line option: ``--storage-tarantool-concurrency``
 
 .. _tcm_configuration_reference_storage_tarantool_skip-schema:
 
@@ -1634,13 +1634,13 @@ etcd cluster is not available or not needed.
 
     Whether the schema is loaded from the Tarantool |tcm| configuration storage.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: bool
     | Default: true
     | Environment variable: TCM_STORAGE_TARANTOOL_SKIP_SCHEMA
-    | Command-line option: --storage-tarantool-skip-schema
+    | Command-line option: ``--storage-tarantool-skip-schema``
 
 .. _tcm_configuration_reference_storage_tarantool_transport:
 
@@ -1648,13 +1648,13 @@ etcd cluster is not available or not needed.
 
     The connection type for the Tarantool |tcm| configuration storage.
 
-    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`.
+    See also `go-tarantool.Opts <https://pkg.go.dev/github.com/tarantool/go-tarantool#Opts>`__.
 
     |
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_TRANSPORT
-    | Command-line option: --storage-tarantool-transport
+    | Command-line option: ``--storage-tarantool-transport``
 
 .. _tcm_configuration_reference_storage_tarantool_ssl_key-file:
 
@@ -1669,7 +1669,7 @@ etcd cluster is not available or not needed.
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_SSL_KEY_FILE
-    | Command-line option: --storage-tarantool-ssl-key-file
+    | Command-line option: ``--storage-tarantool-ssl-key-file``
 
 .. _tcm_configuration_reference_storage_tarantool_ssl_cert-file:
 
@@ -1684,7 +1684,7 @@ etcd cluster is not available or not needed.
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_SSL_CERT_FILE
-    | Command-line option: --storage-tarantool-ssl-cert-file
+    | Command-line option: ``--storage-tarantool-ssl-cert-file``
 
 .. _tcm_configuration_reference_storage_tarantool_ssl_ca-file:
 
@@ -1699,7 +1699,7 @@ etcd cluster is not available or not needed.
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_SSL_CA_FILE
-    | Command-line option: --storage-tarantool-ssl-ca-file
+    | Command-line option: ``--storage-tarantool-ssl-ca-file``
 
 .. _tcm_configuration_reference_storage_tarantool_ssl_ciphers:
 
@@ -1714,7 +1714,7 @@ etcd cluster is not available or not needed.
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_SSL_CIPHERS
-    | Command-line option: --storage-tarantool-ssl-ciphers
+    | Command-line option: ``--storage-tarantool-ssl-ciphers``
 
 .. _tcm_configuration_reference_storage_tarantool_ssl_password:
 
@@ -1724,11 +1724,12 @@ etcd cluster is not available or not needed.
     configuration storage.
 
     See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
+
     |
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_SSL_PASSWORD
-    | Command-line option: --storage-tarantool-ssl-password
+    | Command-line option: ``--storage-tarantool-ssl-password``
 
 .. _tcm_configuration_reference_storage_tarantool_ssl_password-file:
 
@@ -1741,8 +1742,8 @@ etcd cluster is not available or not needed.
     | Type: string
     | Default: ""
     | Environment variable: TCM_STORAGE_TARANTOOL_SSL_PASSWORD_FILE
-    | Command-line option: --storage-tarantool-ssl-password-file
-
+    | Command-line option: ``--storage-tarantool-ssl-password-file``
+``
 .. _tcm_configuration_reference_storage_tarantool_embed:
 
 storage.tarantool.embed.*
@@ -1759,7 +1760,7 @@ cluster is not available or not needed.
 addon
 -----
 
-The ``addon`` section defines the |tcm|
+The ``addon`` section defines settings related to |tcm| add-ons.
 
 -   :ref:`addon.enabled <tcm_configuration_reference_addon_enabled>`
 -   :ref:`addon.addons-dir <tcm_configuration_reference_addon_addons-dir>`
@@ -1776,7 +1777,7 @@ The ``addon`` section defines the |tcm|
     | Type: bool
     | Default: false
     | Environment variable: TCM_ADDON_ENABLED
-    | Command-line option: --addon-enabled
+    | Command-line option: ``--addon-enabled``
 
 .. _tcm_configuration_reference_addon_addons-dir:
 
@@ -1788,19 +1789,19 @@ The ``addon`` section defines the |tcm|
     | Type: string
     | Default: addons
     | Environment variable: TCM_ADDON_ADDONS_DIR
-    | Command-line option: --addon-addons-dir
+    | Command-line option: ``--addon-addons-dir``
 
 .. _tcm_configuration_reference_addon_max-upload-size:
 
 .. confval:: addon.max-upload-size
 
-    The maximum size of addon to upload to |tcm|, in bytes.
+    The maximum size (in bytes) of addon to upload to |tcm|.
 
     |
     | Type: int64
     | Default: 104857600
     | Environment variable: TCM_ADDON_MAX_UPLOAD_SIZE
-    | Command-line option: --addon-max-upload-size
+    | Command-line option: ``--addon-max-upload-size``
 
 .. _tcm_configuration_reference_addon_dev-addons-dir:
 
@@ -1812,7 +1813,7 @@ The ``addon`` section defines the |tcm|
     | Type: []string
     | Default: []
     | Environment variable: TCM_ADDON_DEV_ADDONS_DIR
-    | Command-line option: --addon-dev-addons-dir
+    | Command-line option: ``--addon-dev-addons-dir``
 
 .. limits configuration
 
@@ -1841,7 +1842,7 @@ between them.
     | Type: int
     | Default: 1000
     | Environment variable: TCM_LIMITS_USERS_COUNT
-    | Command-line option: --limits-users-count
+    | Command-line option: ``--limits-users-count``
 
 .. _tcm_configuration_reference_limits_clusters-count:
 
@@ -1853,7 +1854,7 @@ between them.
     | Type: int
     | Default: 10
     | Environment variable: TCM_LIMITS_CLUSTERS_COUNT
-    | Command-line option: --limits-clusters-count
+    | Command-line option: ``--limits-clusters-count``
 
 .. _tcm_configuration_reference_limits_roles-count:
 
@@ -1865,7 +1866,7 @@ between them.
     | Type: int
     | Default: 100
     | Environment variable: TCM_LIMITS_ROLES_COUNT
-    | Command-line option: --limits-roles-count
+    | Command-line option: ``--limits-roles-count``
 
 .. _tcm_configuration_reference_limits_user-secrets-count:
 
@@ -1877,7 +1878,7 @@ between them.
     | Type: int
     | Default: 10
     | Environment variable: TCM_LIMITS_USER_SECRETS_COUNT
-    | Command-line option: --limits-user-secrets-count
+    | Command-line option: ``--limits-user-secrets-count``
 
 .. _tcm_configuration_reference_limits_user-websessions-count:
 
@@ -1889,7 +1890,7 @@ between them.
     | Type: int
     | Default: 10
     | Environment variable: TCM_LIMITS_USER_WEBSESSIONS_COUNT
-    | Command-line option: --limits-user-websessions-count
+    | Command-line option: ``--limits-user-websessions-count``
 
 .. _tcm_configuration_reference_limits_linked-cluster-users:
 
@@ -1901,7 +1902,7 @@ between them.
     | Type: int
     | Default: 10
     | Environment variable: TCM_LIMITS_LINKED_CLUSTER_USERS
-    | Command-line option: --limits-linked-cluster-users
+    | Command-line option: ``--limits-linked-cluster-users``
 
 
 .. security parameters
@@ -1936,7 +1937,7 @@ The ``security`` section defines the security parameters of |tcm|.
     | Type: []string
     | Default: [local]
     | Environment variable: TCM_SECURITY_AUTH
-    | Command-line option: --security-auth
+    | Command-line option: ``--security-auth``
 
 .. _tcm_configuration_reference_security_hash-cost:
 
@@ -1948,7 +1949,7 @@ The ``security`` section defines the security parameters of |tcm|.
     | Type: int
     | Default: 12
     | Environment variable: TCM_SECURITY_HASH_COST
-    | Command-line option: --security-hash-cost
+    | Command-line option: ``--security-hash-cost``
 
 .. _tcm_configuration_reference_security_encryption-key:
 
@@ -1961,7 +1962,7 @@ The ``security`` section defines the security parameters of |tcm|.
     | Type: string
     | Default: ""
     | Environment variable: TCM_SECURITY_ENCRYPTION_KEY
-    | Command-line option: --security-encryption-key
+    | Command-line option: ``--security-encryption-key``
 
 .. _tcm_configuration_reference_security_encryption-key-file:
 
@@ -1974,7 +1975,7 @@ The ``security`` section defines the security parameters of |tcm|.
     | Type: string
     | Default: ""
     | Environment variable: TCM_SECURITY_ENCRYPTION_KEY_FILE
-    | Command-line option: --security-encryption-key-file
+    | Command-line option: ``--security-encryption-key-file``
 
 .. _tcm_configuration_reference_security_bootstrap-password:
 
@@ -1987,7 +1988,7 @@ The ``security`` section defines the security parameters of |tcm|.
     | Type: string
     | Default: ""
     | Environment variable: TCM_SECURITY_BOOTSTRAP_PASSWORD
-    | Command-line option: --security-bootstrap-password
+    | Command-line option: ``--security-bootstrap-password``
 
 .. _tcm_configuration_security_signature-private-key-file:
 
@@ -1999,7 +2000,7 @@ The ``security`` section defines the security parameters of |tcm|.
     | Type: string
     | Default: ""
     | Environment variable: TCM_SECURITY_SIGNATURE_PRIVATE_KEY_FILE
-    | Command-line option: --security-signature-private-key-file
+    | Command-line option: ``--security-signature-private-key-file``
 
 .. _tcm_configuration_security_integrity-check:
 
@@ -2012,7 +2013,7 @@ The ``security`` section defines the security parameters of |tcm|.
     | Type: bool
     | Default: false
     | Environment variable: TCM_SECURITY_INTEGRITY_CHECK
-    | Command-line option: --security-integrity-check
+    | Command-line option: ``--security-integrity-check``
 
 .. mode
 
@@ -2029,5 +2030,5 @@ mode
     | Type: string
     | Default: production
     | Environment variable: TCM_MODE
-    | Command-line option: --mode
+    | Command-line option: ``--mode``
 

--- a/doc/reference/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/reference/tooling/tcm/tcm_configuration_reference.rst
@@ -552,7 +552,7 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
 
 .. confval:: http.tls.min-version
 
-    The minimum version of the TLS protocol. ? 0 == any?
+    The minimum version of the TLS protocol.
 
     |
     | Type: uint16
@@ -793,7 +793,7 @@ The ``log`` section defines the |tcm|  logging parameters.
 
 .. confval:: log.default.add-source
 
-    ? Add sources to the |tcm| logs.
+    Whether sources are added to the |tcm| log.
 
     |
     | Type: bool
@@ -805,7 +805,7 @@ The ``log`` section defines the |tcm|  logging parameters.
 
 .. confval:: log.default.show-stack-trace
 
-    Add stack traces to the |tcm| log.
+    Whether stack traces are added to the |tcm| log.
 
     |
     | Type: bool
@@ -819,7 +819,7 @@ The ``log`` section defines the |tcm|  logging parameters.
 
     The default |tcm| logging level.
 
-    ? сheck: Possible values:
+    Possible values:
 
     *   ``VERBOSE``
     *   ``INFO``
@@ -872,7 +872,7 @@ The ``log`` section defines the |tcm|  logging parameters.
 
 .. confval:: log.default.no-colorized
 
-    Whether the stdout logs are not colorized.
+    Whether the stdout log is not colorized.
 
     |
     | Type: bool
@@ -898,8 +898,6 @@ The ``log`` section defines the |tcm|  logging parameters.
 
     The maximum size of the |tcm| log file, in bytes.
 
-    ? check ``0``- unlimited.
-
     |
     | Type: int
     | Default: 0
@@ -911,8 +909,6 @@ The ``log`` section defines the |tcm|  logging parameters.
 .. confval:: log.default.file.maxage
 
     The maximum age of a |tcm| log file, in days.
-
-    ? check ``0``- unlimited.
 
     |
     | Type: int
@@ -948,12 +944,9 @@ The ``log`` section defines the |tcm|  logging parameters.
 
 .. confval:: log.default.syslog.protocol
 
-    The network protocol used for connecting to the syslog server.
-
-    ? possible values:
-
-    - ``tcp``
-    - ``udp``
+    The network protocol used for connecting to the syslog server. Typically,
+    it's ``tcp``,``udp`, or ``unix``. All possible values are listed in the Go's
+    `net.Dial <https://pkg.go.dev/net#Dial>`__ documentation.
 
     |
     | Type: string
@@ -1124,8 +1117,6 @@ etcd storage parameters:
 -   :ref:`storage.etcd.embed.name <tcm_configuration_reference_storage_etcd_embed>`
 -   :ref:`storage.etcd.embed.initial-cluster-state <tcm_configuration_reference_storage_etcd_embed>`
 -   :ref:`storage.etcd.embed.self-signed-cert-validity <tcm_configuration_reference_storage_etcd_embed>`
--   :ref:`storage.etcd. <tcm_configuration_reference_storage_etcd_>`
-
 
 Tarantool storage parameters:
 
@@ -1166,6 +1157,7 @@ Tarantool storage parameters:
     The type of the storage used for storing |tcm| configuration.
 
     Possible values:
+
     -   ``etcd``
     -   ``tarantool``
 
@@ -1197,7 +1189,7 @@ Tarantool storage parameters:
 
     |
     | Type: []string
-    | Default: [http://127.0.0.1:2379]
+    | Default: ["http://127.0.0.1:2379"]
     | Environment variable: TCM_STORAGE_ETCD_ENDPOINTS
     | Command-line option: --storage-etcd-endpoints
 
@@ -1220,7 +1212,6 @@ Tarantool storage parameters:
 .. confval:: storage.etcd.auto-sync-interval
 
     An automated sync interval.
-    0 - disabled?
 
     |
     | Type: time.Duration
@@ -1271,8 +1262,8 @@ Tarantool storage parameters:
     The maximum size of a transaction between |tcm| and etcd, in bytes.
 
     |
-    | Type: string
-    | Default: ""
+    | Type: int
+    | Default: 2097152
     | Environment variable: TCM_STORAGE_ETCD_MAX_CALL_SEND_MSG_SIZE
     | Command-line option: --storage-etcd-max-call-send-msg-size
 
@@ -1329,7 +1320,6 @@ Tarantool storage parameters:
 .. confval:: storage.etcd.tls.cert-file
 
     A path to a TLS certificate file to use for etcd connections.
-    Mandatory when the TLS connection to etcd is enabled.
 
     |
     | Type: string
@@ -1342,7 +1332,6 @@ Tarantool storage parameters:
 .. confval:: storage.etcd.tls.key-file
 
     A path to a TLS private key file to use for etcd connections.
-    Mandatory when the TLS connection to etcd is enabled.
 
     |
     | Type: string
@@ -1355,7 +1344,6 @@ Tarantool storage parameters:
 .. confval:: storage.etcd.tls.trusted-ca-file
 
     A path to a trusted CA certificate file to use for etcd connections.
-    Mandatory when the TLS connection to etcd is enabled.
 
     |
     | Type: string
@@ -1474,10 +1462,10 @@ Tarantool storage parameters:
 .. _tcm_configuration_reference_storage_etcd_embed:
 
 storage.etcd.embed.*
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
-The ``storage.etcd.embed`` group parameters define the configuration of the
-embedded etcd cluster that can used as a |tcm| configuration storage.
+The ``storage.etcd.embed`` group defines the configuration of the embedded etcd
+cluster that can used as a |tcm| configuration storage.
 This cluster can be used for development purposes when the production or testing
 etcd cluster is not available or not needed.
 
@@ -1486,19 +1474,261 @@ etcd cluster is not available or not needed.
 
 .. confval:: storage.tarantool.prefix
 
-    A
+    A prefix for the TCM configuration parameters in a Tarantool cluster used as
+    a configuration storage.
 
     |
     | Type: string
-    | Default: ""
+    | Default: "_tcm:
     | Environment variable: TCM_STORAGE_TARANTOOL_PREFIX
     | Command-line option: --storage-tarantool-prefix
 
 
+.. _tcm_configuration_reference_storage_tarantool_addr:
+
+.. confval:: storage.tarantool.addr
+
+    The URI for connecting to the Tarantool cluster used as
+    a configuration storage.
+
+    |
+    | Type: string
+    | Default: "unix/:/tmp/tnt_config_instance.sock"
+    | Environment variable: TCM_STORAGE_TARANTOOL_ADDR
+    | Command-line option: --storage-tarantool-ADDR
+
+
+.. _tcm_configuration_reference_storage_tarantool_auth:
+
+.. confval:: storage.tarantool.auth
+
+    ?? TBD
+
+    |
+    | Type: int
+    | Default: o
+    | Environment variable: TCM_STORAGE_TARANTOOL_AUTH
+    | Command-line option: --storage-tarantool-auth
+
+
+.. _tcm_configuration_reference_storage_tarantool_timeout:
+
+.. confval:: storage.tarantool.timeout
+
+    A timeout for connecting to the Tarantool cluster used as
+    a configuration storage.
+
+    |
+    | Type: time.Duration
+    | Default: 0s
+    | Environment variable: TCM_STORAGE_TARANTOOL_TIMEOUT
+    | Command-line option: --storage-tarantool-timeout
+
+.. _tcm_configuration_reference_storage_tarantool_reconnect:
+
+.. confval:: storage.tarantool.reconnect
+
+    ?? TBD
+
+    |
+    | Type: time.Duration
+    | Default: 0s
+    | Environment variable: TCM_STORAGE_TARANTOOL_RECONNECT
+    | Command-line option: --storage-tarantool-reconnect
+
+.. _tcm_configuration_reference_storage_tarantool_max-reconnects:
+
+.. confval:: storage.tarantool.max-reconnects
+
+    Maximum number of reconnects attempts to the Tarantool cluster used as
+    a configuration storage.
+
+    |
+    | Type: int
+    | Default: 0
+    | Environment variable: TCM_STORAGE_TARANTOOL_MAX_RECONNECTS
+    | Command-line option: --storage-tarantool-max-reconnects
+
+.. _tcm_configuration_reference_storage_tarantool_user:
+
+.. confval:: storage.tarantool.user
+
+    A username for connecting to the Tarantool cluster used as
+    a configuration storage.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_TARANTOOL_USER
+    | Command-line option: --storage-tarantool-user
+
+.. _tcm_configuration_reference_storage_tarantool_pass:
+
+.. confval:: storage.tarantool.pass
+
+    A password for connecting to the Tarantool cluster used as
+    a configuration storage.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_TARANTOOL_PASS
+    | Command-line option: --storage-tarantool-pass
+
+.. _tcm_configuration_reference_storage_tarantool_rate-limit:
+
+.. confval:: storage.tarantool.rate-limit
+
+    A rate limit for connecting to the Tarantool cluster used as
+    a configuration storage.
+
+    |
+    | Type: int
+    | Default: 0
+    | Environment variable: TCM_STORAGE_TARANTOOL_RATE_LIMIT
+    | Command-line option: --storage-tarantool-rate-limit
+
+.. _tcm_configuration_reference_storage_tarantool_rate-limit-action:
+
+.. confval:: storage.tarantool.rate-limit-action
+
+    A action to perform when the :ref:`<tcm_configuration_reference_storage_tarantool_rate-limit>` is reached.
+
+    |
+    | Type: int
+    | Default: 0
+    | Environment variable: TCM_STORAGE_TARANTOOL_RATE_LIMIT_ACTION
+    | Command-line option: --storage-tarantool-rate-limit-action
+
+
+.. _tcm_configuration_reference_storage_tarantool_concurrency:
+
+.. confval:: storage.tarantool.concurrency
+
+    ?? TBD.
+
+    |
+    | Type: int
+    | Default: 0
+    | Environment variable: TCM_STORAGE_TARANTOOL_CONCURRENCY
+    | Command-line option: --storage-tarantool-concurrency
+
+.. _tcm_configuration_reference_storage_tarantool_skip-schema:
+
+.. confval:: storage.tarantool.skip-schema
+
+    ?? TBD
+
+    |
+    | Type: bool
+    | Default: true
+    | Environment variable: TCM_STORAGE_TARANTOOL_SKIP_SCHEMA
+    | Command-line option: --storage-tarantool-skip-schema
+
+.. _tcm_configuration_reference_storage_tarantool_transport:
+
+.. confval:: storage.tarantool.transport
+
+    ? TBD
+
+    |
+    | Type: bool
+    | Default: true
+    | Environment variable: TCM_STORAGE_TARANTOOL_TRANSPORT
+    | Command-line option: --storage-tarantool-transport
+
+
+.. _tcm_configuration_reference_storage_tarantool_ssl_key-file:
+
+.. confval:: storage.tarantool.ssl.key-file
+
+    A path to a TLS private key file to use for connecting to Tarantool |tcm|
+    configuration storage.
+
+    See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_TARANTOOL_SSL_KEY_FILE
+    | Command-line option: --storage-tarantool-ssl-key-file
+
+.. _tcm_configuration_reference_storage_tarantool_ssl_cert-file:
+
+.. confval:: storage.tarantool.ssl.cert-file
+
+    A path to an SSL certificate to use for connecting to Tarantool |tcm|
+    configuration storage.
+
+    See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_TARANTOOL_SSL_CERT_FILE
+    | Command-line option: --storage-tarantool-ssl-cert-file
+
+.. _tcm_configuration_reference_storage_tarantool_ssl_ca-file:
+
+.. confval:: storage.tarantool.ssl.ca-file
+
+    A path to a trusted CA certificate to use for connecting to Tarantool |tcm|
+    configuration storage.
+
+    See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_TARANTOOL_SSL_CA_FILE
+    | Command-line option: --storage-tarantool-ssl-ca-file
+
+.. _tcm_configuration_reference_storage_tarantool_ssl_ciphers:
+
+.. confval:: storage.tarantool.ssl.ciphers
+
+    A list of SSL cipher suites that can be used for connecting to a Tarantool |tcm|
+    configuration storage. Possible values are listed in :ref:`Supported ciphers <enterprise-iproto-encryption-ciphers>`.
+
+    See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_TARANTOOL_SSL_CIPHERS
+    | Command-line option: --storage-tarantool-ssl-ciphers
+
+.. _tcm_configuration_reference_storage_tarantool_ssl_password:
+
+.. confval:: storage.tarantool.ssl.password
+
+    A password for an encrypted private SSL key to use for connecting to a Tarantool |tcm|
+    configuration storage.
+
+    See also: :ref:`Traffic encryption <enterprise-iproto-encryption>`.
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_TARANTOOL_SSL_PASSWORD
+    | Command-line option: --storage-tarantool-ssl-password
+
+.. _tcm_configuration_reference_storage_tarantool_ssl_password-file:
+
+.. confval:: storage.tarantool.ssl.password-file
+
+    A text file with one or more passwords for encrypted private SSL keys to use
+    for connecting to a Tarantool |tcm| configuration storage.
+
+    |
+    | Type: string
+    | Default: ""
+    | Environment variable: TCM_STORAGE_TARANTOOL_SSL_PASSWORD_FILE
+    | Command-line option: --storage-tarantool-ssl-password-file
+
 .. _tcm_configuration_reference_storage_tarantool_embed:
 
 storage.tarantool.embed.*
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``storage.tarantool.embed`` group parameters define the configuration of the
 embedded Tarantool cluster that can used as a |tcm| configuration storage.
@@ -1506,9 +1736,7 @@ This cluster can be used for development purposes when the production or testing
 cluster is not available or not needed.
 
 
-
 .. _tcm_configuration_reference_addon:
-
 
 addon
 -----
@@ -1536,7 +1764,7 @@ The ``addon`` section defines the |tcm|
 
 .. confval:: addon.addons-dir
 
-    The directory where add-on files are stored.
+    The directory from which |tcm| takes add-ons.
 
     |
     | Type: string


### PR DESCRIPTION
Resolves #3633 

- [TCM > Configuration](https://docs.d.tarantool.io/en/doc/gh-3633-tcm-config/reference/tooling/tcm/tcm_configuration/):
  - Configuration overview: parameter groups
  - Parameter naming
  - Parameter types
  - Ways to pass TCM config: YAML, env, cli options.
  - Config precedence

- [TCM > Configuration reference](https://docs.d.tarantool.io/en/doc/gh-3633-tcm-config/reference/tooling/tcm/tcm_configuration_reference/) - all config parameters with descriptions. 

**Notes**: 
- perhaps we'll move the config reference page into a **TCM > Reference** section when we write more TCM reference content: UI reference, metrics reference, etc.
- we'll write separate config tutorials on configuring each aspect: HTTP, logging, security, etc. after 3.0 release. When we have such content, we'll add links to it to the parameters descriptions.

Deployment: https://docs.d.tarantool.io/en/doc/gh-3633-tcm-config/reference/tooling/tcm/tcm_config/
