### PR TITLE
Add tt console docs

### DIFF
--- a/doc/reference/tooling/tcm/index.rst
+++ b/doc/reference/tooling/tcm/index.rst
@@ -22,7 +22,7 @@ in an instance's console.
 executable for Linux platforms.
 
 |tcm| works only with Tarantool EE clusters that use centralized configuration in
-:ref:`etcd <configuration_etcd>` or a Tarantool-based storage.
+:ref:`etcd <configuration_etcd>` or a Tarantool-based configuration storage.
 When you create or edit a cluster's configuration in |tcm|, it publishes the saved
 configuration to the storage. This ensures consistent and reliable configuration storage.
 A single |tcm| installation can connect to multiple Tarantool EE clusters and

--- a/doc/reference/tooling/tcm/tcm_quick_start.rst
+++ b/doc/reference/tooling/tcm/tcm_quick_start.rst
@@ -1,0 +1,34 @@
+..  _tcm_quick_start
+
+Quick start with TCM
+====================
+
+..  include:: index.rst
+    :start-after: ee_note_tcm_start
+    :end-before: ee_note_tcm_end
+
+This guide explain how to get |tcm_full_name| up and running on your local system.
+
+?? location: howto or TCM?
+
+Prerequisites
+-------------
+
+- Linux
+- macOS?
+- SDK archive (how to obtain)
+
+Setting up Tarantool EE
+-----------------------
+
+Preparing TCM environment
+-------------------------
+
+Starting TCM
+------------
+
+Logging in
+----------
+
+Adding a cluster ? do we need further steps?
+----------------

--- a/doc/reference/tooling/tt_cli/connect.rst
+++ b/doc/reference/tooling/tt_cli/connect.rst
@@ -8,8 +8,8 @@ Connecting to a Tarantool instance
     $ tt connect {URI|INSTANCE} [OPTION ...]
 
 
-``tt connect`` connects to a Tarantool instance by its URI or name specified
-during its startup (``tt start``).
+``tt connect`` connects to a Tarantool instance by its URI or instance name specified
+in the current environment.
 
 Options
 -------
@@ -27,6 +27,20 @@ Options
     Connect and evaluate the script from a file.
 
     ``-`` – read the script from stdin.
+
+.. option:: -i, --interactive
+
+    Enter the interactive mode after evaluating the script passed in ``-f``/``--file``.
+
+..  option:: -l LANGUAGE, --language LANGUAGE
+
+    The input language of the :ref:`tt interactive console <tt-interactive-console>`:
+    ``lua`` (default) or ``sql``.
+
+..  option:: -x FORMAT, --outputformat FORMAT
+
+    The output format of the :ref:`tt interactive console <tt-interactive-console>`:
+    ``yaml`` (default), ``lua``, ``table``, ``ttable``.
 
 Details
 -------

--- a/doc/reference/tooling/tt_cli/connect.rst
+++ b/doc/reference/tooling/tt_cli/connect.rst
@@ -97,6 +97,10 @@ username and the password:
 
 If no credentials are provided for a remote connection, the user is automatically ``guest``.
 
+.. note::
+
+    Local connections (by instance name instead of the URI) don't require authentication.
+
 Encrypted connection
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/reference/tooling/tt_cli/connect.rst
+++ b/doc/reference/tooling/tt_cli/connect.rst
@@ -16,11 +16,11 @@ Options
 
 ..  option:: -u USERNAME, --username USERNAME
 
-    Username
+    A Tarantool user for connecting to the instance.
 
 ..  option:: -p PASSWORD, --password PASSWORD
 
-    Password
+    The user's password.
 
 ..  option:: -f FILEPATH, --file FILEPATH
 
@@ -44,15 +44,15 @@ Options
 
 ..  option:: --sslcertfile FILEPATH
 
-    The path to a trusted certificate authorities (CA) file for encrypted connections.
-
-..  option:: --sslcafile FILEPATH
-
     The path to an SSL certificate file for encrypted connections.
 
 ..  option:: --sslkeyfile FILEPATH
 
     The path to a private SSL key file for encrypted connections.
+
+..  option:: --sslcafile FILEPATH
+
+    The path to a trusted certificate authorities (CA) file for encrypted connections.
 
 ..  option:: --sslciphers STRING
 
@@ -71,8 +71,9 @@ by their instance names.
 Authentication
 ~~~~~~~~~~~~~~
 
