### PR TITLE
Fix 'tt run' example with the '-i' flag

### DIFF
--- a/doc/reference/tooling/tt_cli/run.rst
+++ b/doc/reference/tooling/tt_cli/run.rst
@@ -61,4 +61,4 @@ Examples
 
     ..  code-block:: console
 
-        $ tt run app.lua -i
+        $ tt run -i app.lua


### PR DESCRIPTION
Staging: https://docs.d.tarantool.io/en/doc/fix-tt-run-example/reference/tooling/tt_cli/run/#examples

<img width="843" alt="image" src="https://github.com/tarantool/doc/assets/38073144/5f77b0a1-fcc8-4ca7-857e-1885ac3da6f8">
