### PR TITLE
Update tt commands descriptions to 2.1.2

### DIFF
--- a/doc/reference/tooling/tt_cli/check.rst
+++ b/doc/reference/tooling/tt_cli/check.rst
@@ -5,14 +5,14 @@ Checking an application file
 
 ..  code-block:: console
 
-    $ tt check {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}
+    $ tt check {FILEPATH | APPLICATION[:APP_INSTANCE]}
 
 ``tt check`` checks the syntax correctness of Lua files within Tarantool applications
 or separate Lua scripts. The files must be stored inside the ``instances_enabled``
 directory specified in the :ref:`tt configuration file <tt-config_file_app>`.
 
-Cluster applications
---------------------
+Examples
+--------
 
 To check all Lua files in an application directory at once, specify the directory name:
 
@@ -32,13 +32,5 @@ To check a single Lua file from an application directory, add the path to this f
 
     The ``.lua`` extension can be omitted.
 
-Single instances
-----------------
-
-To check the syntax of a single Lua file, specify the path from ``instances_enabled`` to this file:
-
-..  code-block:: console
-
-    $ tt check app.lua
 
 

--- a/doc/reference/tooling/tt_cli/check.rst
+++ b/doc/reference/tooling/tt_cli/check.rst
@@ -5,52 +5,40 @@ Checking an application file
 
 ..  code-block:: console
 
-    $ tt check {INSTANCE | APPLICATION[:APP_INSTANCE]}
+    $ tt check {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}
 
-``tt check`` checks the specified Tarantool application or instance for syntax errors.
+``tt check`` checks the syntax correctness of Lua files within Tarantool applications
+or separate Lua scripts. The files must be stored inside the ``instances_enabled``
+directory specified in the :ref:`tt configuration file <tt-config_file_app>`.
 
-Details
--------
+Cluster applications
+--------------------
 
-``tt`` searches for ``APP_FILE`` inside the ``instances_enabled`` directory
-specified in the :ref:`tt configuration file <tt-config_file_app>`. ``APP_FILE`` can be:
+To check all Lua files in an application directory at once, specify the directory name:
 
-*   the name of an application file without the ``.lua`` extension.
-*   the name of a directory containing the ``init.lua`` file. In this case, ``init.lua`` is checked.
+..  code-block:: console
+
+    $ tt check app
+
+To check a single Lua file from an application directory, add the path to this file:
+
+..  code-block:: console
+
+    $ tt check app/router
+    # or
+    $ tt check app/router.lua
+
+.. note::
+
+    The ``.lua`` extension can be omitted.
+
+Single instances
+----------------
+
+To check the syntax of a single Lua file, specify the path from ``instances_enabled`` to this file:
+
+..  code-block:: console
+
+    $ tt check app.lua
 
 
-Examples
---------
-
-Single instance
-~~~~~~~~~~~~~~~
-
-*   Check the syntax of the ``app.lua`` file from the ``instances_enabled`` directory:
-
-    ..  code-block:: console
-
-        $ tt check app
-
-
-*   Check the syntax of the ``init.lua`` file from the ``instance1/`` directory inside ``instances_enabled``:
-
-    ..  code-block:: console
-
-        $ tt check instance1
-
-Multiple instances
-~~~~~~~~~~~~~~~~~~
-
-*   Check all source files of the application stored in the ``app/`` directory inside
-    ``instances_enabled`` in accordance with the :ref:`instances configuration <tt-instances>`:
-
-    ..  code-block:: console
-
-        $ tt check app
-
-*   Check the source of the ``master`` instance of the application stored in the
-    ``app/`` directory inside ``instances_enabled``:
-
-    ..  code-block:: console
-
-        $ tt check app:master

--- a/doc/reference/tooling/tt_cli/clean.rst
+++ b/doc/reference/tooling/tt_cli/clean.rst
@@ -5,7 +5,7 @@ Cleaning instance files
 
 ..  code-block:: console
 
-    $ tt clean {APPLICATION[:APP_INSTANCE]} [OPTION ...]
+    $ tt clean APPLICATION[:APP_INSTANCE] [OPTION ...]
 
 ``tt clean`` cleans stored files of Tarantool instances: logs, snapshots, and
 other files. To avoid accidental deletion of files, ``tt clean`` shows

