### PR TITLE
Add tt replicaset status reference

### DIFF
--- a/doc/reference/tooling/tt_cli/commands.rst
+++ b/doc/reference/tooling/tt_cli/commands.rst
@@ -56,6 +56,8 @@ help for the given command.
             -   Package an application
         *   -   :doc:`play <play>`
             -   Play the contents of ``.snap`` or ``.xlog`` files to another Tarantool instance
+        *   -   :doc:`replicaset <replicaset>`
+            -   Manage a replica set
         *   -   :doc:`restart <restart>`
             -   Restart a Tarantool instance
         *   -   :doc:`rocks <rocks>`
@@ -100,6 +102,7 @@ help for the given command.
     logrotate <logrotate>
     pack <pack>
     play <play>
+    replicaset <replicaset>
     restart <restart>
     rocks <rocks>
     run <run>

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -1,0 +1,176 @@
+.. _tt-replicaset:
+
+Working with replicasets
+=========================
+
+..  code-block:: console
+
+    $ tt replicaset COMMAND {[OPTION ...]|SUBCOMMAND}
+    # or
+    $ tt rs COMMAND {[OPTION ...]|SUBCOMMAND}
+
+``tt replicaset`` (or ``tt rs``) manages a Tarantool replica set.
+
+``COMMAND`` is one of the following:
+
+*   :ref:`status <tt-replicaset-status>`
+*   :ref:`promote <tt-replicaset-promote>`
+*   :ref:`demote <tt-replicaset-demote>`
+
+
+.. _tt-replicaset-status:
+
+status
+------
+
+..  code-block:: console
+
+    $ tt replicaset status {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
+    # or
+    $ tt rs status  {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
+
+``tt replicaset status`` (``tt rs status``) shows the current status of a replica set.
+
+
+.. _tt-replicaset-status-application:
+
+Displaying status of all replica sets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To view the status of all replica sets of an application in the current ``tt``
+environment, run ``tt replicaset status`` with the application name:
+
+..  code-block:: console
+
+    $ tt replicaset status myapp
+
+.. _tt-replicaset-status-instance:
+
+Displaying status of a single replica set
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To view the status of a single replica set of an application , run ``tt replicaset status``
+with a name or a URI of an instance from this replica set:
+
+..  code-block:: console
+
+    $ tt replicaset status myapp:storage-001-a
+
+..  code-block:: console
+
+    $ tt replicaset status myapp:storage-001-a
+
+.. _tt-replicaset-status-authentication:
+
+Authentication
+~~~~~~~~~~~~~~
+
+Use one of the following ways to pass the username and the password when connecting
+to the instance:
+
+*   The ``-u`` (``--username``) and ``-p`` (``--password``) options:
+
+    ..  code-block:: console
+
+        $ tt replicaset status 192.168.10.10:3301 -u myuser -p p4$$w0rD
+
+*   The connection string:
+
+    ..  code-block:: console
+
+        $ tt replicaset status myuser:p4$$w0rD@192.168.10.10:3301
+
+*   Environment variables ``TT_CLI_USERNAME`` and ``TT_CLI_PASSWORD``:
+
+    ..  code-block:: console
+
+        $ export TT_CLI_USERNAME=myuser
+        $ export TT_CLI_PASSWORD=p4$$w0rD
+        $ tt replicaset status 192.168.10.10:3301
+
+.. _tt-replicaset-status-force:
+
+Selecting the application orchestrator manually
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can specify the orchestrator to use for the application using the following options:
+
+*   ``--config`` for applications that use YAML cluster configuration (Tarantool 3.x or later).
+*   ``--cartridge`` for Cartridge applications (Tarantool 2.x).
+*   ``--custom`` for any other orchestrators used on Tarantool 2.x clusters.
+
+If an actual orchestrator that the application uses does not match the specified
+option, an error is raised.
+
+..  code-block:: console
+
+    $ tt replicaset status myapp --config
+    $ tt replicaset status my-cartridge-app --cartridge
+
+
+.. _tt-replicaset-status-options:
+
+Options
+~~~~~~~
+
+..  option:: --cartridge
+
+    Force the Cartridge orchestrator.
+
+..  option:: --config
+
+    Force the centralized config orchestrator.
+
+..  option:: --custom
+
+    Force a custom orchestrator.
+
+..  option:: -u USERNAME, --username USERNAME
+
+    A Tarantool user for connecting to the instance.
+
+..  option:: -p PASSWORD, --password PASSWORD
+
+    The user's password.
+
+..  option:: --sslcertfile FILEPATH
+
+    The path to an SSL certificate file for encrypted connections.
+
+..  option:: --sslkeyfile FILEPATH
+
+    The path to a private SSL key file for encrypted connections.
+
+..  option:: --sslcafile FILEPATH
+
+    The path to a trusted certificate authorities (CA) file for encrypted connections.
+
+..  option:: --sslciphers STRING
+
+    The list of SSL cipher suites used for encrypted connections, separated by colons (``:``).
+
+--sslcafile string path to a trusted certificate authorities (CA)
+file for the URI case
+--sslcertfile string path to an SSL certificate file for the URI
+case
+--sslciphers string colon-separated (:) list of SSL cipher suites
+the replicasetion for the URI case
+--sslkeyfile string path to a private SSL key file the URI case
+
+
+.. _tt-replicaset-promote:
+
+promote
+-------
+
+``tt replicaset promote`` (``tt rs promote``) promotes an instance.
+
+.. _tt-replicaset-demote:
+
+demote
+------
+
+``tt replicaset deomote`` (``tt rs demote``) demotes an instance.
+
+
+

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -49,7 +49,7 @@ environment, run ``tt replicaset status`` with the application name:
 Displaying status of a single replica set
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To view the status of a single replica set of an application , run ``tt replicaset status``
+To view the status of a single replica set of an application, run ``tt replicaset status``
 with a name or a URI of an instance from this replica set:
 
 ..  code-block:: console
@@ -161,7 +161,7 @@ promote
 demote
 ------
 
-``tt replicaset deomote`` (``tt rs demote``) demotes an instance.
+``tt replicaset demote`` (``tt rs demote``) demotes an instance.
 
 
 

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -56,9 +56,13 @@ with a name or a URI of an instance from this replica set:
 
     $ tt replicaset status myapp:storage-001-a
 
+For a replica outside the current ``tt`` environment, specify its URI and access credentials:
+
 ..  code-block:: console
 
-    $ tt replicaset status 192.168.10.10:3301
+    $ tt replicaset status 192.168.10.10:3301 -u myuser -p p4$$w0rD
+
+Learn about other ways to provide user credentials in :ref:`tt-replicaset-status-authentication`.
 
 .. _tt-replicaset-status-authentication:
 

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -5,9 +5,9 @@ Working with replicasets
 
 ..  code-block:: console
 
-    $ tt replicaset COMMAND {[OPTION ...]|SUBCOMMAND}
+    $ tt replicaset COMMAND {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
     # or
-    $ tt rs COMMAND {[OPTION ...]|SUBCOMMAND}
+    $ tt rs COMMAND {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
 
 ``tt replicaset`` (or ``tt rs``) manages a Tarantool replica set.
 
@@ -58,7 +58,7 @@ with a name or a URI of an instance from this replica set:
 
 ..  code-block:: console
 
-    $ tt replicaset status myapp:storage-001-a
+    $ tt replicaset status 192.168.10.10:3301
 
 .. _tt-replicaset-status-authentication:
 
@@ -99,13 +99,13 @@ You can specify the orchestrator to use for the application using the following 
 *   ``--cartridge`` for Cartridge applications (Tarantool 2.x).
 *   ``--custom`` for any other orchestrators used on Tarantool 2.x clusters.
 
-If an actual orchestrator that the application uses does not match the specified
-option, an error is raised.
-
 ..  code-block:: console
 
     $ tt replicaset status myapp --config
     $ tt replicaset status my-cartridge-app --cartridge
+
+If an actual orchestrator that the application uses does not match the specified
+option, an error is raised.
 
 
 .. _tt-replicaset-status-options:
@@ -115,15 +115,15 @@ Options
 
 ..  option:: --cartridge
 
-    Force the Cartridge orchestrator.
+    Force the Cartridge orchestrator for Tarantool 2.x clusters.
 
 ..  option:: --config
 
-    Force the centralized config orchestrator.
+    Force the YAML configuration orchestrator for Tarantool 3.0 or later clusters.
 
 ..  option:: --custom
 
-    Force a custom orchestrator.
+    Force a custom orchestrator for Tarantool 2.x clusters.
 
 ..  option:: -u USERNAME, --username USERNAME
 
@@ -148,15 +148,6 @@ Options
 ..  option:: --sslciphers STRING
 
     The list of SSL cipher suites used for encrypted connections, separated by colons (``:``).
-
---sslcafile string path to a trusted certificate authorities (CA)
-file for the URI case
---sslcertfile string path to an SSL certificate file for the URI
-case
---sslciphers string colon-separated (:) list of SSL cipher suites
-the replicasetion for the URI case
---sslkeyfile string path to a private SSL key file the URI case
-
 
 .. _tt-replicaset-promote:
 

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -69,8 +69,8 @@ Learn about other ways to provide user credentials in :ref:`tt-replicaset-status
 Authentication
 ~~~~~~~~~~~~~~
 
-Use one of the following ways to pass the username and the password when connecting
-to the instance:
+Use one of the following ways to pass the credentials of a Tarantool user when
+connecting to the instance:
 
 *   The ``-u`` (``--username``) and ``-p`` (``--password``) options:
 


### PR DESCRIPTION
Resolves #3966

- Add new reference page [tt replicaset](https://docs.d.tarantool.io/en/doc/gh-3966-tt-replicaset/reference/tooling/tt_cli/replicaset/)
- Describe ``tt replicaset status``
- Add placeholder subsections for ``tt promote`` and ``tt demote``
- Add tt replicaset to [the list of tt commands](https://docs.d.tarantool.io/en/doc/gh-3966-tt-replicaset/reference/tooling/tt_cli/commands/)

Deployment: https://docs.d.tarantool.io/en/doc/gh-3966-tt-replicaset/reference/tooling/tt_cli/replicaset/