-If authentication is required, use one of the following ways to pass the username and
-the password:
+When connecting to an instance by its URI, ``tt connect`` establishes a remote connection
+for which authentication is required. Use one of the following ways to pass the
+username and the password:
 
 *   The ``-u`` (``--username``) and ``-p`` (``--password``) options:
 
@@ -94,12 +95,14 @@ the password:
     $ export TT_CLI_PASSWORD=p4$$w0rD
     $ tt connect 192.168.10.10:3301
 
+If no credentials are provided for a remote connection, the user is automatically ``guest``.
+
 Encrypted connection
 ~~~~~~~~~~~~~~~~~~~~
 
-To connect to instances that use SSL encryption, provide the SSL certificate path and
-other encryption parameters in the options ``--sslcertfile``, ``--sslcafile``,
-``--sslkeyfile``, and ``--sslciphers``.
+To connect to instances that use SSL encryption, provide the SSL certificate and
+SSL key files in the ``--sslcertfile`` and ``--sslkeyfile`` options. If necessary,
+add other SSL parameters -- ``--sslcafile`` and ``--sslciphers``.
 
 Script evaluation
 ~~~~~~~~~~~~~~~~~

--- a/doc/reference/tooling/tt_cli/connect.rst
+++ b/doc/reference/tooling/tt_cli/connect.rst
@@ -42,6 +42,22 @@ Options
     The output format of the :ref:`tt interactive console <tt-interactive-console>`:
     ``yaml`` (default), ``lua``, ``table``, ``ttable``.
 
+..  option:: --sslcertfile FILEPATH
+
+    The path to a trusted certificate authorities (CA) file for encrypted connections.
+
+..  option:: --sslcafile FILEPATH
+
+    The path to an SSL certificate file for encrypted connections.
+
+..  option:: --sslkeyfile FILEPATH
+
+    The path to a private SSL key file for encrypted connections.
+
+..  option:: --sslciphers STRING
+
+    The list of SSL cipher suites used for encrypted connections, separated by colons (``:``).
+
 Details
 -------
 
@@ -52,14 +68,50 @@ You can also connect to instances in the same ``tt`` environment
 (that is, those that use the same :ref:`configuration file <tt-config_file>` and Tarantool installation)
 by their instance names.
 
-If authentication is required, specify the username and the password using the ``-u`` (``--username``)
-and ``-p`` (``--password``) options.
+Authentication
+~~~~~~~~~~~~~~
 
-By default, ``tt connect`` opens an interactive Tarantool console. Alternatively, you
-can open a connection to evaluate a Lua script from a file or stdin. To do this,
-pass the file path in the ``-f`` (``--file``) option or use ``-f -`` to take the script
-from stdin.
+If authentication is required, use one of the following ways to pass the username and
+the password:
 
+*   The ``-u`` (``--username``) and ``-p`` (``--password``) options:
+
+..  code-block:: console
+
+    $ tt connect 192.168.10.10:3301 -u myuser -p p4$$w0rD
+
+*   The connection string:
+
+..  code-block:: console
+
+    $ tt connect myuser:p4$$w0rD@192.168.10.10:3301 -u myuser -p p4$$w0rD
+
+*   Environment variables ``TT_CLI_USERNAME`` and ``TT_CLI_PASSWORD`` :
+
+..  code-block:: console
+
+    $ export TT_CLI_USERNAME=myuser
+    $ export TT_CLI_PASSWORD=p4$$w0rD
+    $ tt connect 192.168.10.10:3301
+
+Encrypted connection
+~~~~~~~~~~~~~~~~~~~~
+
+To connect to instances that use SSL encryption, provide the SSL certificate path and
+other encryption parameters in the options ``--sslcertfile``, ``--sslcafile``,
+``--sslkeyfile``, and ``--sslciphers``.
+
+Script evaluation
+~~~~~~~~~~~~~~~~~
+
+By default, ``tt connect`` opens an :ref:`interactive tt console <tt-interactive-console>`.
+Alternatively, you can open a connection to evaluate a Lua script from a file or stdin.
+To do this, pass the file path in the ``-f`` (``--file``) option or use ``-f -``
+to take the script from stdin.
+
+..  code-block:: console
+
+    $ tt connect app -f test.lua
 
 Examples
 --------

