### PR TITLE
Document logging configuration settings

### DIFF
--- a/doc/book/admin/logs.rst
+++ b/doc/book/admin/logs.rst
@@ -3,7 +3,7 @@
 Logs
 ====
 
-Each Tarantool instance logs important events to its own log file ``<instance-name>.log``.
+Each Tarantool instance logs important events to its own log file.
 For instances started with :ref:`tt <tt-cli>`, the log location is defined by
 the ``log_dir`` parameter in the :ref:`tt configuration <tt-config>`.
 By default, it's ``/var/log/tarantool`` in the ``tt`` :ref:`system mode <tt-config_modes>`,
@@ -43,7 +43,7 @@ Then check the logs:
 Log rotation
 ------------
 
-When :ref:`logging to a file <cfg_logging-log>`, the system administrator must ensure
+When :ref:`logging to a file <configuration_reference_log_file>`, the system administrator must ensure
 logs are rotated timely and do not take up all the available disk space.
 The recommended way to prevent log files from growing infinitely is using an external
 log rotation program, for example, ``logrotate``, which is pre-installed on most
@@ -78,22 +78,16 @@ To learn about log rotation in the deprecated ``tarantoolctl`` utility,
 check its :ref:`documentation <tarantoolctl-log-rotation>`.
 
 
-.. _admin-logs-formats:
+.. _admin-logs-destination:
 
-Log formats
------------
+Log destination
+---------------
 
-Tarantool can write its logs to a log file, to ``syslog``, or to a specified program
-through a pipe.
-
-File is the default log format for ``tt``. To send logs to a pipe or ``syslog``,
-specify the :ref:`log.to <configuration_reference_log_to>` parameter, for example:
+Tarantool can write its logs to a log file, to ``syslog``, or to a specified program through a pipe.
+For example, to send logs to ``syslog``, specify the :ref:`log.to <configuration_reference_log_to>` parameter as follows:
 
 ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/log_syslog/config.yaml
     :language: yaml
     :start-at: log:
     :end-at: 127.0.0.1:514
     :dedent:
-
-In such configurations, log rotation is usually handled by the external program
-used for logging.

