### PR TITLE
Add info about explicit background mode conflicting with tt start

### DIFF
--- a/doc/reference/configuration/cfg_basic.rst
+++ b/doc/reference/configuration/cfg_basic.rst
@@ -27,7 +27,7 @@
     .. important::
 
         Do not enable the background mode for applications intended to run by the
-        ``tt`` utility. For more information, see the :ref:`tt-start` reference.
+        ``tt`` utility. For more information, see the :ref:`tt start <tt-start>` reference.
 
     |
     | Type: boolean

--- a/doc/reference/configuration/cfg_basic.rst
+++ b/doc/reference/configuration/cfg_basic.rst
@@ -24,6 +24,11 @@
     and :ref:`pid_file <cfg_basic-pid_file>` parameters must be non-null for
     this to work.
 
+    .. important::
+
+        Do not enable the background mode for applications intended to run by the
+        ``tt`` utility. For more information, see the :ref:`tt-start` reference.
+
     |
     | Type: boolean
     | Default: false

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -2405,7 +2405,7 @@ The ``process`` defines configuration parameters of the Tarantool process in the
     .. important::
 
         Do not enable the background mode for applications intended to run by the
-        ``tt`` utility. For more information, see the :ref:`tt-start` reference.
+        ``tt`` utility. For more information, see the :ref:`tt start <tt-start>` reference.
 
     |
     | Type: boolean

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -2380,6 +2380,107 @@ The ``memtx`` section is used to configure parameters related to the :ref:`memtx
     | Default: box.NULL
     | Environment variable: TT_MEMTX_SORT_THREADS
 
+..  _configuration_reference_process:
+
+process
+-------
+
+The ``process`` defines configuration parameters of the Tarantool process in the system.
+
+
+-   :ref:`process.background <configuration_reference_process_background>`
+-   :ref:`process.coredump <configuration_reference_process_coredump>`
+-   :ref:`process.custom_proc_title <configuration_reference_process_custom_proc_title>`
+-   :ref:`process.pid_file <configuration_reference_process_pid_file>`
+-   :ref:`process.strip_core <configuration_reference_process_strip_core>`
+-   :ref:`process.username <configuration_reference_process_username>`
+-   :ref:`process.work_dir <configuration_reference_process_work_dir>`
+
+.. _configuration_reference_process_background:
+
+.. confval:: process.background
+
+    Run the server as a background task.
+
+    .. important::
+
+        Do not enable the background mode for applications intended to run by the
+        ``tt`` utility. For more information, see the :ref:`tt-start` reference.
+
+    |
+    | Type: boolean
+    | Default: false
+    | Environment variable: TT_PROCESS_BACKGROUND
+
+
+.. _configuration_reference_process_coredump:
+
+.. confval:: process.coredump
+
+
+    |
+    | Type: boolean
+    | Default: false
+    | Environment variable: TT_PROCESS_COREDUMP
+
+.. _configuration_reference_process_custom_proc_title:
+
+.. confval:: process.custom_proc_title
+
+    Sets the name of the server's process title (what’s shown in the COMMAND column for
+    ``ps -ef`` and ``top -c`` commands).
+
+    |
+    | Type: string
+    | Default: 'tarantool - {{ instance_name }}'
+    | Environment variable: TT_PROCESS_CUSTOM_PROC_TITLE
+
+.. _configuration_reference_process_pid_file:
+
+.. confval:: process.pid_file
+
+    Store the process id in this file.
+
+    |
+    | Type: string
+    | Default: 'var/run/{{ instance_name }}/tarantool.pid'
+    | Environment variable: TT_PROCESS_PID_FILE
+
+.. _configuration_reference_process_strip_core:
+
+.. confval:: process.strip_core
+
+    Whether coredump files should include memory allocated for tuples.
+    (This can be large if Tarantool runs under heavy load.)
+    Setting to ``true`` means "do not include".
+
+    |
+    | Type: boolean
+    | Default: true
+    | Environment variable: TT_PROCESS_STRIP_CORE
+
+.. _configuration_reference_process_username:
+
+.. confval:: process.username
+
+    The name of the system user to switch to after start.
+
+    |
+    | Type: string
+    | Default: box.NULL
+    | Environment variable: TT_PROCESS_USERNAME
+
+.. _configuration_reference_process_work_dir:
+
+.. confval:: process.work_dir
+
+    A directory where Tarantool working files are stored.
+
+    |
+    | Type: string
+    | Default: box.NULL
+    | Environment variable: TT_PROCESS_WORK_DIR
+
 ..  _configuration_reference_replication:
 
 replication

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -2390,7 +2390,7 @@ The ``process`` defines configuration parameters of the Tarantool process in the
 
 -   :ref:`process.background <configuration_reference_process_background>`
 -   :ref:`process.coredump <configuration_reference_process_coredump>`
--   :ref:`process.custom_proc_title <configuration_reference_process_custom_proc_title>`
+-   :ref:`process.title <configuration_reference_process_title>`
 -   :ref:`process.pid_file <configuration_reference_process_pid_file>`
 -   :ref:`process.strip_core <configuration_reference_process_strip_core>`
 -   :ref:`process.username <configuration_reference_process_username>`
@@ -2423,9 +2423,9 @@ The ``process`` defines configuration parameters of the Tarantool process in the
     | Default: false
     | Environment variable: TT_PROCESS_COREDUMP
 
-.. _configuration_reference_process_custom_proc_title:
+.. _configuration_reference_process_title:
 
-.. confval:: process.custom_proc_title
+.. confval:: process.title
 
     Sets the name of the server's process title (what’s shown in the COMMAND column for
     ``ps -ef`` and ``top -c`` commands).
@@ -2433,7 +2433,7 @@ The ``process`` defines configuration parameters of the Tarantool process in the
     |
     | Type: string
     | Default: 'tarantool - {{ instance_name }}'
-    | Environment variable: TT_PROCESS_CUSTOM_PROC_TITLE
+    | Environment variable: TT_PROCESS_TITLE
 
 .. _configuration_reference_process_pid_file:
 

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -38,6 +38,19 @@ For more information about Tarantool application layout, see :ref:`admin-instanc
     which is considered a legacy approach since Tarantool 3.0. For information
     about using ``tt`` with such applications, refer to the Tarantool 2.11 documentation.
 
