### PR TITLE
[Config] Update 'Audit log' to using a new config

### DIFF
--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
@@ -1,0 +1,16 @@
+groups:
+  group001:
+    iproto:
+      listen:
+      - uri: '127.0.0.1:3301'
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            audit_log:
+              to: file
+              file: 'audit_tarantool.log'
+              filter: [ user_create,data_operations,ddl ]
+              format: json
+              spaces: [ bands ]
+              extract_key: true

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
@@ -1,16 +1,17 @@
+audit_log:
+  to: file
+  file: 'audit_tarantool.log'
+  filter: [ user_create,data_operations,ddl,custom ]
+  format: json
+  spaces: [ bands ]
+  extract_key: true
+
 groups:
   group001:
-    iproto:
-      listen:
-      - uri: '127.0.0.1:3301'
     replicasets:
       replicaset001:
         instances:
           instance001:
-            audit_log:
-              to: file
-              file: 'audit_tarantool.log'
-              filter: [ user_create,data_operations,ddl ]
-              format: json
-              spaces: [ bands ]
-              extract_key: true
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log/myapp.lua
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log/myapp.lua
@@ -1,0 +1,51 @@
+-- myapp.lua --
+
+-- Create space
+function create_space()
+    box.schema.space.create('Bands')
+    box.space.bands:format({
+        { name = 'id', type = 'unsigned' },
+        { name = 'band_name', type = 'string' },
+        { name = 'year', type = 'unsigned' }
+    })
+    box.space.bands:create_index('primary', { type = "tree", parts = { 'id' } })
+    box.space.bands:create_index('secondary', { type = "tree", parts = { 'band_name' } })
+    box.schema.user.grant('guest', 'read,write,execute', 'universe')
+end
+-- Insert data
+function load_data()
+    box.space.bands:insert { 1, 'Roxette', 1986 }
+    box.space.bands:insert { 2, 'Scorpions', 1965 }
+end
+
+local audit = require('audit')
+-- Log message string
+audit.log('Hello, Alice!')
+-- Log format string and arguments
+audit.log('Hello, %s!', 'Bob')
+-- Log table with audit log field values
+audit.log({ type = 'custom_hello', description = 'Hello, World!' })
+audit.log({ type = 'custom_farewell', user = 'eve', module = 'custom', description = 'Farewell, Eve!' })
+-- Create a new log module
+local my_audit = audit.new({ type = 'custom_hello', module = 'my_module' })
+my_audit:log('Hello, Alice!')
+my_audit:log({ tag = 'admin', description = 'Hello, Bob!' })
+
+-- Log 'Hello!' message with the VERBOSE severity level
+audit.log({ severity = 'VERBOSE', description = 'Hello!' })
+
+-- Log 'Hello!' message with a shortcut helper function
+audit.verbose('Hello!')
+
+-- Like audit.log(), a shortcut helper function accepts a table of options
+audit.verbose({ description = 'Hello!' })
+
+-- Severity levels are available for custom loggers
+local my_logger = audit.new({ module = 'my_module' })
+my_logger:log({ severity = 'ALARM', description = 'Alarm' })
+my_logger:alarm('Alarm')
+
+-- Overwrite session_type and remote fields
+audit.log({ type = 'custom_hello', description = 'Hello!',
+            session_type = 'my_session', remote = 'my_remote' })
+-- End

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log/myapp.lua
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log/myapp.lua
@@ -2,7 +2,7 @@
 
 -- Create space
 function create_space()