--- a/doc/book/admin/logs.rst
+++ b/doc/book/admin/logs.rst
@@ -14,27 +14,29 @@ To check how logging works, write something to the log using the :ref:`log <log-
 
 .. code-block:: console
 
-    $ tt connect my_app
+    $ tt connect application
        • Connecting to the instance...
-       • Connected to /var/run/tarantool/my_app.control
+       • Connected to application
 
-    /var/run/tarantool/my_app.control> require('log').info("Hello for the manual readers")
+    application> require('log').info("Hello for the manual readers")
+    ---
+    ...
 
 Then check the logs:
 
 .. code-block:: console
 
-    $ tail /var/log/tarantool/my_app.log
-    2023-09-12 18:13:00.396 [67173] main/111/guard of feedback_daemon/box.feedback_daemon V> metrics_collector restarted
-    2023-09-12 18:13:00.396 [67173] main/103/-/box.feedback_daemon V> feedback_daemon started
-    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(14) = 0x1090077b4
-    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(26) = 0x1090077ec
-    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(39) = 0x109007824
-    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(24) = 0x10900785c
-    2023-09-12 18:13:00.396 [67173] main/103/- D> memtx_tuple_new_raw_impl(39) = 0x109007894
-    2023-09-12 18:13:00.396 [67173] main/106/checkpoint_daemon I> scheduled next checkpoint for Tue Sep 12 19:44:34 2023
-    2023-09-12 18:13:00.396 [67173] main I> entering the event loop
-    2023-09-12 18:13:11.656 [67173] main/114/console/unix/:/tarantool I> Hello for the manual readers
+    $ tail instances.enabled/application/var/log/instance001/tt.log
+    2024-04-09 17:34:29.489 [49502] main/106/gc I> wal/engine cleanup is resumed
+    2024-04-09 17:34:29.489 [49502] main/104/interactive/box.load_cfg I> set 'instance_name' configuration option to "instance001"
+    2024-04-09 17:34:29.489 [49502] main/104/interactive/box.load_cfg I> set 'custom_proc_title' configuration option to "tarantool - instance001"
+    2024-04-09 17:34:29.489 [49502] main/104/interactive/box.load_cfg I> set 'log_nonblock' configuration option to false
+    2024-04-09 17:34:29.489 [49502] main/104/interactive/box.load_cfg I> set 'replicaset_name' configuration option to "replicaset001"
+    2024-04-09 17:34:29.489 [49502] main/104/interactive/box.load_cfg I> set 'listen' configuration option to [{"uri":"127.0.0.1:3301"}]
+    2024-04-09 17:34:29.489 [49502] main/107/checkpoint_daemon I> scheduled next checkpoint for Tue Apr  9 19:08:04 2024
+    2024-04-09 17:34:29.489 [49502] main/104/interactive/box.load_cfg I> set 'metrics' configuration option to {"labels":{"alias":"instance001"},"include":["all"],"exclude":[]}
+    2024-04-09 17:34:29.489 [49502] main I> entering the event loop
+    2024-04-09 17:34:38.905 [49502] main/116/console/unix/:/tarantool I> Hello for the manual readers
 
 .. _admin-logs-rotation:
 
@@ -85,13 +87,13 @@ Tarantool can write its logs to a log file, to ``syslog``, or to a specified pro
 through a pipe.
 
 File is the default log format for ``tt``. To send logs to a pipe or ``syslog``,
-specify the :ref:`box.cfg.log <cfg_logging-log>` parameter, for example:
+specify the :ref:`log.to <configuration_reference_log_to>` parameter, for example:
 
-.. code-block:: lua
-
-    box.cfg{log = '| cronolog tarantool.log'}
-    -- or
-    box.cfg{log = 'syslog:identity=tarantool,facility=user'}
+..  literalinclude:: /code_snippets/snippets/config/instances.enabled/log_syslog/config.yaml
+    :language: yaml
+    :start-at: log:
+    :end-at: 127.0.0.1:514
+    :dedent:
 
 In such configurations, log rotation is usually handled by the external program
 used for logging.

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log_pipe/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log_pipe/config.yaml
@@ -1,6 +1,6 @@
 audit_log:
   to: pipe
-  pipe: '| cronolog audit_tarantool.log'
+  pipe: 'cronolog audit_tarantool.log'
 
 groups:
   group001:

--- a/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/audit_log_syslog/config.yaml
@@ -4,14 +4,11 @@ audit_log:
     server: 'unix:/dev/log'
     facility: 'user'
     identity: 'tarantool_audit'
-  filter: 'audit,auth,priv,password_change,access_denied'
+  filter: [ audit, auth, priv, password_change, access_denied ]
   extract_key: false
 
 groups:
   group001:
-    iproto:
-      listen:
-      - uri: '127.0.0.1:3301'
     replicasets:
       replicaset001:
         instances:

--- a/doc/code_snippets/snippets/config/instances.enabled/log_existing_c_modules/app.lua
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_existing_c_modules/app.lua
@@ -1,0 +1,16 @@
+ffi = require('ffi')
+
+-- Prints 'info' messages --
+ffi.C._say(ffi.C.S_INFO, nil, 0, nil, 'Info message from C module')
+--[[
+[6024] main/103/interactive I> Info message from C module
+---
+...
+--]]
+
+-- Swallows 'debug' messages --
+ffi.C._say(ffi.C.S_DEBUG, nil, 0, nil, 'Debug message from C module')
+--[[
+---
+...
+--]]

--- a/doc/code_snippets/snippets/config/instances.enabled/log_existing_c_modules/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_existing_c_modules/config.yaml
@@ -1,0 +1,15 @@
+log:
+  modules:
+    tarantool: 'info'
+app:
+  file: 'app.lua'
+
+groups:
+  group001:
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/log_existing_c_modules/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_existing_c_modules/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/app.lua
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/app.lua
@@ -1,0 +1,17 @@
+module1 = require('test.module1')
+module2 = require('test.module2')
+
+-- Prints 'info' messages --
+module1.say_hello()
+--[[
+[92617] main/103/interactive/test.logging.module1 I> Info message from module1
+---
+...
+--]]
+
+-- Swallows 'info' messages --
+module2.say_hello()
+--[[
+---
+...
+--]]

--- a/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/config.yaml
@@ -1,0 +1,16 @@
+log:
+  modules:
+    test.module1: 'verbose'
+    test.module2: 'error'
+app:
+  file: 'app.lua'
+
+groups:
+  group001:
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/test/module1.lua
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/test/module1.lua
@@ -1,0 +1,6 @@
+return {
+    say_hello = function()
+        local log = require('log')
+        log.info('Info message from module1')
+    end
+}

--- a/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/test/module2.lua
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_existing_modules/test/module2.lua
@@ -1,0 +1,6 @@
+return {
+    say_hello = function()
+        local log = require('log')
+        log.info('Info message from module2')
+    end
+}

--- a/doc/code_snippets/snippets/config/instances.enabled/log_file/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_file/config.yaml
@@ -1,0 +1,13 @@
+log:
+  to: file
+  file: var/log/{{ instance_name }}/instance.log
+
+groups:
+  group001:
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/log_file/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_file/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/code_snippets/snippets/config/instances.enabled/log_level/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_level/config.yaml
@@ -1,0 +1,12 @@
+log:
+  level: 'verbose'
+
+groups:
+  group001:
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/log_level/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_level/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/code_snippets/snippets/config/instances.enabled/log_new_modules/app.lua
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_new_modules/app.lua
@@ -1,0 +1,25 @@
+-- Creates new loggers --
+module1_log = require('log').new('module1')
+module2_log = require('log').new('module2')
+
+-- Prints 'info' messages --
+module1_log.info('Info message from module1')
+--[[
+[16300] main/103/interactive/module1 I> Info message from module1
+---
+...
+--]]
+
+-- Swallows 'debug' messages --
+module1_log.debug('Debug message from module1')
+--[[
+---
+...
+--]]
+
+-- Swallows 'info' messages --
+module2_log.info('Info message from module2')
+--[[
+---
+...
+--]]

--- a/doc/code_snippets/snippets/config/instances.enabled/log_new_modules/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_new_modules/config.yaml
@@ -1,0 +1,16 @@
+log:
+  modules:
+    module1: 'verbose'
+    module2: 'error'
+app:
+  file: 'app.lua'
+
+groups:
+  group001:
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/log_new_modules/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_new_modules/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/code_snippets/snippets/config/instances.enabled/log_pipe/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_pipe/config.yaml
@@ -1,0 +1,13 @@
+log:
+  to: pipe
+  pipe: 'cronolog tarantool.log'
+
+groups:
+  group001:
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/log_pipe/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_pipe/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/code_snippets/snippets/config/instances.enabled/log_syslog/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_syslog/config.yaml
@@ -1,0 +1,15 @@
+log:
+  to: syslog
+  syslog:
+    server: '127.0.0.1:514'
+#    server: 'unix:/dev/log'
+
+groups:
+  group001:
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'

--- a/doc/code_snippets/snippets/config/instances.enabled/log_syslog/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/log_syslog/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/code_snippets/test/logging/log_test.lua
+++ b/doc/code_snippets/test/logging/log_test.lua
@@ -6,26 +6,16 @@ local g = t.group()
 g.before_each(function(cg)
     cg.server = server:new {
         workdir = fio.cwd() .. '/tmp',
-        box_cfg = { log_level = 'warn' }
+        box_cfg = {}
     }
     cg.server:start()
     cg.server:exec(function()
-        log = require('log')
-
-        -- Prints 'warn' messages --
+        local log = require('log')
+        log.cfg { level = 'verbose' }
         log.warn('Warning message')
-        --[[
-        2023-07-20 11:03:57.029 [16300] main/103/interactive/tarantool [C]:-1 W> Warning message
-        ---
-        ...
-        --]]
-
-        -- Swallows 'debug' messages --
+        log.info('Tarantool version: %s', box.info.version)
+        log.error({ 500, 'Internal error' })
         log.debug('Debug message')
-        --[[
-        ---
-        ...
-        --]]
     end)
 end)
 
@@ -43,5 +33,7 @@ end
 
 g.test_log_contains_messages = function(cg)
     find_in_log(cg, 'Warning message', true)
+    find_in_log(cg, 'Tarantool version:', true)
+    find_in_log(cg, 'Internal error', true)
     find_in_log(cg, 'Debug message', false)
 end

--- a/doc/reference/configuration/cfg_logging.rst
+++ b/doc/reference/configuration/cfg_logging.rst
@@ -17,15 +17,16 @@ application.
 
     Since version 1.6.2.
 
-    Specify the level of detail the :ref:`log <admin-logs>` has. There are seven levels:
+    Specify the level of detail the :ref:`log <admin-logs>` has. There are the following levels:
 
-    * 1 -- ``SYSERROR``
-    * 2 -- ``ERROR``
-    * 3 -- ``CRITICAL``
-    * 4 -- ``WARNING``
-    * 5 -- ``INFO``
-    * 6 -- ``VERBOSE``
-    * 7 -- ``DEBUG``
+    * 0 -- ``fatal``
+    * 1 -- ``syserror``
+    * 2 -- ``error``
+    * 3 -- ``crit``
+    * 4 -- ``warn``
+    * 5 -- ``info``
+    * 6 -- ``verbose``
+    * 7 -- ``debug``
 
     By setting ``log_level``, you can enable logging of all events with severities above
     or equal to the given level. Tarantool prints logs to the standard
@@ -33,7 +34,7 @@ application.
     :ref:`log <cfg_logging-log>` configuration parameter.
 
     |
-    | Type: integer
+    | Type: integer, string
     | Default: 5
     | Environment variable: TT_LOG_LEVEL
     | Dynamic: yes

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -1909,8 +1909,8 @@ To handle logging in your application, use the :ref:`log module <log-module>`.
 
     *   ``stderr``: write logs to the standard error stream.
     *   ``file``: write logs to a file (see :ref:`log.file <configuration_reference_log_file>`).
-    *   ``pipe``: start a program and write logs to it (see :ref:`log.pipe <configuration_reference_log_pipe>`).
-    *   ``syslog``: write audit logs to a system logger (see :ref:`log.syslog.* <configuration_reference_log_syslog>`).
+    *   ``pipe``: start a program and write logs to its standard input (see :ref:`log.pipe <configuration_reference_log_pipe>`).
+    *   ``syslog``: write logs to a system logger (see :ref:`log.syslog.* <configuration_reference_log_syslog>`).
 
     |
     | Type: string
@@ -1924,6 +1924,7 @@ To handle logging in your application, use the :ref:`log module <log-module>`.
 
     Specify a file for logs destination.
     To write logs to a file, you need to set :ref:`log.to <configuration_reference_log_to>` to ``file``.
+    Otherwise, ``log.file`` is ignored.
 
     **Example**
 
@@ -2147,8 +2148,8 @@ To handle logging in your application, use the :ref:`log module <log-module>`.
 
 ..  confval:: log.pipe
 
-    Specify a pipe for logs destination.
-    To write logs to a pipe, you need to set :ref:`log.to <configuration_reference_log_to>` to ``pipe``.
+    Start a program and write logs to its standard input (``stdin``).
+    To send logs to a program's standard input, you need to set :ref:`log.to <configuration_reference_log_to>` to ``pipe``.
 
     **Example**
 
@@ -2203,7 +2204,10 @@ log.syslog.*
 ..  confval:: log.syslog.server
 
     Set a location of a syslog server.
-    This option accepts an IPv4 address or Unix socket path starting with ``unix:``.
+    This option accepts one of the following values:
+
+    *   An IPv4 address. Example: ``127.0.0.1:514``.
+    *   A Unix socket path starting with ``unix:``. Examples: ``unix:/dev/log`` on Linux or ``unix:/var/run/syslog`` on macOS.
 
     To write logs to syslog, you need to set :ref:`log.to <configuration_reference_log_to>` to ``syslog``.
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -89,7 +89,7 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
     **Example**
 
     ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log/config.yaml
-        :language: lua
+        :language: yaml
         :start-at: filter:
         :end-at: custom ]
         :dedent:
@@ -117,8 +117,8 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
     ..  code-block:: yaml
 
         audit_log:
-            to: file
-            format: plain
+          to: file
+          format: plain
 
     the output in the file might look as follows:
 
@@ -169,16 +169,14 @@ The ``audit_log`` section defines configuration parameters related to :ref:`audi
 
     **Example**
 
