### PR TITLE
Sharding reference

### DIFF
--- a/doc/how-to/vshard_quick.rst
+++ b/doc/how-to/vshard_quick.rst
@@ -134,7 +134,7 @@ In this section, the following options are configured:
 Step 3: Configuring bucket count
 ********************************
 
-Specify the total number of :ref:`buckets <vshard-vbuckets>` in a sharded cluster using the ``sharding.bucket_count`` option:
+Specify the total number of :ref:`buckets <vshard-vbuckets>` in a sharded cluster using the :ref:`sharding.bucket_count <configuration_reference_sharding_bucket_count>` option:
 
 ..  literalinclude:: /code_snippets/snippets/sharding/instances.enabled/sharded_cluster/config.yaml
     :language: yaml
@@ -181,7 +181,7 @@ Here is a schematic view of the cluster's topology:
     The main group-level options here are:
 
     *   ``app``: The ``app.module`` option specifies that code specific to storages should be loaded from the ``storage`` module. This is explained below in the :ref:`vshard-quick-start-storage-code` section.
-    *   ``sharding``: The ``sharding.roles`` option specifies that all instances inside this group act as storages.
+    *   ``sharding``: The :ref:`sharding.roles <configuration_reference_sharding_roles>` option specifies that all instances inside this group act as storages.
         A rebalancer is selected automatically from two master instances.
     *   ``replication``: The :ref:`replication.failover <configuration_reference_replication_failover>` option specifies that a leader in each replica set should be specified manually.
     *   ``replicasets``: This section configures two replica sets that constitute cluster storages.
@@ -198,7 +198,7 @@ Here is a schematic view of the cluster's topology:
     The main group-level options here are:
 
     *   ``app``: The ``app.module`` option specifies that code specific to a router should be loaded from the ``router`` module. This is explained below in the :ref:`vshard-quick-start-router-code` section.
-    *   ``sharding``: The ``sharding.roles`` option specifies that an instance inside this group acts as a router.
+    *   ``sharding``: The :ref:`sharding.roles <configuration_reference_sharding_roles>` option specifies that an instance inside this group acts as a router.
     *   ``replicasets``: This section configures one replica set with one router instance.
 
 

--- a/doc/reference/reference_rock/vshard/vshard_ref.rst
+++ b/doc/reference/reference_rock/vshard/vshard_ref.rst
@@ -4,6 +4,10 @@
 Configuration reference
 ===============================================================================
 
+..  include:: /concepts/configuration/configuration_code.rst
+    :start-after: box_cfg_legacy_note_start
+    :end-before: box_cfg_legacy_note_end
+
 .. _vshard-config-basic-params:
 
 -------------------------------------------------------------------------------
@@ -21,6 +25,8 @@ Basic parameters
 * :ref:`rebalancer_max_receiving <cfg_basic-rebalancer_max_receiving>`
 * :ref:`rebalancer_max_sending <cfg_basic-rebalancer_max_sending>`
 * :ref:`discovery_mode <cfg_basic-discovery_mode>`
+* :ref:`sched_move_quota <cfg_basic-sched_move_quota>`
+* :ref:`sched_ref_quota <cfg_basic-sched_ref_quota>`
 
 .. _cfg_basic-sharding:
 
@@ -84,6 +90,8 @@ Basic parameters
 
 .. confval:: collect_bucket_garbage_interval
 
+    **Deprecated since:** 0.1.17.
+
     The interval between garbage collector actions, in seconds.
 
     | Type: number
@@ -93,6 +101,8 @@ Basic parameters
 .. _cfg_basic-collect_lua_garbage:
 
 .. confval:: collect_lua_garbage
+
+    **Deprecated since:** 0.1.20.
 
     If set to true, the Lua ``collectgarbage()`` function is called periodically.
 
@@ -172,6 +182,37 @@ Basic parameters
 
     | Type: string
     | Default: 'on'
+    | Dynamic: yes
+
+.. _cfg_basic-sched_move_quota:
+
+.. confval:: sched_move_quota
+
+    A scheduler's bucket move quota used by the rebalancer.
+
+    ``sched_move_quota`` defines how many bucket moves can be done in a row if there are pending storage refs.
+    Then, bucket moves are blocked and a router continues making map-reduce requests.
+
+    See also: :ref:`sched_ref_quota <cfg_basic-sched_ref_quota>`.
+
+    | Type: number
+    | Default: 1
+    | Dynamic: yes
+
+.. _cfg_basic-sched_ref_quota:
+
+.. confval:: sched_ref_quota
+
+    A scheduler's storage ref quota used by a router's map-reduce API.
+    For example, the :ref:`vshard.router.map_callrw() <router_api-map_callrw>` function implements consistent map-reduce over the entire cluster.
+
+    ``sched_ref_quota`` defines how many storage refs, therefore map-reduce requests, can be executed on the storage in a row if there are pending bucket moves.
+    Then, storage refs are blocked and the rebalancer continues bucket moves.
+
+    See also: :ref:`sched_move_quota <cfg_basic-sched_move_quota>`.
+
+    | Type: number
+    | Default: 300
     | Dynamic: yes
 
 .. _vshard-config-replica-set-funcs:

--- a/doc/reference/reference_rock/vshard/vshard_router.rst
+++ b/doc/reference/reference_rock/vshard/vshard_router.rst
@@ -407,7 +407,7 @@ Router public API
 
     The scheduler shares storage time between bucket moves and storage refs fairly.
     The distribution depends on how long and frequent the moves and refs are.
-    It can be configured using the storage options ``sched_move_quota`` and ``sched_ref_quota``.
+    It can be configured using the storage options :ref:`sched_move_quota <configuration_reference_sharding_sched_move_quota>` and :ref:`sched_ref_quota <configuration_reference_sharding_sched_ref_quota>`.
     Keep in mind that the scheduler configuration may affect map-reduce requests if used during rebalancing.
 
     During the Map stage, ``map_callrw()`` sends map requests one by one to many servers.


### PR DESCRIPTION
- Added the `sharding` section to a new config reference. Staging: [sharding](https://docs.d.tarantool.io/en/doc/sharding-reference/reference/configuration/configuration_reference/#sharding).
- Added missing options to the legacy config reference and marked some options as deprecated. Staging: [Basic parameters](https://docs.d.tarantool.io/en/doc/sharding-reference/reference/reference_rock/vshard/vshard_ref/#basic-parameters).
- Added links to `sched_ref_quota` and `sched_move_quota` options in the [vshard.router.map_callrw](https://docs.d.tarantool.io/en/doc/sharding-reference/reference/reference_rock/vshard/vshard_router/#router-api-map-callrw) description.
- Added links to `sharding.bucket_count` and `sharding.roles` options in the `Creating a sharded cluster` tutorial:
   - https://docs.d.tarantool.io/en/doc/sharding-reference/how-to/vshard_quick/#step-3-configuring-bucket-count
   - https://docs.d.tarantool.io/en/doc/sharding-reference/how-to/vshard_quick/#step-4-defining-the-cluster-topology