--- a/doc/reference/tooling/tt_cli/clean.rst
+++ b/doc/reference/tooling/tt_cli/clean.rst
@@ -5,11 +5,14 @@ Cleaning instance files
 
 ..  code-block:: console
 
-    $ tt clean {INSTANCE | APPLICATION[:APP_INSTANCE]} [OPTION ...]
+    $ tt clean {APPLICATION[:APP_INSTANCE]} [OPTION ...]
 
 ``tt clean`` cleans stored files of Tarantool instances: logs, snapshots, and
 other files. To avoid accidental deletion of files, ``tt clean`` shows
 the files it is going to delete and asks for confirmation.
+
+When called without arguments, cleans files of all applications in the current environment.
+
 
 Options
 -------
@@ -21,18 +24,6 @@ Options
 
 Examples
 --------
-
-Single instance
-~~~~~~~~~~~~~~~
-
-*   Clean the files of the ``app`` instance:
-
-    ..  code-block:: console
-
-        $ tt clean app
-
-Multiple instances
-~~~~~~~~~~~~~~~~~~
 
 *   Clean the files of all instances of the ``app`` application:
 

--- a/doc/reference/tooling/tt_cli/connect.rst
+++ b/doc/reference/tooling/tt_cli/connect.rst
@@ -5,7 +5,7 @@ Connecting to a Tarantool instance
 
 ..  code-block:: console
 
-    $ tt connect {URI|INSTANCE} [OPTION ...]
+    $ tt connect {URI|INSTANCE_NAME} [OPTION ...]
 
 
 ``tt connect`` connects to a Tarantool instance by its URI or instance name specified

--- a/doc/reference/tooling/tt_cli/create.rst
+++ b/doc/reference/tooling/tt_cli/create.rst
@@ -108,7 +108,7 @@ Variables
 
 Templates variables are replaced with their values provided upon the instantiation.
 
-All templates have the ``name`` variable. Its value is taken from the ``--name`` flag.
+All templates have the ``name`` variable. Its value is taken from the ``--name`` option.
 
 To add other variables, define them in the ``vars`` section of the template manifest.
 A variable can have the following attributes:
@@ -151,17 +151,17 @@ Examples:
 
 Variables receive their values during the template instantiation. By default, ``tt create``
 asks you to provide the values interactively. You can use the ``-s`` (or ``--non-interactive``)
-flag to disable the interactive input. In this case, the values are searched in the following order:
+option to disable the interactive input. In this case, the values are searched in the following order:
 
-*   In the ``--var`` flag. Pass a string of the ``var=value`` format after the ``--var``
-    flag. You can pass multiple variables, each after a separate ``--var`` flag:
+*   In the ``--var`` option. Pass a string of the ``var=value`` format after the ``--var``
+    option. You can pass multiple variables, each after a separate ``--var`` option:
 
     ..  code-block:: console
 
         $ tt create template app --var user_name=admin
 
 *   In a file. Specify ``var=value`` pairs in a plain text file, each on a new line, and
-    pass it as the value of the ``--vars-file`` flag:
+    pass it as the value of the ``--vars-file`` option:
 
     ..  code-block:: console
 
@@ -186,7 +186,7 @@ Application directory
 By default, the application appears in the directory named after the provided
 application name (``--name`` value).
 
-To change the application location, use the ``-dst`` flag.
+To change the application location, use the ``-dst`` option.
 
 Examples
 --------

--- a/doc/reference/tooling/tt_cli/create.rst
+++ b/doc/reference/tooling/tt_cli/create.rst
@@ -176,14 +176,14 @@ flag to disable the interactive input. In this case, the values are searched in 
         version=2
 
 If a variable isn't initialized in any of these ways, the default value
-from the manifest will be used.
+from the manifest is used.
 
 You can combine different ways of passing variables in a single call of ``tt create``.
 
 Application directory
 ~~~~~~~~~~~~~~~~~~~~~
 
-By default, the application will appear in the directory named after the provided
+By default, the application appears in the directory named after the provided
 application name (``--name`` value).
 
 To change the application location, use the ``-dst`` flag.
@@ -191,17 +191,17 @@ To change the application location, use the ``-dst`` flag.
 Examples
 --------
 