+    This starts the `cronolog <https://linux.die.net/man/1/cronolog>`_ program when the server starts
+    and sends all ``audit_log`` messages to cronolog standard input (``stdin``).
+
     ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/audit_log_pipe/config.yaml
         :language: yaml
         :start-at: audit_log:
-        :end-at: '| cronolog audit_tarantool.log'
+        :end-at: 'cronolog audit_tarantool.log'
         :dedent:
-
-    This starts the `cronolog <https://linux.die.net/man/1/cronolog>`_ program when the server starts
-    and sends all ``audit_log`` messages to cronolog standard input (``stdin``).
-    If the ``audit_log`` string starts with '|',
-    the string is interpreted as a Unix `pipeline <https://en.wikipedia.org/wiki/Pipeline_%28Unix%29>`_.
 
     |
     | Type: string

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -1948,7 +1948,7 @@ To handle logging in your application, use the :ref:`log module <log-module>`.
 
 ..  confval:: log.format
 
-    Specify a format is used for a log entry.
+    Specify a format that is used for a log entry.
     The following formats are supported:
 
     *   ``plain``: a log entry is formatted as plain text. Example:

--- a/doc/reference/reference_lua/log.rst
+++ b/doc/reference/reference_lua/log.rst
@@ -62,41 +62,53 @@ Below is a list of all ``log`` functions.
     Configure logging options.
     The following options are available:
 
