### PR TITLE
Update tt commands reference for tt 1.3

### DIFF
--- a/doc/book/connectors/java.rst
+++ b/doc/book/connectors/java.rst
@@ -19,7 +19,7 @@ There are two Java connectors available:
 The following modules support Java libraries and frameworks:
 
 *   `TestContainers Tarantool module <http://github.com/tarantool/cartridge-java-testcontainers/>`__
-    adds support for the popular `TestСontainers framework <https://www.testcontainers.org/>`__
+    adds support for the popular `TestContainers framework <https://www.testcontainers.org/>`__
     used for integration testing of Java applications.
 *   `Spring Data Tarantool module <http://github.com/tarantool/cartridge-springdata/>`__
     adds support for the `Spring framework <https://projects.spring.io/spring-data/>`__.

--- a/doc/how-to/getting_started_go.rst
+++ b/doc/how-to/getting_started_go.rst
@@ -186,7 +186,7 @@ doesn't exist.
 Deleting data
 ********************************************************************************
 
-To delete a tuple, use ``сonnection.Delete``:
+To delete a tuple, use ``connection.Delete``:
 
 .. code-block:: go
 

--- a/doc/reference/tooling/tcm/tcm_connect_clusters.rst
+++ b/doc/reference/tooling/tcm/tcm_connect_clusters.rst
@@ -1,6 +1,6 @@
 ..  _tcm_connect_clusters:
 
-Сonnecting clusters
+Connecting clusters
 ===================
 
 ..  include:: index.rst

--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -5,7 +5,7 @@ Installing Tarantool software
 
 ..  code-block:: console
 
-    $ tt install PROGRAM_NAME [VERSION] [OPTION ...]
+    $ tt install PROGRAM_NAME [VERSION|COMMIT_HASH|PR_ID] [OPTION ...]
 
 ``tt install`` installs the latest or an explicitly specified version of Tarantool
 or ``tt``. The possible values of ``PROGRAM_NAME`` are:
@@ -20,6 +20,11 @@ or ``tt``. The possible values of ``PROGRAM_NAME`` are:
     For ``tarantool-ee``, account credentials are required. Specify them in a file
     (see the :ref:`ee section <tt-config_file_ee>` of the configuration file) or
     provide them interactively.
+
+Additionally, ``tt install`` can build open source programs ``tarantool`` and ``tt``
+from a specific commit or a pull request on their GitHub repositories.
+
+To uninstall a Tarantool or ``tt`` version, use :doc:`tt uninstall <uninstall>`.
 
 Options
 -------
@@ -66,16 +71,42 @@ dependencies, such as a C compiler. Make sure they are available in the system.
 
 Tarantool Enterprise Edition is installed from prebuilt packages.
 
+Development versions
+~~~~~~~~~~~~~~~~~~~~
+
+``tt install`` can be used to build custom Tarantool and ``tt`` versions for
+development purposes. The sources for such version can be either stored locally
+or exist on GitHub (specific commits or pull requests).
+
+To build Tarantool from a local source, use the ``tarantool-dev`` program name and
+provide a path to the source:
+
+..  code-block:: console
+
+    $ tt install tarantool-dev ~/src/tarantool/build
+
+To build Tarantool or ``tt`` from a specific commit on their GitHub repository,
+pass the commit hash (7 or more characters) after the program name. If you want to use
+a PR as a source, provide a ``pr/<PR_ID>`` argument:
+
+
+..  code-block:: console
+
+    $ tt install tarantool 03c184d
+    $ tt install tt pr/50
+
+
+Local repositories
+~~~~~~~~~~~~~~~~~~
+
 You can also set up a local repository with installation files you need.
 To use it, specify its location in the :ref:`repo section <tt-config_file_repo>`
 of the ``tt`` configuration file and run ``tt install`` with the ``--local-repo`` flag.
 
-To uninstall a Tarantool or ``tt`` version, use :doc:`tt uninstall <uninstall>`.
-
 Example
 --------
 
-*   Install the latest available version of Tarantool:
+*   Install the latest available version of Tarantool CE:
 
     ..  code-block:: console
 
@@ -98,3 +129,16 @@ Example
     ..  code-block:: console
 
         $ tt install tarantool-dev ~/src/tarantool/build
+
+
+*   Install Tarantool from a PR #1234 on the `tarantool/tarantool GitHub repository <https://github.com/tarantool/tarantool>`__:
+
+    ..  code-block:: console
+
+        $ tt install tarantool pr/1234
+
+*   Install ``tt`` from a commit with hash ``00a9e59`` on the `tarantool/tt GitHub repository <https://github.com/tarantool/tt>`__:
+
+    ..  code-block:: console
+
+        $ tt install tt 40e696e

--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -75,15 +75,7 @@ Development versions
 ~~~~~~~~~~~~~~~~~~~~
 
 ``tt install`` can be used to build custom Tarantool and ``tt`` versions for