-*   Create the application ``app1`` from the ``simple_app`` template in the current directory:
+*   Create the application ``app1`` from the ``simple_app`` user-defined template in the current directory:
 
     ..  code-block:: console
 
         $ tt create simple_app --name app1
 
 
-*   Create the ``app1`` application in ``/opt/tt/apps/``, set the ``user_name``
-    variable to ``admin``, force rewrite the application directory if it already exists.
+*   Create the ``app1`` application in ``/opt/tt/apps/`` from the built-in ``vshard_cluster`` template,
+    force rewrite the application directory if it already exists.
     User interaction is disabled.
 
     ..  code-block:: console
 
-        $ tt create cartridge --name app1 --var user_name=admin -f --non-interactive -dst /opt/tt/apps/
+        $ tt create vshard_cluster --name app1 -f --non-interactive -dst /opt/tt/apps/

--- a/doc/reference/tooling/tt_cli/create.rst
+++ b/doc/reference/tooling/tt_cli/create.rst
@@ -198,7 +198,7 @@ Examples
         $ tt create simple_app --name app1
 
 
-*   Create the ``app1`` application in ``/opt/tt/apps/`` from the built-in ``vshard_cluster`` template,
+*   Create the ``app1`` application in ``/opt/tt/apps`` from the built-in ``vshard_cluster`` template,
     force rewrite the application directory if it already exists.
     User interaction is disabled.
 

--- a/doc/reference/tooling/tt_cli/export.rst
+++ b/doc/reference/tooling/tt_cli/export.rst
@@ -11,7 +11,7 @@ Exporting data
 
 ..  code-block:: console
 
-    $ tt [crud] export URI FILE SPACE [EXPORT_OPTION ...]
+    $ tt [crud] export URI SPACE:FILE ... [EXPORT_OPTION ...]
 
 ``tt [crud] export`` exports a space's data to a file.
 The ``crud`` command is optional and can be used to export a cluster's data by using the `CRUD <https://github.com/tarantool/crud>`_ module. Without ``crud``, data is exported using the :ref:`box.space <box_space>` API.
@@ -43,7 +43,7 @@ The command below exports data of the ``customers`` space to the ``customers.csv
 
 .. code-block:: console
 
-    $ tt crud export localhost:3301 customers.csv customers
+    $ tt crud export localhost:3301 customers:customers.csv
 
 If the ``customers`` space has five fields (``id``, ``bucket_id``, ``firstname``, ``lastname``, and ``age``), the file with exported data might look like this:
 
@@ -70,7 +70,7 @@ To export data with a space's field names in the first row, use the ``--header``
 
 .. code-block:: console
 
-    $ tt crud export localhost:3301 customers.csv customers \
+    $ tt crud export localhost:3301 customers:customers.csv  \
                      --header
 
 In this case, field values start from the second row, for example:
@@ -95,7 +95,7 @@ For example, the command below exports compound values serialized in JSON:
 
 .. code-block:: console
 
-    $ tt crud export localhost:3301 customers.csv customers \
+    $ tt crud export localhost:3301 customers:customers.csv  \
                      --compound-value-format json
 
 

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -11,9 +11,9 @@ Importing data
 
 .. code-block:: console
 
-    $ tt [crud] import URI FILE SPACE [IMPORT_OPTION ...]
+    $ tt [crud] import URI FILE:SPACE [IMPORT_OPTION ...]
     # or
-    $ tt [crud] import URI - SPACE < FILE [IMPORT_OPTION ...]
+    $ tt [crud] import URI :SPACE < FILE [IMPORT_OPTION ...]
 
 ``tt [crud] import`` imports data from a file to a space.
 The ``crud`` command is optional and can be used to import data to a cluster by using the `CRUD <https://github.com/tarantool/crud>`_ module. Without ``crud``, data is imported using the :ref:`box.space <box_space>` API.
@@ -62,7 +62,7 @@ If the target ``customers`` space has fields with the same names, you can import
 
 .. code-block:: console
 
-    $ tt crud import localhost:3301 customers.csv customers \
+    $ tt crud import localhost:3301 customers.csv:customers \
                      --header \
                      --match=header
 
@@ -92,7 +92,7 @@ you can configure mapping as follows:
 
 .. code-block:: console
 