-    * ``level``: Specifies the level of detail the log has.
+    *   ``level``: Specify the level of detail the log has.
 
-      Learn more: :ref:`log_level <cfg_logging-log_level>`.
+        The example below shows how to set the log level to ``verbose``:
 
-    * ``log``: Specifies where to send the log's output, for example,
-      to a file, pipe, or system logger.
+        ..  literalinclude:: /code_snippets/test/logging/log_test.lua
+            :language: lua
+            :start-at: local log = require
+            :end-at: log.cfg
+            :dedent:
 
-      Learn more: :ref:`log <cfg_logging-log>`.
+        See also: :ref:`log.level <configuration_reference_log_level>`.
 
-    * ``nonblock``: If **true**, Tarantool does not block during logging when the system
-      is not ready for writing, and drops the message instead.
+    *   ``log``: Specify where to send the log's output, for example, to a file, pipe, or system logger.
 
-      Learn more: :ref:`log_nonblock <cfg_logging-log_nonblock>`.
+        **Example 1: sending the log to the tarantool.log file**
 
-    * ``format``: Specifies the log format: 'plain' or 'json'.
+        .. code-block:: lua
 
-      Learn more: :ref:`log_format <cfg_logging-log_format>`.
+            log.cfg { log = 'tarantool.log' }
 
