### PR TITLE
Add tt tdg2 import and export

### DIFF
--- a/doc/reference/tooling/tt_cli/commands.rst
+++ b/doc/reference/tooling/tt_cli/commands.rst
@@ -70,6 +70,8 @@ help for the given command.
             -   Get the current status of a Tarantool instance
         *   -   :doc:`stop <stop>`
             -   Stop a Tarantool instance
+        *   -   :doc:`tdg2 <tdg2>`
+            -   Interact with `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ clusters
         *   -   :doc:`uninstall <uninstall>`
             -   Uninstall Tarantool or ``tt``
         *   -   :doc:`version <version>`
@@ -107,5 +109,6 @@ help for the given command.
     start <start>
     status <status>
     stop <stop>
+    tdg2 <tdg2>
     uninstall <uninstall>
     version <version>

--- a/doc/reference/tooling/tt_cli/export.rst
+++ b/doc/reference/tooling/tt_cli/export.rst
@@ -16,8 +16,8 @@ Exporting data
 ``tt [crud|tdg2] export`` exports a space's data to a file. Three export commands
 cover the following cases:
 
-*   ``tt export`` exports data of a single-replicaset storage using the :ref:`box.space <box_space>` API.
-*   ``tt crud export`` exports data from a sharded cluster through СRUD router using the `CRUD <https://github.com/tarantool/crud>`_ module.
+*   ``tt export`` exports data from a cluster with a single replica set using the :ref:`box.space <box_space>` API.
+*   ``tt crud export`` exports data from a sharded cluster through a router using the `CRUD <https://github.com/tarantool/crud>`_ module.
 *   ``tt tdg2 export`` exports data from a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
     through its `connector <https://www.tarantool.io/ru/tdg/latest/architecture/#connector>`_ using `TDG2 Repository API <https://www.tarantool.io/en/tdg/latest/reference/sandbox/repository-api/#repository-api>`_.
 

--- a/doc/reference/tooling/tt_cli/export.rst
+++ b/doc/reference/tooling/tt_cli/export.rst
@@ -17,9 +17,9 @@ Exporting data
 cover the following cases:
 
 *   ``tt export`` exports data of a single-replicaset storage using the :ref:`box.space <box_space>` API.
-*   ``tt crud export`` exports data from a sharded cluster through its router using the `CRUD <https://github.com/tarantool/crud>`_ module.
+*   ``tt crud export`` exports data from a sharded cluster through СRUD router using the `CRUD <https://github.com/tarantool/crud>`_ module.
 *   ``tt tdg2 export`` exports data from a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
-    through its router.
+    through its `connector <https://www.tarantool.io/ru/tdg/latest/architecture/#connector>`_ using `TDG2 Repository API <https://www.tarantool.io/en/tdg/latest/reference/sandbox/repository-api/#repository-api>`_..
 
 ``tt [crud|tdg2] export`` takes the following arguments:
 

--- a/doc/reference/tooling/tt_cli/export.rst
+++ b/doc/reference/tooling/tt_cli/export.rst
@@ -19,7 +19,7 @@ cover the following cases:
 *   ``tt export`` exports data of a single-replicaset storage using the :ref:`box.space <box_space>` API.
 *   ``tt crud export`` exports data from a sharded cluster through СRUD router using the `CRUD <https://github.com/tarantool/crud>`_ module.
 *   ``tt tdg2 export`` exports data from a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
-    through its `connector <https://www.tarantool.io/ru/tdg/latest/architecture/#connector>`_ using `TDG2 Repository API <https://www.tarantool.io/en/tdg/latest/reference/sandbox/repository-api/#repository-api>`_..
+    through its `connector <https://www.tarantool.io/ru/tdg/latest/architecture/#connector>`_ using `TDG2 Repository API <https://www.tarantool.io/en/tdg/latest/reference/sandbox/repository-api/#repository-api>`_.
 
 ``tt [crud|tdg2] export`` takes the following arguments:
 