-    box.schema.space.create('Bands')
+    box.schema.space.create('bands')
     box.space.bands:format({
         { name = 'id', type = 'unsigned' },
         { name = 'band_name', type = 'string' },

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log_pipe/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log_pipe/config.yaml
@@ -1,14 +1,13 @@
+audit_log:
+  to: pipe
+  pipe: '| cronolog audit_tarantool.log'
+
 groups:
   group001:
-    iproto:
-      listen:
-      - uri: '127.0.0.1:3301'
     replicasets:
       replicaset001:
         instances:
           instance001:
-            audit_log:
-              to: pipe
-              pipe: 'cronolog audit_tarantool.log'
-              format: json
-              extract_key: false
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log_pipe/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log_pipe/config.yaml
@@ -1,0 +1,14 @@
+groups:
+  group001:
+    iproto:
+      listen:
+      - uri: '127.0.0.1:3301'
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            audit_log:
+              to: pipe
+              pipe: 'cronolog audit_tarantool.log'
+              format: json
+              extract_key: false

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log_pipe/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log_pipe/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/config.yaml
@@ -1,7 +1,7 @@
 audit_log:
   to: syslog
   syslog_server: 'unix:/dev/log'
-  syslog_facility: user
+  syslog_facility: 'user'
   syslog_identity: 'tarantool'
   filter: 'audit,auth,priv,password_change,access_denied'
   extract_key: false

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/config.yaml
@@ -1,3 +1,11 @@
+audit_log:
+  to: syslog
+  syslog_server: 'unix:/dev/log'
+  syslog_facility: user
+  syslog_identity: 'tarantool'
+  filter: 'audit,auth,priv,password_change,access_denied'
+  extract_key: false
+
 groups:
   group001:
     iproto:
@@ -7,10 +15,6 @@ groups:
       replicaset001:
         instances:
           instance001:
-            audit_log:
-              to: syslog
-              syslog_server: 'unix:/dev/log'
-              syslog_facility: user
-              syslog_identity: 'tarantool'
-              filter: 'audit,auth,priv,password_change,access_denied'
-              extract_key: false
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/config.yaml
@@ -1,0 +1,16 @@
+groups:
+  group001:
+    iproto:
+      listen:
+      - uri: '127.0.0.1:3301'
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            audit_log:
+              to: syslog
+              syslog_server: 'unix:/dev/log'
+              syslog_facility: user
+              syslog_identity: 'tarantool'
+              filter: 'audit,auth,priv,password_change,access_denied'
+              extract_key: false

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/enterprise/audit_log.rst
+++ b/doc/enterprise/audit_log.rst
@@ -149,9 +149,15 @@ forces the audit subsystem to log the primary key instead of a full tuple in DML
 Examples of audit log entries
 -----------------------------
 
-In the example, the logs are written to the ``audit_tarantool.log`` file.
+In this example, the following audit log configuration is used:
 
-First, create a space ``bands`` and check the logs in the file after the creation:
+..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
+    :language: yaml
+    :start-at: audit_log
+    :end-at: extract_key: true
+    :dedent:
+
+Create a space ``bands`` and check the logs in the file after the creation:
 
 ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/myapp.lua
     :language: lua
@@ -611,12 +617,10 @@ Tips
 How many events can be recorded?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you write to a file, the size of the Tarantool audit module is limited by the disk space.
-If you write to a system logger, the size of the Tarantool audit module is limited by the system logger.
-If you write to a pipe, the size of the Tarantool audit module is limited by the system buffer.
+If you write to a file, the size of the Tarantool audit log is limited by the disk space.
+If you write to a system logger, the size of the Tarantool audit log is limited by the system logger.
+If you write to a pipe, the size of the Tarantool audit message is limited by the system buffer.
 If the ``audit_log.nonblock = false``, if ``audit_log.nonblock`` = ``true``, there is no limit.
-However, it is not recommended to use the entire memory, as this may cause performance degradation
-and even loss of some logs.
 
 How often should audit logs be reviewed?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/enterprise/audit_log.rst
+++ b/doc/enterprise/audit_log.rst
@@ -3,24 +3,12 @@
 Audit module
 ============
 
-The audit module available in Tarantool Enterprise Edition writes messages that record Tarantool events in plain text, CSV, or JSON format.
+The audit module available in Tarantool Enterprise Edition writes messages that record Tarantool events in plain text,
+CSV, or JSON format.
 
 It provides detailed reports of security-related activities and helps you find and
 fix breaches to protect your business. For example, you can see who created a new user
-and when:
-
-..  code-block:: json
-
-    {
-        "time": "2022-04-07T13:39:36.046+0300",
-        "remote": "",
-        "session_type": "background",
-        "module": "tarantool",
-        "user": "admin",
-        "type": "user_create",
-        "tag": "",
-        "description": "Create user alice"
-    }
+and when.
 
 It is up to each company to decide exactly what activities to audit and what actions to take.
 System administrators, security engineers, and people in charge of the company may want to
@@ -34,7 +22,7 @@ Audit log events
 The Tarantool audit log module can record various events that you can monitor and
 decide whether you need to take actions:
 
-*   Admin activity -- events related to actions performed by the administrator.
+*   Administrator activity -- events related to actions performed by the administrator.
     For example, such logs record the creation of a user.
 
 *   Access events -- events related to authorization and authentication of users.
@@ -53,89 +41,116 @@ The full list of available audit log events is provided in the table below:
 ..  container:: table
 
     ..  list-table::
-        :widths: 30 35 35
+        :widths: 20 25 20 35
         :header-rows: 1
 
         *   -   Event
             -   Type of event written to the audit log
+            -   Severity level
             -   Example of an event description
         *   -   Audit log enabled for events   
-            -   ``audit_enable``   
+            -   ``audit_enable``
+            -   ``VERBOSE``
             -
         *   -   :ref:`User-defined events <audit-log-custom>`
             -   ``custom``
+            -   ``INFO`` (default)
             -
         *   -   User authorized successfully    
-            -   ``auth_ok``   
+            -   ``auth_ok``
+            -   ``VERBOSE``
             -   ``Authenticate user <USER>``
         *   -   User authorization failed    
-            -   ``auth_fail``   
+            -   ``auth_fail``
+            -   ``ALARM``
             -   ``Failed to authenticate user <USER>``
         *   -   User logged out or quit the session    
-            -   ``disconnect``   
+            -   ``disconnect``
+            -   ``VERBOSE``
             -   ``Close connection``
         *   -   User created
             -   ``user_create``
+            -   ``INFO``
             -   ``Create user <USER>``
         *   -   User dropped
             -   ``user_drop``
+            -   ``INFO``
             -   ``Drop user <USER>``
         *   -   Role created
             -   ``role_create``
+            -   ``INFO``
             -   ``Create role <ROLE>``
         *   -   Role dropped
             -   ``role_drop``
+            -   ``INFO``
             -   ``Drop role <ROLE>``
         *   -   User disabled    
-            -   ``user_disable``   
+            -   ``user_disable``
+            -   ``INFO``
             -   ``Disable user <USER>``
         *   -   User enabled   
-            -   ``user_enable``   
+            -   ``user_enable``
+            -   ``INFO``
             -   ``Enable user <USER>``
         *   -   User granted rights
             -   ``user_grant_rights``
+            -   ``INFO``
             -   ``Grant <PRIVILEGE> rights for <OBJECT_TYPE> <OBJECT_NAME> to user <USER>``
         *   -   User revoked rights
             -   ``user_revoke_rights``
+            -   ``INFO``
             -   ``Revoke <PRIVILEGE> rights for <OBJECT_TYPE> <OBJECT_NAME> from user <USER>``
         *   -   Role granted rights
             -   ``role_grant_rights``
+            -   ``INFO``
             -   ``Grant <PRIVILEGE> rights for <OBJECT_TYPE> <OBJECT_NAME> to role <ROLE>``
         *   -   Role revoked rights
             -   ``role_revoke_rights``
+            -   ``INFO``
             -   ``Revoke <PRIVILEGE> rights for <OBJECT_TYPE> <OBJECT_NAME> from role <ROLE>``
         *   -   User password changed
-            -   ``password_change``   
+            -   ``password_change``
+            -   ``INFO``
             -   ``Change password for user <USER>``
-        *   -   Failed attempt to access secure data (personal records, details, geolocation, etc.)
+        *   -   Failed attempt to access secure data (for example, personal records, details, geolocation)
             -   ``access_denied``
+            -   ``ALARM``
             -   ``<ACCESS_TYPE> denied to <OBJECT_TYPE> <OBJECT_NAME>``
         *   -   Expressions with arguments evaluated in a string
             -   ``eval``
+            -   ``INFO``
             -   ``Evaluate expression <EXPR>``
         *   -   Function called with arguments
             -   ``call``
+            -   ``VERBOSE``
             -   ``Call function <FUNCTION> with arguments <ARGS>``
         *   -   Iterator key selected from ``space.index``
             -   ``space_select``
+            -   ``VERBOSE``
             -   ``Select <ITER_TYPE> <KEY> from <SPACE>.<INDEX>``
         *   -   Space created
-            -   ``space_create``  
+            -   ``space_create``
+            -   ``INFO``
             -   ``Create space <SPACE>``
         *   -   Space altered 
-            -   ``space_alter``   
+            -   ``space_alter``
+            -   ``INFO``
             -   ``Alter space <SPACE>``
         *   -   Space dropped   
-            -   ``space_drop``   
+            -   ``space_drop``
+            -   ``INFO``
             -   ``Drop space <SPACE>``
         *   -   Tuple inserted into space     
-            -   ``space_insert``  
+            -   ``space_insert``
+            -   ``VERBOSE``
             -   ``Insert tuple <TUPLE> into space <SPACE>``
         *   -   Tuple replaced in space   
-            -   ``space_replace``   
+            -   ``space_replace``
+            -   ``VERBOSE``
             -   ``Replace tuple <TUPLE> with <NEW_TUPLE> in space <SPACE>``
         *   -   Tuple deleted from space   
-            -   ``space_delete``   
+            -   ``space_delete``
+            -   ``VERBOSE``
             -   ``Delete tuple <TUPLE> from space <SPACE>``
 
 
@@ -147,400 +162,123 @@ The full list of available audit log events is provided in the table below:
         and :ref:`Module net.box -- eval <net_box-eval>`. 
         To separate the data, specify ``console`` or ``binary`` in the session field.
 
-.. _audit-log-event-groups:
+..  _audit-log-structure:
 
-Event groups
-------------
+Structure of audit log event
+----------------------------
 
-You can simplify working with audit log events by using built-in event groups.
-For example, you can set to record only events related to the enabling of the audit log,
-or only events related to a space.
+Each audit log event contains a number of fields that can be used to filter and aggregate the resulting logs.
+An example of a Tarantool audit log entry in JSON:
 
-Tarantool provides the following event groups:
+..  code-block:: json
 
-*   ``all`` -- all :ref:`events <audit-log-events>`.
+    {
+        "time": "2024-01-15T13:39:36.046+0300",
+        "uuid": "cb44fb2b-5c1f-4c4b-8f93-1dd02a76cec0",
+        "severity": "VERBOSE",
+        "remote": "unix/:(socket)",
+        "session_type": "console",
+        "module": "tarantool",
+        "user": "admin",
+        "type": "auth_ok",
+        "tag": "",
+        "description": "Authenticate user Admin"
+    }
 
-    ..  note::
-
-        Events ``call`` and ``eval`` are included only into the ``all`` group.
-
-*   ``audit`` -- ``audit_enable`` event.
-
-*   ``auth`` -- authorization events: ``auth_ok``, ``auth_fail``.
-
-*   ``priv`` -- events related to authentication, authorization, users, and roles:
-    ``user_create``, ``user_drop``, ``role_create``, ``role_drop``, ``user_enable``, ``user_disable``,
-    ``user_grant_rights``, ``user_revoke_rights``, ``role_grant_rights``, ``role_revoke_rights``.
-
-*   ``ddl`` -- events of space creation, altering, and dropping:
-    ``space_create``, ``space_alter``, ``space_drop``.
-
-*   ``dml`` -- events of data modification in spaces:
-    ``space_insert``, ``space_replace``, ``space_delete``.
-
-*   ``data_operations`` -- events of data modification or selection from spaces:
-    ``space_select``, ``space_insert``, ``space_replace``, ``space_delete``.
-
-*   ``compatibility`` -- events available in Tarantool before the version 2.10.0.
-    ``auth_ok``, ``auth_fail``, ``disconnect``, ``user_create``, ``user_drop``,
-    ``role_create``, ``role_drop``, ``user_enable``, ``user_disable``,
-    ``user_grant_rights``, ``user_revoke_rights``, ``role_grant_rights``.
-    ``role_revoke_rights``, ``password_change``, ``access_denied``.
-    This group enables the compatibility with earlier Tarantool versions.
-
-..  warning::
-
-    Be careful when recording ``all`` and ``data_operations`` event groups.
-    The more events you record, the slower the requests will be processed over time.
-    It is recommended that you select only those groups
-    whose events your company really needs to monitor and analyze.
-
-.. _audit-log-structure:
-
-Structure of audit log events
------------------------------
-
-Each audit log event contains several fields to make it easy to filter and aggregate the resulting logs.
-They are described in the following table.
+Each event consists of the following fields:
 
 ..  container:: table
 
     ..  list-table::
         :widths: 30 35 35
         :header-rows: 1
-        
+
         *   -   Field
             -   Description
             -   Example of a log field display
-        *   -   ``time``   
-            -   Time of the event   
-            -   2022-04-07T13:20:05.327+0300             
-        *   -   ``remote``   
-            -   Remote host that triggered the event   
-            -   100.96.163.226:48722             
-        *   -   ``session_type``   
-            -   Session type   
-            -   console             
-        *   -   ``module``   
+        *   -   ``time``
+            -   Time of the event
+            -   ``2024-01-15T16:33:12.368+0300``
+        *   -   ``uuid``. Since :doc:`3.0.0 </release/3.0.0>`
+            -   A unique identifier of audit log event
+            -   ``cb44fb2b-5c1f-4c4b-8f93-1dd02a76cec0``
+        *   -   ``severity``. Since :doc:`3.0.0 </release/3.0.0>`
+            -   A severity level
+            -   ``VERBOSE``
+        *   -   ``remote``
+            -   Remote host that triggered the event
+            -   ``unix/:(socket)``
+        *   -   ``session_type``
+            -   Session type
+            -   ``console``
+        *   -   ``module``
             -   Audit log module. Set to ``tarantool`` for system events;
-                can be overwritten for user-defined events   
-            -   tarantool             
-        *   -   ``user``   
-            -   User who triggered the event   
-            -   admin             
-        *   -   ``type`` 
-            -   Audit event type   
-            -   access_denied            
-        *   -   ``tag``   
-            -   A text field that can be overwritten by the user   
-            -                      
-        *   -   ``description``   
-            -   Human-readable event description   
-            -   Authenticate user Alice                
+                can be overwritten for user-defined events
+            -   ``tarantool``
+        *   -   ``user``
+            -   User who triggered the event
+            -   ``admin``
+        *   -   ``type``
+            -   Audit event type
+            -   ``auth_ok``
+        *   -   ``tag``
+            -   A text field that can be overwritten by the user
+            -
+        *   -   ``description``
+            -   Human-readable event description
+            -   ``Authenticate user Admin``
 
-    ..  warning:: 
-    
-        You can set all these parameters only once. Unlike many other parameters in ``box.cfg``,
-        they cannot be changed.
+    ..  warning::
 
-.. _audit-log-start:
+        You can set all these parameters only once.
 
-Enable the Tarantool audit log
-------------------------------
+..  _audit-log-event-groups:
 
-By default, audit logging is disabled. To enable audit logging,
-define the logs location by setting the ``box.cfg.audit_log`` option.
-Tarantool can write audit logs to a file, to a pipe, or to the system logger.
+Event groups
+------------
 
-To disable audit logging, set the ``audit_log`` option to ``nil``.
+Built-in event groups are used to filter the event types that you want to audit.
+For example, you can set to record only authorization events,
+or only events related to a space.
 
-Write to a file
-~~~~~~~~~~~~~~~
+Tarantool provides the following event groups:
 
-..  code-block:: lua
+    *   ``all`` -- all :ref:`events <audit-log-events>`.
 
-    box.cfg{audit_log = 'audit_tarantool.log'}
-    -- or
-    box.cfg{audit_log = 'file:audit_tarantool.log'}
+        ..  note::
 
-This opens the ``audit_tarantool.log`` file for output in the server’s default directory.
-If the ``audit_log`` string has no prefix or the prefix ``file:``, the string is interpreted as a file path.
+            Events ``call`` and ``eval`` are included only in the ``all`` group.
 
-Send to a pipe
-~~~~~~~~~~~~~~
+    *   ``audit`` -- ``audit_enable`` event.
 
-..  code-block:: lua   
+    *   ``auth`` -- authorization events: ``auth_ok``, ``auth_fail``.
 
-    box.cfg{audit_log = '| cronolog audit_tarantool.log'}
-    -- or
-    box.cfg{audit_log = 'pipe: cronolog audit_tarantool.log'}'
-    
-This starts the `cronolog <https://linux.die.net/man/1/cronolog>`_ program when the server starts
-and sends all ``audit_log`` messages to cronolog's standard input (``stdin``).
-If the ``audit_log`` string starts with '|' or contains the prefix ``pipe:``,
-the string is interpreted as a Unix `pipeline <https://en.wikipedia.org/wiki/Pipeline_%28Unix%29>`_.
+    *   ``priv`` -- events related to authentication, authorization, users, and roles:
+        ``user_create``, ``user_drop``, ``role_create``, ``role_drop``, ``user_enable``, ``user_disable``,
+        ``user_grant_rights``, ``user_revoke_rights``, ``role_grant_rights``, ``role_revoke_rights``.
 
-Send to syslog
-~~~~~~~~~~~~~~
+    *   ``ddl`` -- events of space creation, altering, and dropping:
+        ``space_create``, ``space_alter``, ``space_drop``.
+
+    *   ``dml`` -- events of data modification in spaces:
+        ``space_insert``, ``space_replace``, ``space_delete``.
+
+    *   ``data_operations`` -- events of data modification or selection from spaces:
+        ``space_select``, ``space_insert``, ``space_replace``, ``space_delete``.
+
+    *   ``compatibility`` -- events available in Tarantool before the version 2.10.0.
+        ``auth_ok``, ``auth_fail``, ``disconnect``, ``user_create``, ``user_drop``,
+        ``role_create``, ``role_drop``, ``user_enable``, ``user_disable``,
+        ``user_grant_rights``, ``user_revoke_rights``, ``role_grant_rights``.
+        ``role_revoke_rights``, ``password_change``, ``access_denied``.
+        This group enables the compatibility with earlier Tarantool versions.
 
 ..  warning::
 
-    Below is an example of writing audit logs to a directory shared with the system logs.
-    Tarantool allows this option, but it is not recommended to do this to avoid difficulties
-    when working with audit logs. System and audit logs should be written separately.
-    To do this, create separate paths and specify them.
-
-This example setting sends the audit log to syslog:
-
-..  code-block:: lua 
-    
-    box.cfg{audit_log = 'syslog:identity=tarantool'}
-    -- or
-    box.cfg{audit_log = 'syslog:facility=user'}
-    -- or
-    box.cfg{audit_log = 'syslog:identity=tarantool,facility=user'}
-    -- or
-    box.cfg{audit_log = 'syslog:server=unix:/dev/log'}
-
-If the ``audit_log`` string starts with "syslog:",
-it is interpreted as a message for the `syslogd <https://datatracker.ietf.org/doc/html/rfc5424>`_ program,
-which normally runs in the background of any Unix-like platform.
-The setting can be 'syslog:', 'syslog:facility=...', 'syslog:identity=...', 'syslog:server=...' or a combination.
-
-The ``syslog:identity`` setting is an arbitrary string that is placed at the beginning of all messages.
-The default value is ``tarantool``.
-
-The ``syslog:facility`` setting is currently ignored, but will be used in the future.
-The value must be one of the `syslog <https://en.wikipedia.org/wiki/Syslog>`_ keywords
-that tell ``syslogd`` where to send the message.
-The possible values are ``auth``, ``authpriv``, ``cron``, ``daemon``, ``ftp``,
-``kern``, ``lpr``, ``mail``, ``news``, ``security``, ``syslog``, ``user``, ``uucp``,
-``local0``, ``local1``, ``local2``, ``local3``, ``local4``, ``local5``, ``local6``, ``local7``.
-The default value is ``local7``.
-
-The ``syslog:server`` setting is the locator for the syslog server.
-It can be a Unix socket path starting with "unix:" or an ipv4 port number.
-The default socket value is ``/dev/log`` (on Linux) or ``/var/run/syslog`` (on Mac OS).
-The default port value is 514, which is the UDP port.
-
-If you log to a file, Tarantool will reopen the audit log at `SIGHUP <https://en.wikipedia.org/wiki/SIGHUP>`_.
-If log is a program, its pid is stored in the ``audit_log.logger_pid`` variable.
-You need to send it a signal to rotate logs.
-
-An example of a Tarantool audit log entry in the syslog:
-
-..  code-block:: json
-
-    {
-      "__CURSOR" : "s=81564632436a4de590e80b89b0151148;i=11519;b=def80c1464fe49d1aac8a64895d6614d;m=8c825ebfc;t=5edb27a75f282;x=7eba320f7cc9ae4d",
-      "__REALTIME_TIMESTAMP" : "1668725698065026",
-      "__MONOTONIC_TIMESTAMP" : "37717666812",
-      "_BOOT_ID" : "def80c1464fe49d1aac8a64895d6614d",
-      "_UID" : "1003",
-      "_GID" : "1004",
-      "_COMM" : "tarantool",
-      "_EXE" : "/app/tarantool/dist/tdg-2.6.4.0.x86_64/tarantool",
-      "_CMDLINE" : "tarantool init.lua <running>: core-03",
-      "_CAP_EFFECTIVE" : "0",
-      "_AUDIT_SESSION" : "1",
-      "_AUDIT_LOGINUID" : "1003",
-      "_SYSTEMD_CGROUP" : "/user.slice/user-1003.slice/user@1003.service/app.slice/app@core-03.service",
-      "_SYSTEMD_OWNER_UID" : "1003",
-      "_SYSTEMD_UNIT" : "user@1003.service",
-      "_SYSTEMD_USER_UNIT" : "app@core-03.service",
-      "_SYSTEMD_SLICE" : "user-1003.slice",
-      "_SYSTEMD_USER_SLICE" : "app.slice",
-      "_SYSTEMD_INVOCATION_ID" : "be368b4243d842ea8c06b010e0df62c2",
-      "_MACHINE_ID" : "2e2339725deb4bc198c54ff4a2e8d626",
-      "_HOSTNAME" : "vm-0.test.env",
-      "_TRANSPORT" : "syslog",
-      "PRIORITY" : "6",
-      "SYSLOG_FACILITY" : "23",
-      "SYSLOG_IDENTIFIER" : "tarantool",
-      "SYSLOG_PID" : "101562",
-      "_PID" : "101562",
-      "MESSAGE" : "remote: session_type:background module:common.admin.auth user: type:custom_tdg_audit tag:tdg_severity_INFO description:[119eae0e-a691-42cc-9b4c-f14c499e6726] subj: \"anonymous\", msg: \"Access granted to anonymous user\"",
-      "_SOURCE_REALTIME_TIMESTAMP" : "1668725698064202"
-    }
-
-.. _audit-log-filters:
-
-Select events to write to audit log
------------------------------------
-
-Tarantool's extensive filtering options help you write only the events you need to the audit log.
-
-To select events to write to audit log, use the ``box.cfg.audit_filter`` option.
-Its value can be a list of events and event groups.
-The default value for the ``box.cfg.audit_filter`` option is ``compatibility``,
-which enables logging of all events available before 2.10.0.
-
-..  code-block:: lua
-
-    box.cfg{
-            audit_log = 'audit.log',
-            audit_filter = 'audit,auth,priv,password_change,access_denied'
-           }
-
-.. _audit-log-combinations:
-
-Customize your filters
-~~~~~~~~~~~~~~~~~~~~~~
-
-You can customize the filters and use different combinations of filters for your purposes.
-
-Filter based on a specific event
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can set only certain events that you need to record.
-
-For example, select ``password_change`` to monitor the users who have changed their passwords.
-
-..  code-block:: lua
-
-    box.cfg{
-            audit_log = 'audit.log',
-            audit_filter = 'password_change'
-           }
-
-Filter based on a specific group
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can set one of the groups of events that you need to record.
-
-For example, select ``compatibility`` to monitor only events of user authorization,
-granted privileges, disconnection, user password change, and denied access.
-
-..  code-block:: lua
-
-    box.cfg{
-            audit_log = 'audit.log',
-            audit_filter = 'compatibility'
-           }
-
-Filter based on multiple groups
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can specify multiple groups depending on the purpose.
-
-For example, select ``auth`` and ``priv`` to see only events related to authorization and granted privileges.
-
-..  code-block:: lua
-
-    box.cfg{
-            audit_log = 'audit.log',
-            audit_filter = 'auth,priv'
-           }
-
-Filter based on a group and a specific event
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can specify a group and a certain event depending on the purpose.
-
-For example, you can select ``priv`` and ``disconnect`` to see only events related to
-granted privileges and disconnect events.
-
-..  code-block:: lua
-
-    box.cfg{
-            audit_log = 'audit.log',
-            audit_filter = 'priv,disconnect'
-           }
-
-Example
-~~~~~~~
-
-Run the command to filter:
-
-..  code-block:: lua
-
-    local audit = require('audit')
-
-    box.cfg{audit_log = 'audit.log', audit_filter = 'custom,user_create', audit_format = 'csv'}
-    -- The Tarantool audit module writes the event because a filter is set for it
-    box.schema.user.create('alice')
-    -- The Tarantool audit module will not write the event because no filter is set for it
-    box.schema.user.drop('alice')
-
-.. _audit-log-nonblock:
-
-Configure a blocking mode
--------------------------
-
-By default, the ``audit_nonblock`` option is set to ``true``
-and Tarantool will not block during logging if the system is not ready to write, dropping the message instead.
-Using this value may improve logging performance at the cost of losing some log messages.
-This option only has an effect if the output goes to ``syslog:`` or ``pipe:``.
-Setting ``audit_nonblock`` to ``true`` is not allowed if the output is to a file.
-In this case, set ``audit_nonblock`` to ``false``.   
-
-.. _audit-log-format:
-
-Configure the format of audit log events
-----------------------------------------
-
-You can choose the format of audit log events -- plain text, CSV or JSON format. 
-
-Plain text is used by default. This human-readable format can be efficiently compressed.
-The JSON format is more convenient to receive log events, analyze them and integrate them with other systems if needed.
-Using the CSV format allows you to view audit log events in tabular form.
-
-Use these commands to configure the format of audit log events in Tarantool.
-
-Plain text
-~~~~~~~~~~
-
-..  code-block:: lua
-
-    box.cfg{audit_log = 'audit.log', audit_format = 'plain'}
-
-Example:
-
-..  code-block:: text
-
-    remote:
-    session_type:background
-    module:common.admin.auth
-    user: type:custom_tdg_audit
-    tag:tdg_severity_INFO
-    description:[5e35b406-4274-4903-857b-c80115275940]
-    subj: "anonymous",
-    msg: "Access granted to anonymous user"
-
-JSON format
-~~~~~~~~~~~
-
-..  code-block:: lua
-
-    box.cfg{audit_log = 'audit.log', audit_format = 'json'}
-
-Example:
-
-..  code-block:: json
-
-    {
-        "time": "2022-11-17T21:55:49.880+0300",
-        "remote": "",
-        "session_type": "background",
-        "module": "common.admin.auth",
-        "user": "",
-        "type": "custom_tdg_audit",
-        "tag": "tdg_severity_INFO",
-        "description": "[c26cd11a-3342-4ce6-8f0b-a4b222268b9d] subj: \"anonymous\", msg: \"Access granted to anonymous user\""
-    }
-
-CSV format
-~~~~~~~~~~
-
-..  code-block:: lua
-
-    box.cfg{audit_log = 'audit.log', audit_format = 'csv'}
-
-Example:
-
-..  code-block:: text
-
-    2022-11-17T21:58:03.131+0300,,background,common.admin.auth,,,custom_tdg_audit,tdg_severity_INFO,"[b3dfe2a3-ec29-4e61-b747-eb2332c83b2e] subj: ""anonymous"", msg: ""Access granted to anonymous user"""
+    Be careful when recording ``all`` and ``data_operations`` event groups.
+    The more events you record, the slower the requests are processed over time.
+    It is recommended that you select only those groups
+    whose events your company needs to monitor and analyze.
 
 .. _audit-log-custom:
 
@@ -548,18 +286,20 @@ Create user-defined events
 --------------------------
 
 Tarantool provides an API for writing user-defined audit log events.
+To enable custom events, specify the ``custom`` value in the :ref:`audit_log.filter <configuration_reference_audit_filter>` option.
 
 To add a new event, use the ``audit.log()`` function that takes one of the following values:
 
-*   Message string. Printed to the audit log with type ``message``. Example: ``audit.log('Hello, World!')``.
+*   Message string. Printed to the audit log with type ``message``.
+    Example: ``audit.log('Hello, World!')``.
 
-*   Format string and arguments. Passed to string format and then output to the audit log with type message.
+*   Format string and arguments. Passed to string format and then output to the audit log with type ``message``.
     Example: ``audit.log('Hello, %s!', 'World')``.
 
-*   Table with audit log field values. The table must contain at least one field -- description.
+*   Table with audit log field values. The table must contain at least one field -- ``description``.
     Example: ``audit.log({type = 'custom_hello', description = 'Hello, World!'})``.
 
-Using the field ``audit.new()``, you can create a new log module that allows you
+Using the option ``audit.new()``, you can create a new log module that allows you
 to avoid passing all custom audit log fields each time ``audit.log()`` is called.
 It takes a table of audit log field values (same as ``audit.log()``). The ``type``
 of the log module for writing user-defined events must either be ``message`` or
@@ -570,53 +310,202 @@ Example
 
 ..  code-block:: lua
 
-    local my_audit = audit.new({type = 'custom_hello', module = 'my_module'})
-    my_audit:log('Hello, Alice!')
-    my_audit:log({tag = 'admin', description = 'Hello, Bob!'})
-
-    -- is equivalent to
-    audit.log({type = 'custom_hello', module = 'my_module',
-               description = 'Hello, Alice!' })
-    audit.log({type = 'custom_hello', module = 'my_module',
-               tag = 'admin', description = 'Hello, Bob!'})
+    audit.log({type = 'custom_hello', module = 'my_module', description = 'Hello, Alice!' })
+    audit.log({type = 'custom_hello', module = 'my_module', tag = 'admin', description = 'Hello, Bob!'})
 
 
 Some user-defined audit log fields (``time``, ``remote``, ``session_type``)
 are set in the same way as for a system event.
-If a field is not overwritten, it is set to the same value as for a system event.  
+If a field is not overwritten, it is set to the same value as for a system event.
 
-Some audit log fields you can overwrite with ``audit.new()`` and ``audit.log()``: 
+Some audit log fields you can overwrite with ``audit.new()`` and ``audit.log()``:
 
-*   type
-*   user
-*   module
-*   tag
-*   description
+*   ``type``
+*   ``user``
+*   ``module``
+*   ``tag``
+*   ``description``
 
-    ..  note::
-        
-        To avoid confusion with system events, the value of the type field must either be ``message`` (default)
-        or begin with ``custom_``. Otherwise you will get the error message.
-        User-defined events are filtered out by default.
-        To enable user-defined audit log events, you must add ``custom`` to ``box.cfg.audit_filter``.                                                            
+..  note::
 
-Example
-~~~~~~~
+    To avoid confusion with system events, the value of the type field must either be ``message`` (default)
+    or begin with the ``custom_`` prefix. Otherwise, you receive the error message.
+    User-defined events are filtered out by default..
 
-..  code-block:: lua
 
-    local audit = require('audit')
+..  _audit-log-example:
 
-    box.cfg{audit_log = 'audit.log', audit_filter = 'custom', audit_format = 'csv'}
-    audit.log('Hello, Alice!')
-    audit.log('Hello, %s!', 'Bob')
-    audit.log({type = 'custom_hello', description = 'Hello, Eve!'})
-    audit.log({type = 'custom_farewell', user = 'eve', module = 'custom', description = 'Farewell, Eve!'})
+Example: using Tarantool audit log
+----------------------------------
 
-    local my_audit = audit.new({module = 'my_module', tag = 'default'})
-    my_audit:log({description = 'Message 1'})
-    my_audit:log({description = 'Message 2', tag = 'my_tag'})
-    my_audit:log({description = 'Message 3', module = 'other_module'})
+The example shows how to enable and configure audit logging and write logs to a selected destination (a file, a pipe,
+or a system logger).
+
+Before starting this example:
+
+#.  Install the :ref:`tt <tt-cli>` utility.
+
+#.  Create a tt environment in the current directory by executing the :ref:`tt init <tt-init>` command.
+
+#.  Inside the ``instances.enabled`` directory of the created tt environment, create the ``audit_log`` directory.
+
+#.  Inside ``instances.enabled/audit_log``, create the ``instances.yml`` and ``config.yaml`` files:
+
+    -   ``instances.yml`` specifies instances to run in the current environment and should look like this:
+
+        ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/instances.yml
+            :language: yaml
+            :end-at: instance001:
+            :dedent:
+
+    -   The ``config.yaml`` file stores an audit log configuration (the ``audit_log`` section). The configuration is described in detail in the next section.
+
+..  _audit-log-enable:
+
+Enable audit logging
+~~~~~~~~~~~~~~~~~~~~
+
+To enable audit logging, define the log location using the
+:ref:`audit_log.to <configuration_reference_audit_to>` option in the ``audit_log`` section of the configuration file.
+Possible logs locations:
+
+*   a :ref:`file <audit-log-file>`
+*   a :ref:`pipe <audit-log-pipe>`
+*   a :ref:`system logger <audit-log-syslog>`
+
+To disable audit logging, set the ``audit_log`` option to ``devnull``.
+
+In this tutorial, the logs are written to a file. To do this, set the
+:ref:`audit_log.to <configuration_reference_audit_to>` option to ``file``.
+After that, you can define a file path (for example, ``audit_tarantool.log``) using
+the :ref:`audit_log.file <configuration_reference_audit_file>` option.
+If the option is omitted, the default path is used: ``var/log/instance001/audit.log``.
+
+The configuration might look as follows:
+
+..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
+    :language: yaml
+    :start-at: audit_log:
+    :end-at: audit_tarantool.log
+    :dedent:
+
+If you log to a file, Tarantool reopens the audit log at `SIGHUP <https://en.wikipedia.org/wiki/SIGHUP>`_.
+
+..  _audit-log-filters:
+
+Filter the events
+~~~~~~~~~~~~~~~~~
+
+Tarantool's extensive filtering options help you write only the events you need to the audit log.
+
+To select the recorded events, use the :ref:`audit_log.filter <configuration_reference_audit_filter>` option.
+Its value can be a list of events and event groups.
+You can customize the filters and use different combinations of them for your purposes.
+Possible filtering options:
+
+-   Filter by event. You can set a list of :ref:`events <audit-log-events>` to be recorded. For example, select
+    ``password_change`` to monitor the users who have changed their passwords:
+
+    ..  code-block:: yaml
+
+        audit_log:
+          filter: [ password_change ]
+
+-   Filter by group. You can specify a list of :ref:`event groups <audit-log-event-groups>` to be recorded. For example,
+    select ``auth`` and ``priv`` to see only events related to authorization and granted privileges.
+
+    ..  code-block:: yaml
+
+        audit_log:
+          filter: [ auth,priv ]
+
+-   Filter by group and event. You can specify a group and a certain event depending on the purpose.
+    For example, you can select ``user_create``, ``data_operations``, and ``ddl`` to see the events related to
+
+    *   user creation
+    *   space creation, altering, and dropping
+    *   data modification or selection from spaces
+
+    Let's add this filter to our configuration file:
+
+    ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
+        :language: yaml
+        :start-at: audit_log:
+        :end-at: audit_tarantool.log
+        :dedent:
+
+
+..  _audit-log-format:
+
+Set the format of audit log events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :ref:`audit_log.format <configuration_reference_audit_format>` option to choose the format of audit log events
+-- plain text, CSV, or JSON.
+
+JSON is used by default. It is more convenient to receive log events, analyze them, and integrate them with other systems if needed.
+The plain format can be efficiently compressed.
+The CSV format allows you to view audit log events in tabular form.
+
+In this tutorial, set the format to JSON:
+
+..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
+    :language: yaml
+    :start-at: audit_log:
+    :end-at: format: json
+    :dedent:
+
+..  _audit-log-spaces:
+
+Specify the spaces to be logged
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since: :doc:`3.0.0 </release/3.0.0>`, it is possible to :ref:`specify a list of space names <configuration_reference_audit_spaces>`
+for which data operation events should be logged.
+
+To log the events from the ``bands`` space only, specify the option in the configuration file:
+
+..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
+    :language: yaml
+    :liines: 15
+    :dedent:
+
+..  _audit-log-extract:
+
+Specify the logging mode in DML events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since: :doc:`3.0.0 </release/3.0.0>`, it is possible to
+force the audit subsystem to log the primary key instead of a full tuple in DML operations.
+
+To do so, set the :ref:`audit_log.extract_key <configuration_reference_audit_extract_key>` option to ``true``.
+
+The resulting configuration in ``config.yaml`` now looks as follows:
+
+..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
+    :language: yaml
+    :dedent:
+
+..  _audit-log-run-example:
+
+Check the example
+~~~~~~~~~~~~~~~~~
+
+After the configuration is done, execute the :ref:`tt start <tt-start>` command from the :ref:`tt environment directory <replication-tt-env>`:
+
+    .. code-block:: console
+
+        $ tt start audit_log
+           • Starting an instance [audit_log:instance001]...
+
+After that, connect to the instance with :ref:`tt connect <tt-connect>`:
+
+..  code-block:: console
+
+    $ tt connect audit_log:instance001
+
+In the interactive console. run the following commands:
+
 
 .. _audit-log-read:
 
@@ -647,8 +536,8 @@ How many events can be recorded?
 
 If you write to a file, the size of the Tarantool audit module is limited by the disk space.
 If you write to a system logger, the size of the Tarantool audit module is limited by the system logger.
-If you write to a pipe, the size of the Tarantool audit module is limited by the system buffer
-if the ``audit_nonblock`` = ``false``; if ``audit_nonblock`` = ``true``, there is no limit.
+If you write to a pipe, the size of the Tarantool audit module is limited by the system buffer.
+If the ``audit_nonblock = false``, if ``audit_nonblock`` = ``true``, there is no limit.
 However, it is not recommended to use the entire memory, as this may cause performance degradation
 and even loss of some logs.
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -47,7 +47,6 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
 
     **Since:** :doc:`3.0.0 </release/3.0.0>`.
 
-    Specify the logging mode in DML events.
     If set to ``true``, the audit subsystem extracts and prints only the primary key instead of full
     tuples in DML events (``space_insert``, ``space_replace``, ``space_delete``).
     Otherwise, full tuples are logged.
@@ -78,8 +77,8 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
     Enable logging for a specified subset of audit events.
     This option accepts the following values:
 
-    *   event names (for example, ``password_change``). For details, see :ref:`Audit log events <audit-log-events>`.
-    *   event groups (for example, ``audit``).  For details, see :ref:`Event groups <audit-log-event-groups>`.
+    *   Event names (for example, ``password_change``). For details, see :ref:`Audit log events <audit-log-events>`.
+    *   Event groups (for example, ``audit``).  For details, see :ref:`Event groups <audit-log-event-groups>`.
 
     The option contains either one value from above or a combination of them.
 
@@ -322,10 +321,12 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
 
     **Example**
 
-    The basic audit log configuration in the :doc:`3.0.0 </release/3.0.0>` version might look as follows:
+    The basic audit log configuration might look as follows:
 
     ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
         :language: yaml
+        :start-at: audit_log
+        :end-at: extract_key: true
         :dedent:
 
     |

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -80,9 +80,17 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
     *   Event names (for example, ``password_change``). For details, see :ref:`Audit log events <audit-log-events>`.
     *   Event groups (for example, ``audit``).  For details, see :ref:`Event groups <audit-log-event-groups>`.
 
-    The option contains either one value from above or a combination of them.
+    The option contains either one value from ``Possible values`` section (see below) or a combination of them.
 
-    To enable :ref:`user-defined audit log events <audit-log-custom>`, specify the ``custom`` value in this option.
+    To enable :ref:`custom audit log events <audit-log-custom>`, specify the ``custom`` value in this option.
+
+    **Example**
+
+    ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/myapp.lua
+        :language: lua
+        :start-at: filter:
+        :end-at: custom ]
+        :dedent:
 
     |
     | Type: array
@@ -154,7 +162,7 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
 
     Specify a pipe for the audit log destination.
     You can set the ``pipe`` type using the :ref:`audit_log.to <configuration_reference_audit_to>` option.
-    If log is a program, its pid is stored in the ``audit_log.logger_pid`` variable.
+    If log is a program, its pid is stored in the ``audit.pid`` field.
     You need to send it a signal to rotate logs.
 
     **Example**
@@ -218,7 +226,7 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
 
 ..  confval:: audit_log.syslog_identity
 
-    Specify an arbitrary string that will be placed at the beginning of all messages.
+    Specify an application name to show in logs.
     You can enable logging to a system logger using the :ref:`audit_log.to <configuration_reference_audit_to>` option.
 
     See also: :ref:`syslog configuration example <configuration_reference_audit_syslog-example>`.
@@ -251,7 +259,7 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
     -   :ref:`audit_log.syslog_facility <configuration_reference_audit_syslog-facility>` -- a system logger keyword that tells syslogd where to send the message.
         The default value is ``local7``.
 
-    -   :ref:`audit_log.syslog_identity <configuration_reference_audit_syslog-identity>` -- a string placed at the beginning of every message.
+    -   :ref:`audit_log.syslog_identity <configuration_reference_audit_syslog-identity>` -- an application name to show in logs.
         The default value is ``tarantool``.
 
     These options are interpreted as a message for the `syslogd <https://datatracker.ietf.org/doc/html/rfc5424>`_ program,
@@ -259,39 +267,9 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
 
     An example of a Tarantool audit log entry in the syslog:
 
-    ..  code-block:: json
+    ..  code-block:: text
 
-        {
-          "__CURSOR" : "s=81564632436a4de590e80b89b0151148;i=11519;b=def80c1464fe49d1aac8a64895d6614d;m=8c825ebfc;t=5edb27a75f282;x=7eba320f7cc9ae4d",
-          "__REALTIME_TIMESTAMP" : "1668725698065026",
-          "__MONOTONIC_TIMESTAMP" : "37717666812",
-          "_BOOT_ID" : "def80c1464fe49d1aac8a64895d6614d",
-          "_UID" : "1003",
-          "_GID" : "1004",
-          "_COMM" : "tarantool",
-          "_EXE" : "/app/tarantool/dist/tdg-2.6.4.0.x86_64/tarantool",
-          "_CMDLINE" : "tarantool init.lua <running>: core-03",
-          "_CAP_EFFECTIVE" : "0",
-          "_AUDIT_SESSION" : "1",
-          "_AUDIT_LOGINUID" : "1003",
-          "_SYSTEMD_CGROUP" : "/user.slice/user-1003.slice/user@1003.service/app.slice/app@core-03.service",
-          "_SYSTEMD_OWNER_UID" : "1003",
-          "_SYSTEMD_UNIT" : "user@1003.service",
-          "_SYSTEMD_USER_UNIT" : "app@core-03.service",
-          "_SYSTEMD_SLICE" : "user-1003.slice",
-          "_SYSTEMD_USER_SLICE" : "app.slice",
-          "_SYSTEMD_INVOCATION_ID" : "be368b4243d842ea8c06b010e0df62c2",
-          "_MACHINE_ID" : "2e2339725deb4bc198c54ff4a2e8d626",
-          "_HOSTNAME" : "vm-0.test.env",
-          "_TRANSPORT" : "syslog",
-          "PRIORITY" : "6",
-          "SYSLOG_FACILITY" : "23",
-          "SYSLOG_IDENTIFIER" : "tarantool",
-          "SYSLOG_PID" : "101562",
-          "_PID" : "101562",
-          "MESSAGE" : "remote: session_type:background module:common.admin.auth user: type:custom_tdg_audit tag:tdg_severity_INFO description:[119eae0e-a691-42cc-9b4c-f14c499e6726] subj: \"anonymous\", msg: \"Access granted to anonymous user\"",
-          "_SOURCE_REALTIME_TIMESTAMP" : "1668725698064202"
-        }
+        09:32:52 tarantool: {"time": "2024-02-08T09:32:52.190+0300", "uuid": "94454e46-9a0e-493a-bb9f-d59e44a43581", "severity": "INFO", "remote": "unix/:(socket)", "session_type": "console", "module": "tarantool", "user": "admin", "type": "space_create", "tag": "", "description": "Create space bands"}
 
     ..  warning::
 
@@ -314,7 +292,7 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
 
     -   ``devnull``: disable audit logging.
     -   ``file``: write audit logs to a file (see :ref:`audit_log.file <configuration_reference_audit_file>`).
-    -   ``pipe``: write audit logs to a pipe (see :ref:`audit_log.pipe <configuration_reference_audit_pipe>`).
+    -   ``pipe``: start a program and write audit logs to it (see :ref:`audit_log.pipe <configuration_reference_audit_pipe>`).
     -   ``syslog``: write audit logs to a system logger (see :ref:`audit_log.syslog <configuration_reference_audit_pipe>`).
 
     By default, audit logging is disabled.

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -142,7 +142,7 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
     ..  note::
 
         The option only has an effect if the :ref:`audit_log.to <configuration_reference_audit_to>` is set to ``syslog``
-        ``pipe``.
+        or ``pipe``.
 
     |
     | Type: boolean

--- a/doc/reference/tooling/tt_cli/search.rst
+++ b/doc/reference/tooling/tt_cli/search.rst
@@ -25,7 +25,7 @@ Options
 
 .. option:: --debug
 
-    **Applicable to:** ``taranttol-ee``
+    **Applicable to:** ``tarantool-ee``
 
     Search for debug builds of Tarantool Enterprise Edition's SDK.
 
@@ -36,7 +36,7 @@ Options
 
 .. option:: --version VERSION
 
-    **Applicable to:** ``taranttol-ee``
+    **Applicable to:** ``tarantool-ee``
 
     Tarantool Enterprise version.
 


### PR DESCRIPTION
* Updated and restructured [Audit module](https://docs.d.tarantool.io/en/doc/gh-3667-audit-new/enterprise/audit_log/) page
* Added [audit_log](https://docs.d.tarantool.io/en/doc/gh-3667-audit-new/reference/configuration/configuration_reference/#audit-log) reference section:
  * [audit_log.extract_key](https://docs.d.tarantool.io/en/doc/gh-3667-audit-new/reference/configuration/configuration_reference/#configuration-reference-audit-extract-key), [audit_log.spaces](https://docs.d.tarantool.io/en/doc/gh-3667-audit-new/reference/configuration/configuration_reference/#confval-audit_log.spaces)  - new options
  * other options are moved from the box.cfg reference
* Documented new audit log [fields](https://docs.d.tarantool.io/en/doc/gh-3667-audit-new/enterprise/audit_log/#structure-of-audit-log-event) - uuid, severity
* Added a new [Severity level](https://docs.d.tarantool.io/en/doc/gh-3667-audit-new/enterprise/audit_log/#severity-level) subsection to Custom events section (with examples)

* Fixed typo in the `tt search` description

Fixes https://github.com/tarantool/doc/issues/3667
Fixes https://github.com/tarantool/enterprise_doc/issues/258
Fixes https://github.com/tarantool/enterprise_doc/issues/257
Fixes https://github.com/tarantool/enterprise_doc/issues/221 - **also related to 2.11, don't forget to update this in 2.11 branch**
Fixes https://github.com/tarantool/enterprise_doc/issues/248