-    * ``modules``: Configures the specified log levels for different modules.
+        **Example 2: sending the log to a pipe**
 
-      Learn more: :ref:`log_modules <cfg_logging-log_modules>`.
+        .. code-block:: lua
 
-    The example below shows how to set the log level to 'debug' and how to send the resulting log
-    to the 'tarantool.log' file:
+            log.cfg { log = '| cronolog tarantool.log' }
 
-    .. code-block:: lua
+        **Example 3: sending the log to syslog**
 
-        log = require('log')
-        log.cfg{ level='debug', log='tarantool.log'}
+        .. code-block:: lua
 
-    .. NOTE::
+            log.cfg { log = 'syslog:server=unix:/dev/log' }
 
-        Note that calling ``log.cfg()`` before ``box.cfg()`` takes into account
-        logging options specified using :ref:`environment variables <box-cfg-params-env>`,
-        such as ``TT_LOG`` and ``TT_LOG_LEVEL``.
+        See also: :ref:`log.to <configuration_reference_log_to>`.
+
+    *   ``nonblock``: If **true**, Tarantool does not block during logging when the system
+        is not ready for writing, and drops the message instead.
+
+        See also: :ref:`log.nonblock <configuration_reference_log_nonblock>`.
+
+    *   ``format``: Specify the log format: 'plain' or 'json'.
+
+        See also: :ref:`log.format <configuration_reference_log_format>`.
+
+    *   ``modules``: Configure the specified log levels for different modules.
+
+        See also: :ref:`log.modules <configuration_reference_log_modules>`.
+
 
 .. _log-ug_message:
 
@@ -108,13 +120,16 @@ Below is a list of all ``log`` functions.
 
     Log a message with the specified logging level.
     You can learn more about the available levels from the
-    :ref:`log_level <cfg_logging-log_level>` property description.
+    :ref:`log.level <configuration_reference_log_level>` option description.
 
-    The example below shows how to log a message with the ``info`` level:
+    **Example**
+
+    The example below shows how to log a message with the ``warn`` level:
 
     ..  literalinclude:: /code_snippets/test/logging/log_test.lua
         :language: lua
-        :lines: 13-21
+        :start-at: log.warn
+        :end-at: log.warn
         :dedent:
 
     :param any message:    A log message.