-    $ tt crud import localhost:3301 customers.csv customers \
+    $ tt crud import localhost:3301 customers.csv:customers \
                      --header \
                      --match "id=customer_id;firstname=name;lastname=surname;age=customer_age"
 
@@ -100,7 +100,7 @@ Similarly, you can configure mapping using numeric field positions in the input 
 
 .. code-block:: console
 
-    $ tt crud import localhost:3301 customers.csv customers \
+    $ tt crud import localhost:3301 customers.csv:customers \
                      --header \
                      --match "id=1;firstname=2;lastname=3;age=4"
 
@@ -119,7 +119,7 @@ In the example below, values already existing in the space are replaced with new
 
 .. code-block:: console
 
-    $ tt crud import localhost:3301 customers.csv customers \
+    $ tt crud import localhost:3301 customers.csv:customers \
                      --on-exist replace
 
 .. _tt-import-parsing-error:
@@ -131,7 +131,7 @@ To skip rows whose data cannot be parsed correctly, use the ``--on-error`` optio
 
 .. code-block:: console
 
-    $ tt crud import localhost:3301 customers.csv customers \
+    $ tt crud import localhost:3301 customers.csv:customers \
                      --on-error skip
 
 
@@ -156,7 +156,7 @@ Options
 
     .. code-block:: console
 
-        $ tt crud import localhost:3301 customers.csv customers \
+        $ tt crud import localhost:3301 customers.csv:customers \
                          --delimiter tab
 
     .. NOTE::

--- a/doc/reference/tooling/tt_cli/installation.rst
+++ b/doc/reference/tooling/tt_cli/installation.rst
@@ -60,7 +60,7 @@ To build ``tt`` from sources:
 
       git clone https://github.com/tarantool/tt --recursive
 
-3.  Go to the ``tt/`` directory:
+3.  Go to the ``tt`` directory:
 
     ..  code-block:: bash
 

--- a/doc/reference/tooling/tt_cli/instances.rst
+++ b/doc/reference/tooling/tt_cli/instances.rst
@@ -7,7 +7,8 @@ Listing enabled applications
 
     $ tt instances
 
-``tt instances`` shows the list of enabled applications.
+``tt instances`` shows the list of enabled applications and their instances
+in the current environment.
 
 .. note::
 
@@ -19,7 +20,7 @@ Listing enabled applications
 Example
 --------
 
-*   Show the list of enabled applications:
+*   Show the list of enabled applications and their instances:
 
     ..  code-block:: console
 

--- a/doc/reference/tooling/tt_cli/logrotate.rst
+++ b/doc/reference/tooling/tt_cli/logrotate.rst
@@ -5,7 +5,7 @@ Rotating instance logs
 
 ..  code-block:: console
 
-    $ tt logrotate {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}
+    $ tt logrotate APPLICATION[:APP_INSTANCE]
 
 ``tt logrotate`` rotates logs of a Tarantool application or specific instances,
 and the ``tt`` log. For example, you need to call this function to continue logging

--- a/doc/reference/tooling/tt_cli/logrotate.rst
+++ b/doc/reference/tooling/tt_cli/logrotate.rst
@@ -5,7 +5,7 @@ Rotating instance logs
 
 ..  code-block:: console
 
-    $ tt logrotate {INSTANCE | APPLICATION[:APP_INSTANCE]}
+    $ tt logrotate {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}
 
 ``tt logrotate`` rotates logs of a Tarantool application or specific instances,
 and the ``tt`` log. For example, you need to call this function to continue logging

--- a/doc/reference/tooling/tt_cli/restart.rst
+++ b/doc/reference/tooling/tt_cli/restart.rst
@@ -38,7 +38,7 @@ Examples
         This call starts all application instances specified in its ``instances.yml``,
         even those that were not running before the call.
 
- *   Restart only the ``master`` instance of the ``app`` application  with automatic confirmation:
+*   Restart only the ``master`` instance of the ``app`` application  with automatic confirmation:
 
     ..  code-block:: console
 

--- a/doc/reference/tooling/tt_cli/restart.rst
+++ b/doc/reference/tooling/tt_cli/restart.rst
@@ -5,7 +5,7 @@ Restarting a Tarantool instance
 
 ..  code-block:: console
 