+Running in the background
+-------------------------
+
+``tt start`` runs Tarantool applications in the background and uses its own watchdog
+process for status checks (:ref:`tt-status`) and application stopping (:ref:`tt-stop`).
+
+.. important::
+
+    Do not switch the application to the background mode using the cluster configuration
+    (``process.background: true`` in the YAML configuration) or application code (``box.cfg.background = true``).
+    If you start such an application with ``tt start``, ``tt`` won't be able to check
+    the application status or stop it using the corresponding commands.
+
 Examples
 --------
 

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -42,12 +42,13 @@ Running in the background
 -------------------------
 
 ``tt start`` runs Tarantool applications in the background and uses its own watchdog
-process for status checks (:ref:`tt-status`) and application stopping (:ref:`tt-stop`).
+process for status checks (:ref:`tt status <tt-status>`) and application stopping (:ref:`tt stop <tt-stop>`).
 
 .. important::
 
-    Do not switch the application to the background mode using the cluster configuration
-    (``process.background: true`` in the YAML configuration) or application code (``box.cfg.background = true``).
+    Do not switch on the background mode using the cluster configuration
+    (``process.background: true`` in the YAML configuration) or code (``box.cfg.background = true``)
+    in applications that you run with ``tt``.
     If you start such an application with ``tt start``, ``tt`` won't be able to check
     the application status or stop it using the corresponding commands.
 


### PR DESCRIPTION
Resolves #4079
Related to #4014 

- Add a note that manual switch to background is prohibited on the [tt start page](https://docs.d.tarantool.io/en/doc/gh-4079-tt-start-background/reference/tooling/tt_cli/start/)
- Add a note with link to tt start page to [box.cfg.background reference](https://docs.d.tarantool.io/en/doc/gh-4079-tt-start-background/reference/configuration/#confval-background)
- Add [process.* config options reference](https://docs.d.tarantool.io/en/doc/gh-4079-tt-start-background/reference/configuration/configuration_reference/#process) with minimal (draft) descriptions
- Add a note with link to tt start page to [process.background config option reference](https://docs.d.tarantool.io/en/doc/gh-4079-tt-start-background/reference/configuration/configuration_reference/#confval-process.background)

Deployment: https://docs.d.tarantool.io/en/doc/gh-4079-tt-start-background/reference/tooling/tt_cli/start/