@@ -123,18 +138,19 @@ Below is a list of all ``log`` functions.
 
                            * A message may contain C-style format specifiers ``%d`` or ``%s``. Example:
 
-                             .. code-block:: lua
-
-                                 box.cfg{}
-                                 log = require('log')
-                                 log.info('Info %s', box.info.version)
+                             ..  literalinclude:: /code_snippets/test/logging/log_test.lua
+                                 :language: lua
+                                 :start-at: log.info
+                                 :end-at: log.info
+                                 :dedent:
 
                            * A message may be a scalar data type or a table. Example:
 
-                             .. code-block:: lua
-
-                                 log = require('log')
-                                 log.error({500,'Internal error'})
+                             ..  literalinclude:: /code_snippets/test/logging/log_test.lua
+                                 :language: lua
+                                 :start-at: log.error
+                                 :end-at: log.error
+                                 :dedent:
 
     :return: nil
 
@@ -146,7 +162,7 @@ Below is a list of all ``log`` functions.
     * ``message``
 
     Note that the message will not be logged if the severity level corresponding to
-    the called function is less than :ref:`log_level <cfg_logging-log_level>`.
+    the called function is less than :ref:`log.level <configuration_reference_log_level>`.
 
 .. _log-pid:
 
@@ -171,33 +187,37 @@ Below is a list of all ``log`` functions.
     **Since:** :doc:`2.11.0 </release/2.11.0>`
 
     Create a new logger with the specified name.
-    You can configure a specific log level for a new logger using the :ref:`log_modules <cfg_logging-log_modules>` configuration property.
+    You can configure a specific log level for a new logger using the :ref:`log.modules <configuration_reference_log_modules>` configuration property.
 
     :param string name: a logger name
     :return: a logger instance
 
-    **Example:**
+    **Example**
 
-    The code snippet below shows how to set the ``verbose`` level for ``module1`` and the ``error`` level for ``module2``:
+    This example shows how to set the ``verbose`` level for ``module1`` and the ``error`` level for ``module2`` in a configuration file:
 
-    ..  literalinclude:: /code_snippets/test/logging/log_new_modules_test.lua
-        :language: lua
-        :lines: 9-13
+    ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/log_new_modules/config.yaml
+        :language: yaml
+        :start-at: log:
+        :end-at: app.lua
         :dedent:
 
-    To create the ``module1`` and ``module2`` loggers, call the ``new()`` function:
+    To create the ``module1`` and ``module2`` loggers in your application (``app.lua``), call the ``new()`` function:
 
-    ..  literalinclude:: /code_snippets/test/logging/log_new_modules_test.lua
+    ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/log_new_modules/app.lua
         :language: lua
-        :lines: 17-19
+        :start-at: Creates new loggers
+        :end-at: module2_log = require
         :dedent:
 
     Then, you can call functions corresponding to different logging levels to make sure
     that events with severities above or equal to the given levels are shown:
 
-    ..  literalinclude:: /code_snippets/test/logging/log_new_modules_test.lua
+    ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/log_new_modules/app.lua
         :language: lua
-        :lines: 21-41
+        :start-after: module2_log = require
         :dedent:
 
     At the same time, the events with severities below the specified levels are swallowed.
+
+    Example on GitHub: `log_new_modules <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/config/instances.enabled/log_new_modules>`_.


### PR DESCRIPTION
1) Runnable samples/tests used in docs:
    - Added samples showing how to configure various logging options (placed in the `doc/code_snippets/snippets/config/instances.enabled/` directory, names start with `log_`).
    - Updated `log_test.lua` used in the `log` module docs.

2) Docs:
    - Added a new `log` section in the configuration reference. Staging: https://docs.d.tarantool.io/en/doc/logging/reference/configuration/configuration_reference/#log.
    - Updated the `log` module API descriptions taking into account new config options. Staging: https://docs.d.tarantool.io/en/doc/logging/reference/reference_lua/log/.
    - Updated the `Logs` topic in the `Administration` section. Staging: https://docs.d.tarantool.io/en/doc/logging/book/admin/logs/.

3) Changes not directly related to `log` settings - fixed `audit_log` samples:
    - `audit_log_pipe` had an incorrect value in the `audit_log.pipe` option.
    - `audit_log_syslog` had a broken cluster topology and an incorrect value in the `audit_log.filter` option (string instead of array).