-    $ tt restart {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE} [OPTION ...]
+    $ tt restart APPLICATION[:APP_INSTANCE] [OPTION ...]
 
 ``tt restart`` restarts the specified running Tarantool instance.
 A ``tt restart`` call is equivalent to consecutive calls of
@@ -13,30 +13,8 @@ A ``tt restart`` call is equivalent to consecutive calls of
 
 When called without arguments, restarts all running applications in the current environment.
 
-Cluster application
--------------------
+See also: :ref:`tt-start`, :ref:`tt-stop`, :ref:`tt-status`.
 
-To restart all instances of the application stored in the ``app/`` directory inside
-``instances_enabled`` in accordance with the :ref:`instances configuration <tt-instances>`:
-
-..  code-block:: console
-
-    $ tt restart app
-
-To restart only the ``master`` instance of the application stored in the ``app/`` directory inside ``instances_enabled``:
-
-..  code-block:: console
-
-    $ tt restart app:master
-
-Single instance
----------------
-
-Restart the ``instance1`` instance with automatic confirmation:
-
-..  code-block:: console
-
-    $ tt restart instance1 -y
 
 Options
 -------
@@ -44,4 +22,26 @@ Options
 ..  option:: -y, --yes
 
     Automatic "Yes" to confirmation prompt.
+
+Examples
+--------
+
+*   Restart all instances of the application stored in the ``app`` directory inside
+    ``instances_enabled`` in accordance with the :ref:`instances configuration <tt-instances>`:
+
+    ..  code-block:: console
+
+        $ tt restart app
+
+    .. note::
+
+        This call starts all application instances specified in its ``instances.yml``,
+        even those that were not running before the call.
+
+ *   Restart only the ``master`` instance of the ``app`` application  with automatic confirmation:
+
+    ..  code-block:: console
+
+        $ tt restart app:master -y
+
 

--- a/doc/reference/tooling/tt_cli/restart.rst
+++ b/doc/reference/tooling/tt_cli/restart.rst
@@ -5,11 +5,38 @@ Restarting a Tarantool instance
 
 ..  code-block:: console
 
-    $ tt restart {INSTANCE | APPLICATION[:APP_INSTANCE]} [OPTION ...]
+    $ tt restart {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE} [OPTION ...]
 
 ``tt restart`` restarts the specified running Tarantool instance.
 A ``tt restart`` call is equivalent to consecutive calls of
 :doc:`tt stop <stop>` and :doc:`tt start <start>`.
+
+When called without arguments, restarts all running applications in the current environment.
+
+Cluster application
+-------------------
+
+To restart all instances of the application stored in the ``app/`` directory inside
+``instances_enabled`` in accordance with the :ref:`instances configuration <tt-instances>`:
+
+..  code-block:: console
+
+    $ tt restart app
+
+To restart only the ``master`` instance of the application stored in the ``app/`` directory inside ``instances_enabled``:
+
+..  code-block:: console
+
+    $ tt restart app:master
+
+Single instance
+---------------
+
+Restart the ``instance1`` instance with automatic confirmation:
+
+..  code-block:: console
+
+    $ tt restart instance1 -y
 
 Options
 -------
@@ -18,30 +45,3 @@ Options
 
     Automatic "Yes" to confirmation prompt.
 
-Examples
---------
-
-Single instance
-~~~~~~~~~~~~~~~
-
-Restart the ``app`` instance with automatic confirmation:
-
-..  code-block:: console
-
-    $ tt restart app -y
-
-Multiple instances
-~~~~~~~~~~~~~~~~~~
-
-*   Restart all instances of the application stored in the ``app/`` directory inside
-    ``instances_enabled`` in accordance with the :ref:`instances configuration <tt-instances>`:
-
-    ..  code-block:: console
-
-        $ tt restart app
-
-*   Restart only the ``master`` instance of the application stored in the ``app/`` directory inside ``instances_enabled``:
-
-    ..  code-block:: console
-
-        $ tt restart app:master

--- a/doc/reference/tooling/tt_cli/run.rst
+++ b/doc/reference/tooling/tt_cli/run.rst
@@ -7,7 +7,7 @@ Running code in a Tarantool instance
 
     $ tt run [SCRIPT|-e EXPR] [OPTION ...]
 
