### PR TITLE
Add env variables that tt CLI uses

### DIFF
--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -133,6 +133,8 @@ ee section
 *   ``credential_path`` -- a path to the file with credentials used for
     downloading Tarantool Enterprise Edition (Tarantool customer zone credentials).
     The file should contain a username and a password, each on a separate line.
+    Find an example in the :ref:`tt install <tt-install-authentication>` command
+    reference.
 
     .. note::
 

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -67,8 +67,8 @@ env section
 
     .. note::
 
-        The header files directory path can also be passed using the ``TT_CLI_TARANTOOL_PREFIX``.
-        If this variable is set, ``tt rocks`` and ``tt build`` commands use the
+        The header files directory path can also be passed using the ``TT_CLI_TARANTOOL_PREFIX``
+        environment variable. If it is set, ``tt rocks`` and ``tt build`` commands use the
         ``include/tarantool`` directory inside ``TT_CLI_TARANTOOL_PREFIX`` as the
         header files directory.
 
@@ -119,9 +119,9 @@ repo section
 
     .. note::
 
-        The rocks directory path can be passed in the ``TT_CLI_REPO_ROCKS`` instead.
-        environment variable. The variable is also used if the directory specified
-        in ``repo.rocks`` does not include a repository manifest.
+        The rocks directory path can be passed in the ``TT_CLI_REPO_ROCKS``
+        environment variable instead. The variable is also used if the directory
+        specified in ``repo.rocks`` does not include a repository manifest.
 
 *   ``distfiles`` -- the directory where installation files are stored.
 

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -64,6 +64,14 @@ env section
 *   ``inc_dir`` -- the base directory for storing header files. They will
     be placed in the ``include`` subdirectory inside the specified directory.
     Default: ``include``.
+
+    .. note::
+
+        The header files directory path can also be passed using the ``TT_CLI_TARANTOOL_PREFIX``.
+        If this variable is set, ``tt rocks`` and ``tt build`` commands use the
+        ``include/tarantool`` directory inside ``TT_CLI_TARANTOOL_PREFIX`` as the
+        header files directory.
+
 *   ``restart_on_failure`` -- restart the instance on failure: ``true`` or ``false``.
     Default: ``false``.
 *   ``tarantoolctl_layout`` -- use a layout compatible with the deprecated ``tarantoolctl``
@@ -108,6 +116,13 @@ repo section
 ~~~~~~~~~~~~
 
 *   ``rocks`` -- the directory where rocks files are stored.
+
+    .. note::
+
+        The rocks directory path can be passed in the ``TT_CLI_REPO_ROCKS`` instead.
+        environment variable. The variable is also used if the directory specified
+        in ``repo.rocks`` does not include a repository manifest.
+
 *   ``distfiles`` -- the directory where installation files are stored.
 
 .. _tt-config_file_ee:
@@ -116,7 +131,13 @@ ee section
 ~~~~~~~~~~
 
 *   ``credential_path`` -- a path to the file with credentials used for
-    downloading Tarantool Enterprise Edition.
+    downloading Tarantool Enterprise Edition (Tarantool customer zone credentials).
+    The file should contain a username and a password, each on a separate line.
+
+    .. note::
+
+        The customer zone credentials can also be passed in the
+        ``TT_CLI_EE_USERNAME`` and ``TT_CLI_EE_PASSWORD`` environment variables.
 
 templates section
 ~~~~~~~~~~~~~~~~~

--- a/doc/reference/tooling/tt_cli/connect.rst
+++ b/doc/reference/tooling/tt_cli/connect.rst
@@ -77,23 +77,23 @@ username and the password:
 
 *   The ``-u`` (``--username``) and ``-p`` (``--password``) options:
 
-..  code-block:: console
+    ..  code-block:: console
 
-    $ tt connect 192.168.10.10:3301 -u myuser -p p4$$w0rD
+        $ tt connect 192.168.10.10:3301 -u myuser -p p4$$w0rD
 
 *   The connection string:
 
-..  code-block:: console
+    ..  code-block:: console
 
-    $ tt connect myuser:p4$$w0rD@192.168.10.10:3301 -u myuser -p p4$$w0rD
+        $ tt connect myuser:p4$$w0rD@192.168.10.10:3301
 
-*   Environment variables ``TT_CLI_USERNAME`` and ``TT_CLI_PASSWORD`` :
+*   Environment variables ``TT_CLI_USERNAME`` and ``TT_CLI_PASSWORD``:
 
-..  code-block:: console
+    ..  code-block:: console
 
-    $ export TT_CLI_USERNAME=myuser
-    $ export TT_CLI_PASSWORD=p4$$w0rD
-    $ tt connect 192.168.10.10:3301
+        $ export TT_CLI_USERNAME=myuser
+        $ export TT_CLI_PASSWORD=p4$$w0rD
+        $ tt connect 192.168.10.10:3301
 
 If no credentials are provided for a remote connection, the user is automatically ``guest``.
 

--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -71,6 +71,8 @@ dependencies, such as a C compiler. Make sure they are available in the system.
 
 Tarantool Enterprise Edition is installed from prebuilt packages.
 
+.. _tt-install-authentication:
+
 Authentication
 ~~~~~~~~~~~~~~
 

--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -93,14 +93,14 @@ for Tarantool customer zone. Use one of the following ways to pass the username 
 
     .. code-block:: text
 