--- a/doc/reference/tooling/tt_cli/index.rst
+++ b/doc/reference/tooling/tt_cli/index.rst
@@ -27,6 +27,7 @@ concept explanation, and the ``tt`` command reference.
     global_options
     commands
     external_modules
+    tt_interactive_console
 
 ..  _tt-cli-environments:
 

--- a/doc/reference/tooling/tt_cli/tt_interactive_console.rst
+++ b/doc/reference/tooling/tt_cli/tt_interactive_console.rst
@@ -1,0 +1,261 @@
+.. _tt-interactive-console:
+
+tt interactive console
+======================
+
+The ``tt`` utility features an command-line console that allows executing requests
+and Lua code interactively on the connected Tarantool instances.
+It is similar to the :ref:`Tarantool interactive console <interactive_console>` with
+one key difference: the ``tt`` console allows connecting to any available instance,
+both local and remote. Additionally, it offers more flexible output formatting capabilities.
+
+.. _tt-interactive-console-enter:
+
+Entering the console
+--------------------
+
+To connect to a Tarantool instance using the ``tt`` console, run :ref:`tt connect <tt-connect>`.
+Specify the instance URI and connection options, such as the username and the password,
+in the corresponding options.
+
+..  code-block:: console
+
+    $ tt connect 192.168.10.10:3301 -u myuser -p p4$$w0rD
+       • Connecting to the instance...
+       • Connected to 192.168.10.10:3301
+
+    192.168.10.10:3301>
+
+When connecting to an instance from the same ``tt`` environment, you can use the
+``<application>:<instance>`` string instead of the URI:
+
+..  code-block:: console
+
+   $ tt connect app:storage001
+       • Connecting to the instance...
+       • Connected to app:storage001
+
+    app:storage001>
+
+To get the list of supported console commands, enter ``\help`` or ``?``.
+To quit the console, enter ``\quit`` or ``\q``.
+
+.. _tt-interactive-console-input:
+
+Console input
+-------------
+
+Similarly to the :ref:`Tarantool interactive console <interactive_console>`, the
+``tt`` console can handle Lua or SQL input. The default is Lua. To change the input
+language, run ``\set language <language>``, for example:
+
+..  code-block:: console
+
+    app:storage001> \set language sql
+    app:storage001> select * from bands where id = 1
+    ---
+    - metadata:
+      - name: id
+        type: unsigned
+      - name: band_name
+        type: string
+      - name: year
+        type: unsigned
+      rows:
+      - [1, 'Roxette', 1986]
+    ...
+
+..  code-block:: console
+
+    app:storage001> \set language lua
+    app:storage001> box.space.bands:select { 1 }
+    ---
+    - - [1, 'Roxette', 1986]
+    ...
+
+.. note::
+
+    You can also specify the input language in the ``tt connect`` call using the
+    ``-l``/``--language`` option:
+
+    ..  code-block:: console
+
+        $ tt connect app:storage001 -l sql
+
+For Lua input, the tab-based autocompletion works automatically for loaded modules.
+
+.. _tt-interactive-console-output:
+
+Console output
+--------------
+
+By default, the ``tt`` console prints the output data in the YAML format, each
+tuple on the new line:
+
+..  code-block:: console
+
+    app:storage001> box.space.bands:select { }
+    ---
+    - - [1, 'Roxette', 1986]
+      - [2, 'Scorpions', 1965]
+      - [3, 'Ace of Base', 1987]
+    ...
+
+You can switch to alternative output formats -- Lua or human-readable tables --
+using the ``\set output`` console command:
+
+..  code-block:: console
+
+    app:storage001> \set output lua
+    app:storage001> box.space.bands:select { }
+    {{1, "Roxette", 1986}, {2, "Scorpions", 1965}, {3, "Ace of Base", 1987}};
+    app:storage001> \set output table
+    app:storage001> box.space.bands:select { }
+    +------+-------------+------+
+    | col1 | col2        | col3 |
+    +------+-------------+------+
+    | 1    | Roxette     | 1986 |
+    +------+-------------+------+
+    | 2    | Scorpions   | 1965 |
+    +------+-------------+------+
+    | 3    | Ace of Base | 1987 |
+    +------+-------------+------+
+
+The table output can be printed in the transposed format, where an object's fields
+are arranged in columns instead of rows:
+
+..  code-block:: console
+
+    app:storage001> \set output ttable
+    app:storage001> box.space.bands:select { }
+    +------+---------+-----------+-------------+
+    | col1 | 1       | 2         | 3           |
+    +------+---------+-----------+-------------+
+    | col2 | Roxette | Scorpions | Ace of Base |
+    +------+---------+-----------+-------------+
+    | col3 | 1986    | 1965      | 1987        |
+    +------+---------+-----------+-------------+
+
+.. note::
+
+    You can also specify the output format in the ``tt connect`` call using the
+    ``-x``/``--outputformat`` option:
+
+    ..  code-block:: console
+
+        $ tt connect app:storage001 -x table
+
+For ``table`` and ``ttable`` output, more customizations are possible with the
+following commands:
+
+*   ``\set table_format`` -- table format: default (pseudographics, or ASCII table), Markdown,
+    or Jira-compatible format.
+*   ``\set grahpics`` -- enable or disable graphics for table cells in the default format.
+*   ``\set table_column_width`` -- maximum column width.
+
+..  code-block:: console
+
+    app:storage001> \set table_format jira
+    app:storage001> box.space.bands:select {}
+    | col1 | 1 | 2 | 3 |
+    | col2 | Roxette | Scorpions | Ace of Base |
+    | col3 | 1986 | 1965 | 1987 |
+    app:storage001> \set table_format default
+    app:storage001> \set graphics false
+    app:storage001> box.space.bands:select {}
+     col1  1        2          3
+     col2  Roxette  Scorpions  Ace of Base
+     col3  1986     1965       1987
+
+    app:storage001> \set table_column_width 6
+    app:storage001> box.space.bands:select {}
+     col1  1       2       3
+     col2  Roxett  Scorpi  Ace of
+           +e      +ons    + Base
+     col3  1986    1965    1987
+
+
+.. _tt-interactive-console-commands:
+
+Commands
+--------
+
+\\help, ?
+~~~~~~~~~
+
+Show help on the ``tt`` console.
+
+\\quit, \\q
+~~~~~~~~~~~
+
+Quit the ``tt`` console.
+
+\\shortcuts
+~~~~~~~~~~~
+
+Show available keyboard shortcuts.
+
+\\set language {lua|sql}
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set the input language.
+Possible values:
+
+*   ``lua`` (default)
+*   ``sql``.
+
+An analog of the :ref:`tt connect <tt-connect>` option ``-l``/``--language``
+
+\\set output FORMAT, \\x{l|t|T|y}, \\x
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set the output format.
+Possible ``FORMAT`` values:
+
+*   ``yaml`` (default) -- each output item is a YAML object. Example: ``[1, 'Roxette', 1986]``.
+    Shorthand: ``\xy``.
+*   ``lua`` -- each output tuple is a separate Lua table. Example: ``{{1, "Roxette", 1986}};``.
+    Shorthand: ``\xl``.
+*   ``table`` -- the output is a table where tuples are rows.
+    Shorthand: ``\xt``.
+*   ``ttable`` -- the output is a transposed table where tuples are columns.
+    Shorthand: ``\xT``.
+
+.. note::
+
+    The ``\x`` command switches the output format cyclically in the order
+    ``yaml`` > ``lua`` > ``table`` > ``ttable``.
+
+The format of ``table`` and ``ttable`` output can be adjusted using the ``\set table_format``,
+``\set graphics`, and ``\set table_colum_width`` commands.
+
+An analog of the :ref:`tt connect <tt-connect>` option ``-x``/``--outputformat``
+
+\\set table_format
+~~~~~~~~~~~~~~~~~~
+
+Set the table format if the output format is ``table`` or ``ttable``.
+Possible values:
+
+*   ``default`` -- a pseudographics (ASCII) table.
+*   ``markdown`` -- a table in the Markdown format.
+*   ``jira`` -- a Jira-compatible table.
+
+\\set graphics {true|false}, \\x{g|G}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether to print pseudographics for table cells if the output format is ``table`` or ``ttable``.
+Possible values: ``true`` (default) and ``false``.
+
+The shorthands are:
+
+*  ``\xG`` for ``true``
+*  ``\xg`` for ``false``
+
+\\set table_colum_width WIDTH, \\xw WIDTH
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set maximum printed width of a table cell content. If the length exceeds this value,
+it continues on the next line starting from the `+` (plus) sign.
+
+Shorthand: ``\xw``

--- a/doc/reference/tooling/tt_cli/tt_interactive_console.rst
+++ b/doc/reference/tooling/tt_cli/tt_interactive_console.rst
@@ -3,7 +3,7 @@
 tt interactive console
 ======================
 
-The ``tt`` utility features an command-line console that allows executing requests
+The ``tt`` utility features a command-line console that allows executing requests
 and Lua code interactively on the connected Tarantool instances.
 It is similar to the :ref:`Tarantool interactive console <interactive_console>` with
 one key difference: the ``tt`` console allows connecting to any available instance,
@@ -15,8 +15,8 @@ Entering the console
 --------------------
 
 To connect to a Tarantool instance using the ``tt`` console, run :ref:`tt connect <tt-connect>`.
-Specify the instance URI and connection options, such as the username and the password,
-in the corresponding options.
+
+Specify the instance URI and the user credentials in the corresponding options:
 
 ..  code-block:: console
 
@@ -26,8 +26,10 @@ in the corresponding options.
 
     192.168.10.10:3301>
 
-When connecting to an instance from the same ``tt`` environment, you can use the
-``<application>:<instance>`` string instead of the URI:
+If a user is not specified, the connection is established on behalf of the ``guest`` user.
+
+If the instance runs in the same ``tt`` environment, you can establish a local
+connection with it by specifying the``<application>:<instance>`` string instead of the URI:
 
 ..  code-block:: console
 
@@ -36,6 +38,8 @@ When connecting to an instance from the same ``tt`` environment, you can use the
        • Connected to app:storage001
 
     app:storage001>
+
+Local connections are established on behalf of the ``admin`` user.
 
 To get the list of supported console commands, enter ``\help`` or ``?``.
 To quit the console, enter ``\quit`` or ``\q``.
@@ -46,8 +50,10 @@ Console input
 -------------
 
 Similarly to the :ref:`Tarantool interactive console <interactive_console>`, the
-``tt`` console can handle Lua or SQL input. The default is Lua. To change the input
-language, run ``\set language <language>``, for example:
+``tt`` console can handle Lua or SQL input. The default is Lua. For Lua input,
+the tab-based autocompletion works automatically for loaded modules.
+
+To change the input language to SQL, run ``\set language sql``:
 
 ..  code-block:: console
 
@@ -64,6 +70,8 @@ language, run ``\set language <language>``, for example:
       rows:
       - [1, 'Roxette', 1986]
     ...
+
+To change the input language back to Lua, run ``\set language lua``:
 
 ..  code-block:: console
 
@@ -82,7 +90,6 @@ language, run ``\set language <language>``, for example:
 
         $ tt connect app:storage001 -l sql
 
-For Lua input, the tab-based autocompletion works automatically for loaded modules.
 
 .. _tt-interactive-console-output:
 
@@ -101,7 +108,7 @@ tuple on the new line:
       - [3, 'Ace of Base', 1987]
     ...
 
-You can switch to alternative output formats -- Lua or human-readable tables --
+You can switch to alternative output formats -- Lua or ASCII (pseudographics) tables --
 using the ``\set output`` console command:
 
 ..  code-block:: console
@@ -149,30 +156,37 @@ For ``table`` and ``ttable`` output, more customizations are possible with the
 following commands:
 
 *   ``\set table_format`` -- table format: default (pseudographics, or ASCII table), Markdown,
-    or Jira-compatible format.
-*   ``\set grahpics`` -- enable or disable graphics for table cells in the default format.
+    or Jira-compatible format:
+
+    ..  code-block:: console
+
+        app:storage001> \set table_format jira
+        app:storage001> box.space.bands:select {}
+        | col1 | 1 | 2 | 3 |
+        | col2 | Roxette | Scorpions | Ace of Base |
+        | col3 | 1986 | 1965 | 1987 |
+
+*   ``\set grahpics`` -- enable or disable graphics for table cells in the default format:
+
+    ..  code-block:: console
+
+        app:storage001> \set table_format default
+        app:storage001> \set graphics false
+        app:storage001> box.space.bands:select {}
+         col1  1        2          3
+         col2  Roxette  Scorpions  Ace of Base
+         col3  1986     1965       1987
+
 *   ``\set table_column_width`` -- maximum column width.
 
-..  code-block:: console
+    ..  code-block:: console
 
-    app:storage001> \set table_format jira
-    app:storage001> box.space.bands:select {}
-    | col1 | 1 | 2 | 3 |
-    | col2 | Roxette | Scorpions | Ace of Base |
-    | col3 | 1986 | 1965 | 1987 |
-    app:storage001> \set table_format default
-    app:storage001> \set graphics false
-    app:storage001> box.space.bands:select {}
-     col1  1        2          3
-     col2  Roxette  Scorpions  Ace of Base
-     col3  1986     1965       1987
-
-    app:storage001> \set table_column_width 6
-    app:storage001> box.space.bands:select {}
-     col1  1       2       3
-     col2  Roxett  Scorpi  Ace of
-           +e      +ons    + Base
-     col3  1986    1965    1987
+        app:storage001> \set table_column_width 6
+        app:storage001> box.space.bands:select {}
+         col1  1       2       3
+         col2  Roxett  Scorpi  Ace of
+               +e      +ons    + Base
+         col3  1986    1965    1987
 
 
 .. _tt-interactive-console-commands:
@@ -202,7 +216,7 @@ Set the input language.
 Possible values:
 
 *   ``lua`` (default)
-*   ``sql``.
+*   ``sql``
 
 An analog of the :ref:`tt connect <tt-connect>` option ``-l``/``--language``
 
@@ -227,7 +241,7 @@ Possible ``FORMAT`` values:
     ``yaml`` > ``lua`` > ``table`` > ``ttable``.
 
 The format of ``table`` and ``ttable`` output can be adjusted using the ``\set table_format``,
-``\set graphics`, and ``\set table_colum_width`` commands.
+``\set graphics``, and ``\set table_colum_width`` commands.
 
 An analog of the :ref:`tt connect <tt-connect>` option ``-x``/``--outputformat``
 
