### PR TITLE
Add TCM to EE setup guide

### DIFF
--- a/doc/enterprise/setup.rst
+++ b/doc/enterprise/setup.rst
@@ -120,14 +120,19 @@ at Tarantool website. Please contact ``support@tarantool.io`` for access.
 Each package is distributed as a ``tar + gzip`` archive and includes
 the following components and features:
 
-* static Tarantool binary for simplified deployment in Linux environments,
-* selection of open and closed source modules,
-* sample application walking you through all included modules.
+* Static Tarantool binary for simplified deployment in Linux environments.
+* ``tt`` command-line utility that provides a unified command-line interface for
+  managing Tarantool-based applications. See :ref:`tt-cli` for details.
+* |tcm_full_name| -- a web-based interface for managing Tarantool EE clusters.
+  See :ref:`tcm` for details.
+* Selection of open and closed source modules.
+* Sample application walking you through all included modules
 
 Archive contents:
 
 * ``tarantool`` is the main executable of Tarantool.
-* ``tt`` is the utility that provides a unified command-line interface for managing Tarantool-based applications.
+* ``tt`` command-line utility.
+* ``tcm`` is the |tcm_full_name| executable.
 * ``tarantoolctl`` is the utility script for installing supplementary modules
   and connecting to the administrative console.
 

--- a/doc/reference/tooling/tcm/index.rst
+++ b/doc/reference/tooling/tcm/index.rst
@@ -14,8 +14,8 @@ and individual instances, from monitoring their state to executing commands inte
 in an instance's console.
 
 |tcm| is a standalone application included in the Tarantool Enterprise Edition
-distribution package. It is shipped as an executable that is ready to run on Linux
-and macOS platforms.
+:ref:`distribution package <enterprise-package-contents>`. It is shipped as ready-to-run
+executable for Linux platforms.
 
 |tcm| works only with Tarantool EE clusters that use :ref:`etcd as a configuration storage <configuration_etcd>`.
 When you create or edit a cluster's configuration in |tcm|, it publishes the saved


### PR DESCRIPTION
Resolves #3630

Since TCM is shipped as a ready-to-run executable in the EE SDK archive, no specific installation instruction is needed.

Changes: 
- [TCM overview](https://docs.d.tarantool.io/en/doc/gh-3630-tcm-install/reference/tooling/tcm/) page: add a link to EE Setup page.
- [EE setup](https://docs.d.tarantool.io/en/doc/gh-3630-tcm-install/enterprise/setup/) page: 
  - Add TCM to the package contents description
  - Give a link to the TCM section