-        myuser
+        myuser@tarantool.io
         p4$$w0rD
 
 *   Environment variables ``TT_CLI_EE_USERNAME`` and ``TT_CLI_EE_PASSWORD``:
 
     ..  code-block:: console
 
-        $ export TT_CLI_EE_USERNAME=myuser
+        $ export TT_CLI_EE_USERNAME=myuser@tarantool.io
         $ export TT_CLI_EE_PASSWORD=p4$$w0rD
         $ tt install tarantool-ee
 

--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -71,6 +71,37 @@ dependencies, such as a C compiler. Make sure they are available in the system.
 
 Tarantool Enterprise Edition is installed from prebuilt packages.
 
+Authentication
+~~~~~~~~~~~~~~
+
+To install Tarantool EE using ``tt install``, you need to provide access credentials
+for Tarantool customer zone. Use one of the following ways to pass the username and the password:
+
+*   A text file specified in the ``ee.credentials_path`` parameter of the
+    :ref:`tt enviromnment configuration <tt-config_file>`:
+
+    ..  code-block:: yaml
+
+        # tt.yaml
+        # ...
+        ee:
+          credential_path: cred.txt
+
+    `cred.txt` should contain a username and a password on separate lines:
+
+    .. code-block:: text
+
+        myuser
+        p4$$w0rD
+
+*   Environment variables ``TT_CLI_EE_USERNAME`` and ``TT_CLI_EE_PASSWORD``:
+
+    ..  code-block:: console
+
+        $ export TT_CLI_EE_USERNAME=myuser
+        $ export TT_CLI_EE_PASSWORD=p4$$w0rD
+        $ tt install tarantool-ee
+
 Development versions
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/reference/tooling/tt_cli/play.rst
+++ b/doc/reference/tooling/tt_cli/play.rst
@@ -14,6 +14,14 @@ A single call of ``tt play`` can play multiple files.
 Options
 -------
 
+..  option:: -u USERNAME, --username USERNAME
+
+    A Tarantool user for connecting to the instance.
+
+..  option:: -p PASSWORD, --password PASSWORD
+
+    The user's password.
+
 ..  option:: --from LSN
 
     Play operations starting from the given LSN.
@@ -56,6 +64,32 @@ on this instance. This means that:
 *   The operations' LSNs will change unless you play all operations that took place since the instance startup.
 
 *   Replica IDs will change in accordance with the destination instance configuration.
+
+Authentication
+~~~~~~~~~~~~~~
+
+If authentication is required on the instance, use one of the following ways to pass the
+username and the password:
+
+*   The ``-u`` (``--username``) and ``-p`` (``--password``) options:
+
+    ..  code-block:: console
+
+        $ tt play 192.168.10.10:3301 00000000000000000000.xlog -u myuser -p p4$$w0rD
+
+*   The connection string:
+
+    ..  code-block:: console
+
+        $ tt play myuser:p4$$w0rD@192.168.10.10:3301 00000000000000000000.xlog
+
+*   Environment variables ``TT_CLI_USERNAME`` and ``TT_CLI_PASSWORD``:
+
+    ..  code-block:: console
+
+        $ export TT_CLI_USERNAME=myuser
+        $ export TT_CLI_PASSWORD=p4$$w0rD
+        $ tt play 192.168.10.10:3301 00000000000000000000.xlog
 
 Examples
 --------

--- a/doc/reference/tooling/tt_cli/play.rst
+++ b/doc/reference/tooling/tt_cli/play.rst
@@ -61,15 +61,15 @@ on this instance. This means that:
     by adding the ``--show-system`` flag. With this flag, ``tt`` plays the operations that
     create and configure user-defined spaces.
 
-*   The operations' LSNs will change unless you play all operations that took place since the instance startup.
+*   The operations' LSNs change unless you play all operations that took place since the instance startup.
 
-*   Replica IDs will change in accordance with the destination instance configuration.
+*   Replica IDs change in accordance with the destination instance configuration.
 
 Authentication
 ~~~~~~~~~~~~~~
 
-If authentication is required on the instance, use one of the following ways to pass the
-username and the password:
+Use one of the following ways to pass the username and the password when connecting
+to the instance:
 
 *   The ``-u`` (``--username``) and ``-p`` (``--password``) options:
 


### PR DESCRIPTION
Resolves #3828 

* Add  authentication section to [tt install ](https://docs.d.tarantool.io/en/doc/gh-3828-tt-env-vars/reference/tooling/tt_cli/install/#authentication)page
* Add authentication section to [tt play](https://docs.d.tarantool.io/en/doc/gh-3828-tt-env-vars/reference/tooling/tt_cli/play/#authentication) page
* Add `TT_CLI_TARANTOOL_PREFIX` and `TT_CLI_REPO_ROCKS` to the [tt configuration page](https://docs.d.tarantool.io/en/doc/gh-3828-tt-env-vars/reference/tooling/tt_cli/configuration/)
* Add `TT_CLI_EE_USERNAME` and `TT_CLI_EE_PASSWORD`, and EE credentials file format to the [tt configuration page](https://docs.d.tarantool.io/en/doc/gh-3828-tt-env-vars/reference/tooling/tt_cli/configuration/)
* Minor fixes on the [tt connect ](https://docs.d.tarantool.io/en/doc/gh-3828-tt-env-vars/reference/tooling/tt_cli/connect/)page

Deployment: https://docs.d.tarantool.io/en/doc/gh-3828-tt-env-vars/reference/tooling/tt_cli/commands/