@@ -255,7 +269,7 @@ The shorthands are:
 \\set table_colum_width WIDTH, \\xw WIDTH
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Set maximum printed width of a table cell content. If the length exceeds this value,
+Set the maximum printed width of a table cell content. If the length exceeds this value,
 it continues on the next line starting from the `+` (plus) sign.
 
 Shorthand: ``\xw``

--- a/doc/reference/tooling/tt_cli/tt_interactive_console.rst
+++ b/doc/reference/tooling/tt_cli/tt_interactive_console.rst
@@ -29,7 +29,7 @@ Specify the instance URI and the user credentials in the corresponding options:
 If a user is not specified, the connection is established on behalf of the ``guest`` user.
 
 If the instance runs in the same ``tt`` environment, you can establish a local
-connection with it by specifying the``<application>:<instance>`` string instead of the URI:
+connection with it by specifying the ``<application>:<instance>`` string instead of the URI:
 
 ..  code-block:: console
 
@@ -218,7 +218,7 @@ Possible values:
 *   ``lua`` (default)
 *   ``sql``
 
-An analog of the :ref:`tt connect <tt-connect>` option ``-l``/``--language``
+An analog of the :ref:`tt connect <tt-connect>` option ``-l``/``--language``.
 
 \\set output FORMAT, \\x{l|t|T|y}, \\x
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -243,7 +243,7 @@ Possible ``FORMAT`` values:
 The format of ``table`` and ``ttable`` output can be adjusted using the ``\set table_format``,
 ``\set graphics``, and ``\set table_colum_width`` commands.
 
-An analog of the :ref:`tt connect <tt-connect>` option ``-x``/``--outputformat``
+An analog of the :ref:`tt connect <tt-connect>` option ``-x``/``--outputformat``.
 
 \\set table_format
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Resolves #3734 
Resolves #3820 

- Add new page [tt interactive console](https://docs.d.tarantool.io/en/doc/gh-3734-tt-connect-console/reference/tooling/tt_cli/tt_interactive_console/) with quick tutorial on using the tt console and commands reference
- Add new `tt connect` options `-l` (input language) and `-x` (output format) to the [tt connect reference page](https://docs.d.tarantool.io/en/doc/gh-3734-tt-connect-console/reference/tooling/tt_cli/connect/#options).
- Add the ``--ssl*`` options to the [tt connect reference page](https://docs.d.tarantool.io/en/doc/gh-3734-tt-connect-console/reference/tooling/tt_cli/connect/#options).
- Add new ``tt connect`` auth methods: URI string and env variables.

Deployment: https://docs.d.tarantool.io/en/doc/gh-3734-tt-connect-console/reference/tooling/tt_cli/tt_interactive_console/

**To cherry pick to 2.11**