-``tt run`` executes Lua code in a Tarantool instance.
+``tt run`` executes Lua code in a new Tarantool instance.
 
 Options
 -------

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -5,7 +5,7 @@ Starting Tarantool applications
 
 ..  code-block:: console
 
-    $ tt start {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}
+    $ tt start APPLICATION[:APP_INSTANCE]
 
 ``tt start`` starts Tarantool applications. The application files must be stored
 inside the ``instances_enabled`` directory specified in the :ref:`tt configuration file <tt-config_file_app>`.
@@ -14,8 +14,10 @@ For detailed instructions on preparing and running Tarantool applications, see
 
 When called without arguments, starts all enabled applications in the current environment.
 
-Cluster application
--------------------
+See also: :ref:`tt-stop`, :ref:`tt-restart`, :ref:`tt-status`.
+
+Application layout
+------------------
 
 ``tt start`` can start entire Tarantool clusters based on their YAML configurations.
 A cluster application directory inside ``instances_enabled`` must contain the following files:
@@ -30,7 +32,14 @@ A cluster application directory inside ``instances_enabled`` must contain the fo
 
 For more information about Tarantool application layout, see :ref:`admin-instance-environment-overview`.
 
-Examples:
+.. note::
+
+    ``tt`` also supports Tarantool applications with :ref:`configuration in code <configuration_code>`,
+    which is considered a legacy approach since Tarantool 3.0. For information
+    about using ``tt`` with such applications, refer to the Tarantool 2.11 documentation.
+
+Examples
+--------
 
 *   Start instances of the application stored in the ``app/`` directory inside
     ``instances_enabled`` in accordance with its ``instances.yml``:

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -24,7 +24,7 @@ A cluster application directory inside ``instances_enabled`` must contain the fo
     the cluster topology and settings.
     It can either contain an explicit configuration in the YAML format, or point
     to a centralized configuration storage (for Enterprise Edition).
-*   ``instances yml`` -- a file that defines the list of cluster instances to run
+*   ``instances.yml`` -- a file that defines the list of cluster instances to run
     in the current environment.
 *   (Optionally) ``*.lua`` files with code to load and run in the cluster.
 

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -22,7 +22,7 @@ A cluster application directory inside ``instances_enabled`` must contain the fo
 
 *   ``config.yaml`` -- a :ref:`YAML configuration <configuration>` that defines
     the cluster topology and settings.
-    It can either contain an explicit configuration in the YAML format, or point
+    It can either contain an explicit configuration in the YAML format or point
     to a centralized configuration storage (for Enterprise Edition).
 *   ``instances.yml`` -- a file that defines the list of cluster instances to run
     in the current environment.
@@ -51,7 +51,7 @@ Single instances
 ----------------
 
 ``tt start`` can start single Tarantool instances without cluster configurations.
-Such instances are based on Lua code provided in files inside the ``instances_enabled`
+Such instances are based on Lua code provided in files inside the ``instances_enabled``
 directory.
 
 Example: start an instance with the ``app.lua`` application from the ``instances_enabled``

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -41,31 +41,16 @@ For more information about Tarantool application layout, see :ref:`admin-instanc
 Examples
 --------
 
-*   Start instances of the application stored in the ``app/`` directory inside
+*   Start instances of the application stored in the ``app`` directory inside
     ``instances_enabled`` in accordance with its ``instances.yml``:
 
     ..  code-block:: console
 
         $ tt start app
 
-*   Start only the ``master`` instance of the application stored in the ``app/``
-    directory inside ``instances_enabled``:
+*   Start the ``router`` instance of the ``app`` application:
 
     ..  code-block:: console
 
-        $ tt start app:master
+        $ tt start app:router
 
-
-Single instances
-----------------
-
-``tt start`` can start single Tarantool instances without cluster configurations.
-Such instances are based on Lua code provided in files inside the ``instances_enabled``
-directory.
-
-Example: start an instance with the ``app.lua`` application from the ``instances_enabled``
-directory:
-
-..  code-block:: console
-
-    $ tt start app

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -1,54 +1,62 @@
 .. _tt-start:
 
-Starting a Tarantool instance
-=============================
+Starting Tarantool applications
+===============================
 
 ..  code-block:: console
 
