### PR TITLE
Add a 'rockspec' file to a sharding sample

### DIFF
--- a/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/README.md
+++ b/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/README.md
@@ -59,3 +59,14 @@ To run the cluster, go to the `sharding` directory in the terminal and perform t
         - [10, 167, 'Queen', 1970]
       ...
       ```
+
+
+## Packaging
+
+To package an application into a `.tgz` archive, use the `tt pack` command:
+
+```console
+$ tt pack tgz --app-list sharded_cluster
+```
+
+Note that the necessary `vshard` dependency is specified in the [sharded_cluster-scm-1.rockspec](sharded_cluster-scm-1.rockspec) file.

--- a/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/sharded_cluster-scm-1.rockspec
+++ b/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/sharded_cluster-scm-1.rockspec
@@ -1,0 +1,14 @@
+package = 'sharded_cluster'
+version = 'scm-1'
+source  = {
+    url = '/dev/null',
+}
+
+dependencies = {
+    'tarantool',
+    'lua >= 5.1',
+    'vshard == 0.1.24'
+}
+build = {
+    type = 'none';
+}

--- a/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/sharded_cluster-scm-1.rockspec
+++ b/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/sharded_cluster-scm-1.rockspec
@@ -5,9 +5,7 @@ source  = {
 }
 
 dependencies = {
-    'tarantool',
-    'lua >= 5.1',
-    'vshard == 0.1.24'
+    'vshard == 0.1.25'
 }
 build = {
     type = 'none';


### PR DESCRIPTION
This file is required to be able to package and distribute the application. This example can be included to the  [tt pack](https://www.tarantool.io/en/doc/latest/reference/tooling/tt_cli/pack/) doc page later.

_Note: On macOS (AArch64) executing the `tt pack` command causes an error (see https://github.com/tarantool/tt/issues/640) (tt version 2.0)._ 