### PR TITLE
3.0 new bootstrap strategy - "supervised"

### DIFF
--- a/doc/code_snippets/snippets/replication/instances.enabled/bootstrap_strategy/README.md
+++ b/doc/code_snippets/snippets/replication/instances.enabled/bootstrap_strategy/README.md
@@ -1,0 +1,11 @@
+# replication.bootstrap_strategy
+
+A sample application demonstrating how to use the specified instance to bootstrap a replica set.
+
+## Running
+
+To start all instances, execute the following command in the [replication](../../../replication) directory:
+
+```console
+$ tt start bootstrap_strategy
+```

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -933,9 +933,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
     *   ``config``: use the specified node to bootstrap a replica set.
         To specify the bootstrap leader, use the :ref:`<replicaset_name>.bootstrap_leader <configuration_reference_replicasets_name_bootstrap_leader>` option.
 
-    *   ``supervised``: a bootstrap leader isn't chosen automatically but should be appointed using ``box.ctl.make_bootstrap_leader()`` on the desired node.
-
-        Configuration fails if no bootstrap leader is appointed during a :ref:`replication.connect_timeout <configuration_reference_replication_connect_timeout>`.
+    *   ``supervised``: a bootstrap leader isn't chosen automatically but should be appointed using :ref:`box.ctl.make_bootstrap_leader() <box_ctl-make_bootstrap_leader>` on the desired node.
 
     *   ``legacy`` (deprecated since :doc:`2.11.0 </release/2.11.0>`): a node requires the :ref:`replication_connect_quorum <cfg_replication-replication_connect_quorum>` number of other nodes to be connected.
         This option is added to keep the compatibility with the current versions of Cartridge and might be removed in the future.

--- a/doc/reference/reference_lua/box_ctl.rst
+++ b/doc/reference/reference_lua/box_ctl.rst
@@ -26,7 +26,7 @@ Below is a list of all ``box.ctl`` functions.
     ..  rst-class:: left-align-column-2
 
     ..  list-table::
-        :widths: 25 75
+        :widths: 35 65
         :header-rows: 1
 
         *   - Name
@@ -62,6 +62,9 @@ Below is a list of all ``box.ctl`` functions.
         *  - :doc:`./box_ctl/demote`
            - Revoke the leader role from the instance
 
+        *  - :doc:`./box_ctl/make_bootstrap_leader`
+           - Make the instance a bootstrap leader of a replica set
+
 ..  toctree::
     :hidden:
 
@@ -75,3 +78,4 @@ Below is a list of all ``box.ctl`` functions.
     box_ctl/is_recovery_finished
     box_ctl/promote
     box_ctl/demote
+    box_ctl/make_bootstrap_leader

--- a/doc/reference/reference_lua/box_ctl/make_bootstrap_leader.rst
+++ b/doc/reference/reference_lua/box_ctl/make_bootstrap_leader.rst
@@ -1,0 +1,20 @@
+.. _box_ctl-make_bootstrap_leader:
+
+box.ctl.make_bootstrap_leader()
+===============================
+
+.. function:: make_bootstrap_leader()
+
+    **Since:** :doc:`3.0.0 </release/3.0.0>`.
+
+    Make the instance a bootstrap leader of a replica set.
+
+    To be able to make the instance a bootstrap leader manually, the :ref:`replication.bootstrap_strategy <configuration_reference_replication_bootstrap_strategy>` configuration option should be set to ``supervised``.
+    In this case, the instances do not choose a bootstrap leader automatically but wait for it to be appointed manually.
+    Configuration fails if no bootstrap leader is appointed during a :ref:`replication.connect_timeout <configuration_reference_replication_connect_timeout>`.
+
+    ..  NOTE::
+
+        When a new instance joins a replica set configured with the ``supervised`` bootstrap strategy,
+        this instance doesn't choose the bootstrap leader automatically but joins to the instance on which
+        ``box.ctl.make_bootstrap_leader()`` was executed last time.


### PR DESCRIPTION
Fixes https://github.com/tarantool/doc/issues/3460.

Staging:

- [replication.bootstrap_strategy](https://docs.d.tarantool.io/en/doc/3.0-bootstrap-strategy/reference/configuration/configuration_reference/#configuration-reference-replication-bootstrap-strategy)
- [box.ctl.make_bootstrap_leader()](https://docs.d.tarantool.io/en/doc/3.0-bootstrap-strategy/reference/reference_lua/box_ctl/make_bootstrap_leader/)
- [Submodule box.ctl](https://docs.d.tarantool.io/en/doc/3.0-bootstrap-strategy/reference/reference_lua/box_ctl/)