-    $ tt start {INSTANCE | APPLICATION[:APP_INSTANCE]}
+    $ tt start {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}
 
-``tt start`` starts Tarantool applications.
+``tt start`` starts Tarantool applications. The application files must be stored
+inside the ``instances_enabled`` directory specified in the :ref:`tt configuration file <tt-config_file_app>`.
+For detailed instructions on preparing and running Tarantool applications, see
+:ref:`admin-instance-environment-overview` and :ref:`admin-start_stop_instance`.
 
-Details
--------
+When called without arguments, starts all enabled applications in the current environment.
 
-The application files must be stored inside the ``instances_enabled``
-directory specified in the :ref:`tt configuration file <tt-config_file_app>`.
-The ``APPLICATION`` value can be:
+Cluster application
+-------------------
 
-*   the name of an application file without the ``.lua`` extension.
-*   the name of an application directory. It must contain the ``init.lua``
-    application file and, optionally, the instances configuration if the
-    application runs on multiple instances. Learn more about
-    :ref:`instances configuration <tt-instances>`.
+``tt start`` can start entire Tarantool clusters based on their YAML configurations.
+A cluster application directory inside ``instances_enabled`` must contain the following files:
 
+*   ``config.yaml`` -- a :ref:`YAML configuration <configuration>` that defines
+    the cluster topology and settings.
+    It can either contain an explicit configuration in the YAML format, or point
+    to a centralized configuration storage (for Enterprise Edition).
+*   ``instances yml`` -- a file that defines the list of cluster instances to run
+    in the current environment.
+*   (Optionally) ``*.lua`` files with code to load and run in the cluster.
 
-Examples
---------
+For more information about Tarantool application layout, see :ref:`admin-instance-environment-overview`.
 
-Single instance
-~~~~~~~~~~~~~~~
+Examples:
 
-*   Start an instance with the ``app.lua`` application from the ``instances_enabled``
-    directory:
-
-    ..  code-block:: console
-
-        $ tt start app
-
-
-Multiple instances
-~~~~~~~~~~~~~~~~~~
-
-*   Start all instances of the application stored in the ``app/`` directory inside
-    ``instances_enabled`` in accordance with the :ref:`instances configuration <tt-instances>`:
+*   Start instances of the application stored in the ``app/`` directory inside
+    ``instances_enabled`` in accordance with its ``instances.yml``:
 
     ..  code-block:: console
 
         $ tt start app
 
-*   Start only the ``master`` instance of the application stored in the ``app/`` directory inside ``instances_enabled``:
+*   Start only the ``master`` instance of the application stored in the ``app/``
+    directory inside ``instances_enabled``:
 
     ..  code-block:: console
 
         $ tt start app:master
