### PR TITLE
Remove 'vshard.router.bootstrap()' from router code

### DIFF
--- a/doc/code_snippets/snippets/sharding/templates/basic/router.lua
+++ b/doc/code_snippets/snippets/sharding/templates/basic/router.lua
@@ -1,5 +1,3 @@
 local vshard = require('vshard')
 
-vshard.router.bootstrap()
-
 -- Router code --


### PR DESCRIPTION
The `vshard.router.bootstrap()` command should be executed manually after starting a cluster: https://github.com/tarantool/doc/pull/3981. See `Step 4`: [sharded_cluster/README.md](https://github.com/tarantool/doc/blob/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/README.md).

In the current sharding sample, this code is already removed: https://github.com/tarantool/doc/blob/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/router.lua