-development purposes. The sources for such version can be either stored locally
-or exist on GitHub (specific commits or pull requests).
-
-To build Tarantool from a local source, use the ``tarantool-dev`` program name and
-provide a path to the source:
-
-..  code-block:: console
-
-    $ tt install tarantool-dev ~/src/tarantool/build
+development purposes from commits and pull requests on their GitHub repositories.
 
 To build Tarantool or ``tt`` from a specific commit on their GitHub repository,
 pass the commit hash (7 or more characters) after the program name. If you want to use
@@ -95,6 +87,13 @@ a PR as a source, provide a ``pr/<PR_ID>`` argument:
     $ tt install tarantool 03c184d
     $ tt install tt pr/50
 
+If you :ref:`build Tarantool from sources <building_from_source>`, you can install
+local builds to the current ``tt`` environment by running ``tt install`` with
+the ``tarantool-dev`` program name and the path to the build:
+
+..  code-block:: console
+
+    $ tt install tarantool-dev ~/src/tarantool/build
 
 Local repositories
 ~~~~~~~~~~~~~~~~~~
@@ -124,13 +123,6 @@ Example
 
         $ tt install tarantool 2.10.8 --reinstall
 
-*   Install Tarantool :ref:`built from sources <building_from_source>`:
-
-    ..  code-block:: console
-
-        $ tt install tarantool-dev ~/src/tarantool/build
-
-
 *   Install Tarantool from a PR #1234 on the `tarantool/tarantool GitHub repository <https://github.com/tarantool/tarantool>`__:
 
     ..  code-block:: console
@@ -142,3 +134,9 @@ Example
     ..  code-block:: console
 
         $ tt install tt 40e696e
+
+*   Install Tarantool :ref:`built from sources <building_from_source>`:
+
+    ..  code-block:: console
+
+        $ tt install tarantool-dev ~/src/tarantool/build

--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -123,13 +123,13 @@ Example
 
         $ tt install tarantool 2.10.8 --reinstall
 
-*   Install Tarantool from a PR #1234 on the `tarantool/tarantool GitHub repository <https://github.com/tarantool/tarantool>`__:
+*   Install Tarantool from a PR #1234 on the `tarantool/tarantool <https://github.com/tarantool/tarantool>`__ GitHub repository:
 
     ..  code-block:: console
 
         $ tt install tarantool pr/1234
 
-*   Install ``tt`` from a commit with a hash ``00a9e59`` on the `tarantool/tt GitHub repository <https://github.com/tarantool/tt>`__:
+*   Install ``tt`` from a commit with a hash ``40e696e`` on the `tarantool/tt  <https://github.com/tarantool/tt>`__ GitHub repository:
 
     ..  code-block:: console
 

--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -129,7 +129,7 @@ Example
 
         $ tt install tarantool pr/1234
 
-*   Install ``tt`` from a commit with hash ``00a9e59`` on the `tarantool/tt GitHub repository <https://github.com/tarantool/tt>`__:
+*   Install ``tt`` from a commit with a hash ``00a9e59`` on the `tarantool/tt GitHub repository <https://github.com/tarantool/tt>`__:
 
     ..  code-block:: console
 

--- a/doc/reference/tooling/tt_cli/pack.rst
+++ b/doc/reference/tooling/tt_cli/pack.rst
@@ -126,9 +126,16 @@ Options
 
         $ tt pack deb --postinst post.sh
 
+..  option:: --tarantool-version
+
+    Specify a Tarantool version for packaging in a Docker container.
+    For use with ``--use-docker`` only.
+
 ..  option:: --use-docker
 
-    Build a package in an Ubuntu 18.04 Docker container.
+    Build a package in an Ubuntu 18.04 Docker container. To specify a Tarantool
+    version to use in the container, add the ``--tarantool-version`` option.
+
     Before executing ``tt pack`` with this option, make sure Docker is running.
 
 ..  option:: --version PACKAGE_VERSION

--- a/doc/reference/tooling/tt_cli/rocks.rst
+++ b/doc/reference/tooling/tt_cli/rocks.rst
@@ -72,6 +72,8 @@ Commands
         :widths: 20 80
         :header-rows: 0
 
+        *   -   ``admin``
+            -   Use the `luarocks-admin <https://github.com/luarocks/luarocks/wiki/luarocks-admin>`__ tool
         *   -   ``build``
             -   Build and compile a rock
         *   -   ``config``


### PR DESCRIPTION
Resolves #3755 #3756 #3649 

Expand and update `tt` commands reference:
- [tt pack](https://docs.d.tarantool.io/en/doc/gh-3754-tt-1-3/reference/tooling/tt_cli/pack/): add `--tarantool-version` option (#3755)
- [tt rocks](https://docs.d.tarantool.io/en/doc/gh-3754-tt-1-3/reference/tooling/tt_cli/rocks/#commands): add the `admin` command with a link to luarocks-admin docs (#3756)
- [tt install](https://docs.d.tarantool.io/en/doc/gh-3754-tt-1-3/reference/tooling/tt_cli/install/): add commit and PR installation scenarios, improve structure (#3649)

Deployment: https://docs.d.tarantool.io/en/doc/gh-3754-tt-1-3/reference/tooling/tt_cli/commands/

**To cherry-pick to 2.11.**