+
+
+Single instances
+----------------
+
+``tt start`` can start single Tarantool instances without cluster configurations.
+Such instances are based on Lua code provided in files inside the ``instances_enabled`
+directory.
+
+Example: start an instance with the ``app.lua`` application from the ``instances_enabled``
+directory:
+
+..  code-block:: console
+
+    $ tt start app

--- a/doc/reference/tooling/tt_cli/status.rst
+++ b/doc/reference/tooling/tt_cli/status.rst
@@ -5,14 +5,14 @@ Checking instance status
 
 ..  code-block:: console
 
-    $ tt status {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}
+    $ tt status APPLICATION[:APP_INSTANCE]
 
 ``tt status`` prints the current status of Tarantool applications and instances
 in the current environment. When called without arguments, prints the status of
 all enabled applications in the current environment.
 
-Cluster application
--------------------
+Examples
+--------
 
 *   Check the status of all instances of the ``app`` application:
 
@@ -25,14 +25,4 @@ Cluster application
     ..  code-block:: console
 
         $ tt status app:replica
-
-Single instance
----------------
-
-*   Check the status of the ``instance1`` instance:
-
-    ..  code-block:: console
-
-        $ tt status instance1
-
 

--- a/doc/reference/tooling/tt_cli/status.rst
+++ b/doc/reference/tooling/tt_cli/status.rst
@@ -5,25 +5,14 @@ Checking instance status
 
 ..  code-block:: console
 
-    $ tt status {INSTANCE | APPLICATION[:APP_INSTANCE]}
+    $ tt status {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}
 
-``tt status`` prints the current status of the specified Tarantool instance or
-all instances of an application.
+``tt status`` prints the current status of Tarantool applications and instances
+in the current environment. When called without arguments, prints the status of
+all enabled applications in the current environment.
 
-Examples
---------
-
-Single instance
-~~~~~~~~~~~~~~~
-
-*   Check the status of the ``app`` instance:
-
-    ..  code-block:: console
-
-        $ tt status app
-
-Multiple instances
-~~~~~~~~~~~~~~~~~~
+Cluster application
+-------------------
 
 *   Check the status of all instances of the ``app`` application:
 
@@ -36,3 +25,14 @@ Multiple instances
     ..  code-block:: console
 
         $ tt status app:replica
+
+Single instance
+---------------
+
+*   Check the status of the ``instance1`` instance:
+
+    ..  code-block:: console
+
+        $ tt status instance1
+
+

--- a/doc/reference/tooling/tt_cli/stop.rst
+++ b/doc/reference/tooling/tt_cli/stop.rst
@@ -5,13 +5,15 @@ Stopping a Tarantool instance
 
 ..  code-block:: console
 
-    $ tt stop {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}}
+    $ tt stop APPLICATION[:APP_INSTANCE]
 
 ``tt stop`` stops the specified running Tarantool applications or instances.
 When called without arguments, stops all running applications in the current environment.
 
-Cluster application
--------------------
+See also: :ref:`tt-start`, :ref:`tt-restart`, :ref:`tt-status`.
+
+Examples
+--------
 
 *   Stop all instances of the ``app`` application:
 
@@ -25,11 +27,3 @@ Cluster application
 
         $ tt stop app:replica
 
-Single instance
----------------
-
-*   Stop the ``instance1`` instance:
-
-    ..  code-block:: console
-
-        $ tt stop instance1

--- a/doc/reference/tooling/tt_cli/stop.rst
+++ b/doc/reference/tooling/tt_cli/stop.rst
@@ -5,24 +5,13 @@ Stopping a Tarantool instance
 
 ..  code-block:: console
 
-    $ tt stop {INSTANCE | APPLICATION[:APP_INSTANCE]}
+    $ tt stop {APPLICATION[:APP_INSTANCE] | SINGLE_INSTANCE}}
 
-``tt stop`` stops the specified running Tarantool instances.
+``tt stop`` stops the specified running Tarantool applications or instances.
+When called without arguments, stops all running applications in the current environment.
 
-Examples
---------
-
-Single instance
-~~~~~~~~~~~~~~~
-
-*   Stop the ``app`` instance:
-
-    ..  code-block:: console
-
-        $ tt stop app
-
-Multiple instances
-~~~~~~~~~~~~~~~~~~
+Cluster application
+-------------------
 
 *   Stop all instances of the ``app`` application:
 
@@ -35,3 +24,12 @@ Multiple instances
     ..  code-block:: console
 
         $ tt stop app:replica
+
+Single instance
+---------------
+
+*   Stop the ``instance1`` instance:
+
+    ..  code-block:: console
+
+        $ tt stop instance1


### PR DESCRIPTION
Resolves #3999 https://github.com/tarantool/enterprise_doc/issues/260 https://github.com/tarantool/enterprise_doc/issues/259

Update descriptions in tt commands reference to new application concept of Tarantool 3.0:
- [tt start](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/start/), [tt stop](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/stop/), [tt restart](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/restart/), [tt status](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/status/), [tt check](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/check/):
  - update the text to reflect the new app layout, provide links to explanations in admin guide
  - move the cluster (multi-instance) app examples to the first place
  - improve and simplify page structure
- [tt import](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/import/), [tt export](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/export/): update synopsis and examples to the new syntax (`FILE:SPACE` for import and `SPACE:FILE` for export)
- [tt create](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/create/): use the new `vshard_cluster` built-in template in an example instead of outdated `cartridge`
- [tt clean](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/clean/), [tt connect](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/connect/), [tt logrotate](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/logrotate/), [tt instances](https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/instances/): minor cosmetic improvements.

Deployment: https://docs.d.tarantool.io/en/doc/gh-3999-tt-2-0-commands-update/reference/tooling/tt_cli/commands/