--- a/doc/reference/tooling/tt_cli/export.rst
+++ b/doc/reference/tooling/tt_cli/export.rst
@@ -81,7 +81,7 @@ If a tuple contains a ``null`` value, for example, ``[1, 477, 'Andrew', null, 38
 Exporting headers
 -----------------
 
-To export data with a space's field names in the first row, use the ``--header`` option:
+To export data with a space's field names in the first row of the CSV file, use the ``--header`` option:
 
 .. code-block:: console
 
@@ -104,9 +104,9 @@ In this case, field values start from the second row, for example:
 Exporting compound data
 -----------------------
 
-By default, ``tt`` exports empty values for fields containing compound data such as arrays or maps.
+In the CSV format, ``tt`` exports empty values by default for fields containing compound data such as arrays or maps.
 To export compound values in a specific format, use the ``--compound-value-format`` option.
-For example, the command below exports compound values serialized in JSON:
+For example, the command below exports compound values to CSV serialized in JSON:
 
 .. code-block:: console
 
@@ -132,7 +132,6 @@ If the ``customers`` space has four fields (``id``, ``firstname``, ``lastname``,
     {"age":30,"first_name":"Samantha","id":1,"second_name":"Carter"}
     {"age":41,"first_name":"Fay","id":2,"second_name":"Rivers"}
     {"age":74,"first_name":"Milo","id":4,"second_name":"Walters"}
-    # ...
 
 If a tuple contains a ``null`` value in a field, this field is not exported:
 
@@ -140,13 +139,13 @@ If a tuple contains a ``null`` value in a field, this field is not exported:
 
     {"age":13,"first_name":"Zachariah","id":3}
 
-Tuple fields that contain maps with non-string keys are converted maps with string keys:
+Tuple fields that contain maps with non-string keys are converted maps with string keys.
 
 
 TDG2 sets a limit on the number of tuples returned in result of a query execution
 in the `hard-limits.returned <https://www.tarantool.io/en/tdg/latest/reference/config/config_logic/#hard-limits>`_
 TDG2 configuration parameter.
-When exporting TDG2 data, make sure that the result tuples count does not exceed
+When exporting data from TDG2, make sure that the result tuples count does not exceed
 this limit and set the export batch size (``--batch-size`` parameter) accordingly.
 For example, if your TDG2 cluster has a 1000 tuples return limit:
 

--- a/doc/reference/tooling/tt_cli/export.rst
+++ b/doc/reference/tooling/tt_cli/export.rst
@@ -149,7 +149,7 @@ Object fields that contain maps with non-string keys are converted to maps with 
 TDG2 sets a limit on the number of objects transferred from each storage during a query execution
 (the `hard-limits.returned <https://www.tarantool.io/en/tdg/latest/reference/config/config_logic/#hard-limits>`_
 TDG2 configuration parameter). If an export batch size (``--batch-size`` parameter)
-is greater than this limit, it is possible that more than  ``hard-limits.returned`` objects
+is greater than this limit, it is possible that more than ``hard-limits.returned`` objects
 will be requested from one storage and export will fail.
 To make sure that ``hard-limits.returned`` is never exceeded during an export operation,
 set the export batch size less or equal to this limit.

--- a/doc/reference/tooling/tt_cli/export.rst
+++ b/doc/reference/tooling/tt_cli/export.rst
@@ -36,7 +36,7 @@ Without ``crud`` and ``tdg2``, the data is exported using the :ref:`box.space <b
 Output format
 -------------
 
-``tt export`` exports the data in the following formats:
+``tt export`` exports data in the following formats:
 
 *   ``tt export`` and ``tt crud export``: CSV
 *   ``tt tdg2 export``: JSON lines

--- a/doc/reference/tooling/tt_cli/export.rst
+++ b/doc/reference/tooling/tt_cli/export.rst
@@ -16,7 +16,7 @@ Exporting data
 ``tt [crud|tdg2] export`` exports a space's data to a file. Three export commands
 cover the following cases:
 
-*   ``tt export`` exports data from a cluster with a single replica set using the :ref:`box.space <box_space>` API.
+*   ``tt export`` exports data from a replica set using the :ref:`box.space <box_space>` API.
 *   ``tt crud export`` exports data from a sharded cluster through a router using the `CRUD <https://github.com/tarantool/crud>`_ module.
 *   ``tt tdg2 export`` exports data from a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
     through its `connector <https://www.tarantool.io/ru/tdg/latest/architecture/#connector>`_ using `TDG2 Repository API <https://www.tarantool.io/en/tdg/latest/reference/sandbox/repository-api/#repository-api>`_.

--- a/doc/reference/tooling/tt_cli/export.rst
+++ b/doc/reference/tooling/tt_cli/export.rst
@@ -184,7 +184,7 @@ Options
 
     .. important::
 
-        When using ``tt tdg2 export``, make sure that te batch size does not exceed
+        When using ``tt tdg2 export``, make sure that the batch size does not exceed
         the ``hard-limits.returned`` TDG2 parameter value set on the cluster.
 
 ..  option:: --compound-value-format STRING

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -19,7 +19,7 @@ Importing data
 The ``crud`` and ``tdg2`` commands are optional and cover specific import cases:
 
 *   ``tt crud import`` uses the `CRUD <https://github.com/tarantool/crud>`_ module to import data into a cluster.
-*   ``tt tdg2 export`` imports data into a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
+*   ``tt tdg2 import`` imports data into a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
     using the ``repository.put`` function of the TDG2 `repository API <https://www.tarantool.io/en/tdg/latest/reference/sandbox/repository-api/#repository-api>`_.
 
 Without ``crud`` and ``tdg2``, the data is imported using the :ref:`box.space <box_space>` API.
@@ -41,8 +41,8 @@ Input file format
 
 ``tt import`` imports data from the following formats:
 
-*   ``tt export`` and ``tt crud export``: CSV
-*   ``tt tdg2 export``: JSON lines
+*   ``tt import`` and ``tt crud import``: CSV
+*   ``tt tdg2 import``: JSON lines
 
 .. _tt-import-limitations:
 

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -18,8 +18,8 @@ Importing data
 ``tt [crud|tdg] import`` imports data from a file to a space. Three import commands
 cover the following cases:
 
-*   ``tt import`` imports data into a single-replicaset storage through its master instance using the :ref:`box.space <box_space>` API.
-*   ``tt crud import`` imports data into a sharded cluster through CRUD router using the `CRUD <https://github.com/tarantool/crud>`_ module.
+*   ``tt import`` imports data into a cluster with a single replica set through its master instance using the :ref:`box.space <box_space>` API.
+*   ``tt crud import`` imports data into a sharded cluster through a router using the `CRUD <https://github.com/tarantool/crud>`_ module.
 *   ``tt tdg2 import`` imports data into a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
     through its router using the ``repository.put`` function of the `TDG2 Repository API <https://www.tarantool.io/en/tdg/latest/reference/sandbox/repository-api/#repository-api>`_.
 

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -180,7 +180,7 @@ The input file can look like this:
 
 In case of an error during TDG2 import, ``tt tdg2 import`` rolls back the changes made
 *within the current batch* on the *storage where the error has happened* (per-storage rollback)
-and reports an error. On other storages, objects from the same batch can be succesfully
+and reports an error. On other storages, objects from the same batch can be successfully
 imported. So, the rollback process of ``tt tdg2 import``
 is the same as the one of ``tt crud import`` with the ``--rollback-on-error`` option.
 
@@ -197,7 +197,7 @@ To automatically confirm a batch import operation, add the ``--force`` option:
 .. code-block:: console
 
     $ tt tdg2 import localhost:3301 customers.jsonl:customers \
-                     --batch-size=100
+                     --batch-size=100 \
                      --force
 
 

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -18,7 +18,7 @@ Importing data
 ``tt [crud|tdg] import`` imports data from a file to a space. Three import commands
 cover the following cases:
 
-*   ``tt import`` imports data into a cluster with a single replica set through its master instance using the :ref:`box.space <box_space>` API.
+*   ``tt import`` imports data into a replica set through its master instance using the :ref:`box.space <box_space>` API.
 *   ``tt crud import`` imports data into a sharded cluster through a router using the `CRUD <https://github.com/tarantool/crud>`_ module.
 *   ``tt tdg2 import`` imports data into a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
     through its router using the ``repository.put`` function of the `TDG2 Repository API <https://www.tarantool.io/en/tdg/latest/reference/sandbox/repository-api/#repository-api>`_.

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -19,7 +19,7 @@ Importing data
 cover the following cases:
 
 *   ``tt import`` imports data into a single-replicaset storage through its master instance using the :ref:`box.space <box_space>` API.
-*   ``tt crud import`` imports data into a sharded cluster through its router using the `CRUD <https://github.com/tarantool/crud>`_ module.
+*   ``tt crud import`` imports data into a sharded cluster through CRUD router using the `CRUD <https://github.com/tarantool/crud>`_ module.
 *   ``tt tdg2 import`` imports data into a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
     through its router using the ``repository.put`` function of the `TDG2 Repository API <https://www.tarantool.io/en/tdg/latest/reference/sandbox/repository-api/#repository-api>`_.
 

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -36,10 +36,10 @@ Without ``crud`` and ``tdg2``, the data is imported using the :ref:`box.space <b
 
 .. _tt-import-format:
 
-Import file format
-------------------
+Input file format
+-----------------
 
-``tt import`` imports the data from the following formats:
+``tt import`` imports data from the following formats:
 
 *   ``tt export`` and ``tt crud export``: CSV
 *   ``tt tdg2 export``: JSON lines
@@ -177,11 +177,12 @@ The input file can look like this:
 If an error happens during TDG2 import, the all the changes made within the current batch
 are rolled back. The rollback process is the same as in ``tt crud import`` with the ``--rollback-on-error`` option.
 
-
-TDG2 and the ``tt tdg2 import`` implementation do not match errors to specific tuples
-wh
-batching: e--batch-siz is 1
-            -- force to skip warning and continue
+Batch rollback prevents the import of correct tuples that fall in a batch with errors in data,
+and complicates debugging due to the abscence of error matching. To minimize this
+effect, the default batch size (``--batch-size)``for ``tt tdg2 import`` is 1.
+If you increase the batch size, ``tt`` informs you about the possible issues and
+asks for an explicit confirmation to proceed.
+To automatically confirm a batch import operation, add the ``--force`` option:
 
 .. code-block:: console
 

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -375,7 +375,8 @@ Options
 
     **Applicable to:** ``tt crud import``
 
-    Specify whether any operation failed on a router leads to rollback on a storage where the operation is failed.
+    Specify whether any operation failed on a storage leads to rollback of a batch
+    import on this storage.
 
     .. note::
 

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -16,7 +16,7 @@ Importing data
     $ tt [crud|tdg2] import URI :SPACE < FILE [IMPORT_OPTION ...]
 
 ``tt import`` imports data from a file to a space.
-The ``crud`` and ``tdg2`` commands are optional and cover specific export cases:
+The ``crud`` and ``tdg2`` commands are optional and cover specific import cases:
 
 *   ``tt crud import`` uses the `CRUD <https://github.com/tarantool/crud>`_ module to import data into a cluster.
 *   ``tt tdg2 export`` imports data into a `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ cluster
@@ -179,7 +179,7 @@ are rolled back. The rollback process is the same as in ``tt crud import`` with 
 
 Batch rollback prevents the import of correct tuples that fall in a batch with errors in data,
 and complicates debugging due to the abscence of error matching. To minimize this
-effect, the default batch size (``--batch-size)``for ``tt tdg2 import`` is 1.
+effect, the default batch size (``--batch-size``) for ``tt tdg2 import`` is 1.
 If you increase the batch size, ``tt`` informs you about the possible issues and
 asks for an explicit confirmation to proceed.
 To automatically confirm a batch import operation, add the ``--force`` option:

--- a/doc/reference/tooling/tt_cli/tdg2.rst
+++ b/doc/reference/tooling/tt_cli/tdg2.rst
@@ -1,0 +1,19 @@
+.. _tt-tdg2:
+
+Interacting with the Tarantool Data Grid 2
+==========================================
+
+..  admonition:: Enterprise Edition
+    :class: fact
+
+    This command is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
+
+..  code-block:: console
+
+    $ tt tdg2 COMMAND [COMMAND_OPTION ...]
+
+``tt tdg2`` enables the interaction with `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ clusters.
+``COMMAND`` is one of the following:
+
+*   ``export``: export a TDG2 cluster's data to a file. Learn more at :ref:`Exporting data <tt-export>`.
+*   ``import``: import data to a TDG2 cluster from a file. Learn more at :ref:`Importing data <tt-import>`.


### PR DESCRIPTION
Resolves #4145 

- Add new reference page [tt tdg2](https://docs.d.tarantool.io/en/doc/gh-4145-tt-tdg2/reference/tooling/tt_cli/tdg2/)
- Add tt tdg2 subcommand to [tt import](https://docs.d.tarantool.io/en/doc/gh-4145-tt-tdg2/reference/tooling/tt_cli/import/) page:
  - add tdg2 to synopsys
  - add new subsection for TDG2 import specifics
  - add new options --batch-size and --force
  - Clarify the difference between `tt import`, `tt crud import`, and `tt tdg2 import` in the intro
  - Fix the description of `--rollback-on-error`
- Add tt tdg2 subcommand to [tt export](https://docs.d.tarantool.io/en/doc/gh-4145-tt-tdg2/reference/tooling/tt_cli/export/) page:
  - add tdg2 to synopsys
  - add new subsection for TDG2 export specifics
  - Clarify the difference between `tt export`, `tt crud export`, and `tt tdg2 export` in the intro
- Add tt tdg2 to [tt commands](https://docs.d.tarantool.io/en/doc/gh-4145-tt-tdg2/reference/tooling/tt_cli/commands/) table

Deployment: https://docs.d.tarantool.io/en/doc/gh-4145-tt-tdg2/reference/tooling/tt_cli/tdg2/