### PR TITLE
Update the Get Started tutorial for Go connector

### DIFF
--- a/doc/code_snippets/snippets/connectors/go/README.md
+++ b/doc/code_snippets/snippets/connectors/go/README.md
@@ -1,0 +1,14 @@
+# Go
+
+A sample application containing requests from the [Connecting from Go](https://www.tarantool.io/en/doc/latest/how-to/getting_started_go) tutorial.
+
+
+## Running
+
+Before running this sample, start an application that allows remote connections to a sample database: [sample_db](../instances.enabled/sample_db).
+
+Then, start this sample by executing the following command in the `go` directory:
+
+```
+$ go run .
+```

--- a/doc/code_snippets/snippets/connectors/go/go.mod
+++ b/doc/code_snippets/snippets/connectors/go/go.mod
@@ -1,0 +1,10 @@
+module example/hello
+
+go 1.22.3
+
+require (
+        github.com/tarantool/go-iproto v1.0.0 // indirect
+        github.com/tarantool/go-tarantool/v2 v2.1.0 // indirect
+        github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
+        github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+)

--- a/doc/code_snippets/snippets/connectors/go/go.mod
+++ b/doc/code_snippets/snippets/connectors/go/go.mod
@@ -3,8 +3,10 @@ module example/hello
 go 1.22.3
 
 require (
-        github.com/tarantool/go-iproto v1.0.0 // indirect
-        github.com/tarantool/go-tarantool/v2 v2.1.0 // indirect
-        github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
-        github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/shopspring/decimal v1.3.1 // indirect
+	github.com/tarantool/go-iproto v1.0.0 // indirect
+	github.com/tarantool/go-tarantool/v2 v2.1.0 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 )

--- a/doc/code_snippets/snippets/connectors/go/go.sum
+++ b/doc/code_snippets/snippets/connectors/go/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tarantool/go-iproto v1.0.0 h1:quC4hdFhCuFYaCqOFgUxH2foRkhAy+TlEy7gQLhdVjw=
+github.com/tarantool/go-iproto v1.0.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
+github.com/tarantool/go-tarantool/v2 v2.1.0 h1:IY33WoS8Kqb+TxNnKbzu/7yVkiCNZGhbG5Gw0/tMfSk=
+github.com/tarantool/go-tarantool/v2 v2.1.0/go.mod h1:cpjGW5FHAXIMf0PKZte70pMOeadw1MA/hrDv1LblWk4=
+github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
+github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/doc/code_snippets/snippets/connectors/go/go.sum
+++ b/doc/code_snippets/snippets/connectors/go/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tarantool/go-iproto v1.0.0 h1:quC4hdFhCuFYaCqOFgUxH2foRkhAy+TlEy7gQLhdVjw=

--- a/doc/code_snippets/snippets/connectors/go/hello.go
+++ b/doc/code_snippets/snippets/connectors/go/hello.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/tarantool/go-tarantool/v2"
+	"time"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	dialer := tarantool.NetDialer{
+		Address:  "127.0.0.1:3301",
+		User:     "sampleuser",
+		Password: "123456",
+	}
+	opts := tarantool.Opts{
+		Timeout: time.Second,
+	}
+
+	conn, err := tarantool.Connect(ctx, dialer, opts)
+	if err != nil {
+		fmt.Println("Connection refused:", err)
+		return
+	}
+
+	// Interacting with the database
+	// Insert data
+	tuple1, err := conn.Do(
+		tarantool.NewInsertRequest("bands").
+			Tuple([]interface{}{1, "Roxette", 1986}),
+	).Get()
+	tuple2, err := conn.Do(
+		tarantool.NewInsertRequest("bands").
+			Tuple([]interface{}{2, "Scorpions", 1965}),
+	).Get()
+	tuple3, err := conn.Do(
+		tarantool.NewInsertRequest("bands").
+			Tuple([]interface{}{3, "Ace of Base", 1987}),
+	).Get()
+	tuple4, err := conn.Do(
+		tarantool.NewInsertRequest("bands").
+			Tuple([]interface{}{4, "The Beatles", 1960}),
+	).Get()
+	fmt.Println("Inserted tuples: ", tuple1, tuple2, tuple3, tuple4)
+
+	// Select by primary key
+	data, err := conn.Do(
+		tarantool.NewSelectRequest("bands").
+			Limit(10).
+			Iterator(tarantool.IterEq).
+			Key([]interface{}{uint(1)}),
+	).Get()
+	fmt.Println("Tuple selected the primary key value:", data)
+
+	// Select by secondary key
+	data, err = conn.Do(
+		tarantool.NewSelectRequest("bands").
+			Index("band").
+			Limit(10).
+			Iterator(tarantool.IterEq).
+			Key([]interface{}{"The Beatles"}),
+	).Get()
+	fmt.Println("Tuple selected the secondary key value:", data)
+
+	// Update
+	data, err = conn.Do(
+		tarantool.NewUpdateRequest("bands").
+			Key(tarantool.IntKey{2}).
+			Operations(tarantool.NewOperations().Assign(1, "Pink Floyd")),
+	).Get()
+	fmt.Println("Updated tuple:", data)
+
+	// Upsert
+	data, err = conn.Do(
+		tarantool.NewUpsertRequest("bands").
+			Tuple([]interface{}{uint(5), "The Rolling Stones", 1962}).
+			Operations(tarantool.NewOperations().Assign(1, "The Doors")),
+	).Get()
+
+	// Replace
+	data, err = conn.Do(
+		tarantool.NewReplaceRequest("bands").
+			Tuple([]interface{}{1, "Queen", 1970}),
+	).Get()
+	fmt.Println("Replaced tuple:", data)
+
+	// Delete
+	data, err = conn.Do(
+		tarantool.NewDeleteRequest("bands").
+			Key([]interface{}{uint(5)}),
+	).Get()
+	fmt.Println("Deleted tuple:", data)
+
+	// Call
+	data, err = conn.Do(
+		tarantool.NewCallRequest("get_bands_older_than").Args([]interface{}{1966}),
+	).Get()
+	fmt.Println("Stored procedure result:", data)
+
+	// Close connection
+	conn.CloseGraceful()
+	fmt.Println("Connection is closed")
+}

--- a/doc/code_snippets/snippets/connectors/go/hello.go
+++ b/doc/code_snippets/snippets/connectors/go/hello.go
@@ -11,6 +11,7 @@ import (
 )
 
 func main() {
+	// Connect to the database
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	dialer := tarantool.NetDialer{
@@ -28,7 +29,8 @@ func main() {
 		return
 	}
 
-	// Interacting with the database
+	// Interact with the database
+	// ...
 	// Insert data
 	tuples := [][]interface{}{
 		{1, "Roxette", 1986},
@@ -61,7 +63,7 @@ func main() {
 	if err != nil {
 		fmt.Println("Got an error:", err)
 	}
-	fmt.Println("Tuple selected the primary key value:", data)
+	fmt.Println("Tuple selected by the primary key value:", data)
 
 	// Select by secondary key
 	data, err = conn.Do(
@@ -74,7 +76,7 @@ func main() {
 	if err != nil {
 		fmt.Println("Got an error:", err)
 	}
-	fmt.Println("Tuple selected the secondary key value:", data)
+	fmt.Println("Tuple selected by the secondary key value:", data)
 
 	// Update
 	data, err = conn.Do(

--- a/doc/how-to/getting_started_go.rst
+++ b/doc/how-to/getting_started_go.rst
@@ -5,7 +5,7 @@ Connecting from Go
 
 **Examples on GitHub**: `sample_db <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/connectors/instances.enabled/sample_db>`_, `go <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/connectors/go>`_
 
-The tutorial shows how to use the 2.x version of the `go-tarantool <https://github.com/tarantool/go-tarantool>`__ library to create a Go application that connects to a remote Tarantool instance, performs CRUD operations, and executes a stored procedure.
+The tutorial shows how to use the `go-tarantool <https://github.com/tarantool/go-tarantool>`__ 2.x library to create a Go application that connects to a remote Tarantool instance, performs CRUD operations, and executes a stored procedure.
 You can find the full package documentation here: `Client in Go for Tarantool <https://pkg.go.dev/github.com/tarantool/go-tarantool/v2>`__.
 
 
@@ -24,7 +24,7 @@ Sample database configuration
 Starting a sample database application
 --------------------------------------
 
-Before creating and starting a client Go application, you need to run the :ref:`sample_db <getting_started_net_box_sample_db>` application using ``tt start``:
+Before creating and starting a client Go application, you need to run the :ref:`sample_db <getting_started_net_box_sample_db>` application using :ref:`tt start <tt-start>`:
 
 .. code-block:: console
 
@@ -94,8 +94,8 @@ Connecting to the database
 
     ..  literalinclude:: /code_snippets/snippets/connectors/go/hello.go
         :language: go
-        :start-after: func main()
-        :end-at: // Interacting with the database
+        :start-at: // Connect to the database
+        :end-before: // Insert data
         :dedent:
 
     This code establishes a connection to a running Tarantool instance on behalf of ``sampleuser``.
@@ -103,10 +103,10 @@ Connecting to the database
 
 
 
-.. _getting_started_go_using_data_operations:
+.. _getting_started_go_manipulating_data:
 
-Using data operations
-~~~~~~~~~~~~~~~~~~~~~
+Manipulating data
+~~~~~~~~~~~~~~~~~
 
 .. _getting_started_go_inserting_data:
 
@@ -142,7 +142,7 @@ To get a tuple by the specified primary key value, use ``NewSelectRequest()`` to
 ..  literalinclude:: /code_snippets/snippets/connectors/go/hello.go
     :language: go
     :start-at: // Select by primary key
-    :end-at: Tuple selected the primary key value
+    :end-at: Tuple selected by the primary key value
     :dedent:
 
 You can also get a tuple by the value of the specified index by using ``Index()``:
@@ -150,7 +150,7 @@ You can also get a tuple by the value of the specified index by using ``Index()`
 ..  literalinclude:: /code_snippets/snippets/connectors/go/hello.go
     :language: go
     :start-at: // Select by secondary key
-    :end-at: Tuple selected the secondary key value
+    :end-at: Tuple selected by the secondary key value
     :dedent:
 
 
@@ -260,8 +260,8 @@ Starting a client application
         [[2 Scorpions 1965]]
         [[3 Ace of Base 1987]]
         [[4 The Beatles 1960]]
-        Tuple selected the primary key value: [[1 Roxette 1986]]
-        Tuple selected the secondary key value: [[4 The Beatles 1960]]
+        Tuple selected by the primary key value: [[1 Roxette 1986]]
+        Tuple selected by the secondary key value: [[4 The Beatles 1960]]
         Updated tuple: [[2 Pink Floyd 1965]]
         Replaced tuple: [[1 Queen 1970]]
         Deleted tuple: [[5 The Rolling Stones 1962]]
@@ -272,8 +272,8 @@ Starting a client application
 
 .. _getting_started-go-comparison:
 
-Feature comparison
-------------------
+Go connectors feature comparison
+--------------------------------
 
 There are two more connectors from the open-source community:
 

--- a/doc/how-to/getting_started_go.rst
+++ b/doc/how-to/getting_started_go.rst
@@ -38,6 +38,8 @@ Now you can create a client Go application that makes requests to this database.
 Developing a client application
 -------------------------------
 
+Before you start, make sure you have `Go installed <https://go.dev/doc/install>`__ on your computer.
+
 .. _getting_started_go_create_client_app:
 
 Creating an application
@@ -61,8 +63,8 @@ Creating an application
 
 .. _getting_started_go_import_:
 
-Importing 'go-tarantool'
-~~~~~~~~~~~~~~~~~~~~~~~~
+Importing 'go-tarantool' packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the ``hello.go`` file, declare a ``main`` package and import the following packages:
 
@@ -72,11 +74,13 @@ In the ``hello.go`` file, declare a ``main`` package and import the following pa
     :end-before: func main()
     :dedent:
 
+The packages for external MsgPack types, such as ``datetime``, ``decimal``, or ``uuid``, are required to parse these types in a response.
+
 
 .. _getting_started_go_creating_connection:
 
-Creating a connection
-~~~~~~~~~~~~~~~~~~~~~
+Connecting to the database
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1.  Declare the ``main()`` function:
 
@@ -114,11 +118,18 @@ Add the following code to insert four tuples into the ``bands`` space:
 ..  literalinclude:: /code_snippets/snippets/connectors/go/hello.go
     :language: go
     :start-at: // Insert data
-    :end-at: Inserted tuples:
+    :end-before: // Select by primary key
     :dedent:
 
-The ``NewInsertRequest()`` method creates an insert request object that is executed by the connection.
+This code makes insert requests asynchronously:
 
+-   The ``Future`` structure is used as a handle for asynchronous requests.
+-   The ``NewInsertRequest()`` method creates an insert request object that is executed by the connection.
+
+..  NOTE::
+
+    Making requests asynchronously is the recommended way to perform data operations.
+    Further requests in this tutorial are made synchronously.
 
 
 .. _getting_started_go_querying_data:
@@ -157,7 +168,7 @@ Updating data
     :end-at: Updated tuple
     :dedent:
 
-``NewUpsertRequest()`` can be used to update an existing tuple or inserts a new one.
+``NewUpsertRequest()`` can be used to update an existing tuple or insert a new one.
 In the example below, a new tuple is inserted:
 
 ..  literalinclude:: /code_snippets/snippets/connectors/go/hello.go
@@ -231,18 +242,24 @@ The ``CloseGraceful()`` method can be used to close the connection when it is no
 Starting a client application
 -----------------------------
 
-1.  Execute the ``go get`` command to update dependencies in the ``go.mod`` file:
+1.  Execute the following ``go get`` commands to update dependencies in the ``go.mod`` file:
 
     .. code-block:: console
 
         $ go get github.com/tarantool/go-tarantool/v2
+        $ go get github.com/tarantool/go-tarantool/v2/decimal
+        $ go get github.com/tarantool/go-tarantool/v2/uuid
 
 2.  To run the resulting application, execute the ``go run`` command in the application directory:
 
     .. code-block:: console
 
         $ go run .
-        Inserted tuples:  [[1 Roxette 1986]] [[2 Scorpions 1965]] [[3 Ace of Base 1987]] [[4 The Beatles 1960]]
+        Inserted tuples:
+        [[1 Roxette 1986]]
+        [[2 Scorpions 1965]]
+        [[3 Ace of Base 1987]]
+        [[4 The Beatles 1960]]
         Tuple selected the primary key value: [[1 Roxette 1986]]
         Tuple selected the secondary key value: [[4 The Beatles 1960]]
         Updated tuple: [[2 Pink Floyd 1965]]
@@ -258,7 +275,7 @@ Starting a client application
 Feature comparison
 ------------------
 
-There are two more connectors from the open source community:
+There are two more connectors from the open-source community:
 
 *   `viciious/go-tarantool <https://github.com/viciious/go-tarantool>`_
 

--- a/doc/how-to/getting_started_net_box.rst
+++ b/doc/how-to/getting_started_net_box.rst
@@ -14,6 +14,8 @@ For more information about the ``net.box`` module API, check :ref:`net_box-modul
 Sample database configuration
 -----------------------------
 
+.. connectors_sample_db_config_start
+
 This section describes the :ref:`configuration <configuration_file>` of a sample database that allows remote connections:
 
 ..  literalinclude:: /code_snippets/snippets/connectors/instances.enabled/sample_db/config.yaml
@@ -31,6 +33,8 @@ The ``myapp.lua`` file looks as follows:
     :dedent:
 
 You can find the full example on GitHub: `sample_db <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/connectors/instances.enabled/sample_db>`_.
+
+.. connectors_sample_db_config_end
 
 
 

--- a/doc/how-to/getting_started_net_box.rst
+++ b/doc/how-to/getting_started_net_box.rst
@@ -22,7 +22,7 @@ This section describes the :ref:`configuration <configuration_file>` of a sample
     :language: yaml
     :dedent:
 
--   The configuration contains one instance that listens incoming requests on the ``127.0.0.1:3301`` address.
+-   The configuration contains one instance that listens for incoming requests on the ``127.0.0.1:3301`` address.
 -   ``sampleuser`` has :ref:`privileges <authentication-owners_privileges>` to select and modify data in the ``bands`` space and execute the ``get_bands_older_than`` stored function. This user can be used to connect to the instance remotely.
 -   ``myapp.lua`` defines how data is stored in a database and includes a stored function.
 

--- a/doc/how-to/getting_started_net_box.rst
+++ b/doc/how-to/getting_started_net_box.rst
@@ -24,7 +24,7 @@ This section describes the :ref:`configuration <configuration_file>` of a sample
 
 -   The configuration contains one instance that listens for incoming requests on the ``127.0.0.1:3301`` address.
 -   ``sampleuser`` has :ref:`privileges <authentication-owners_privileges>` to select and modify data in the ``bands`` space and execute the ``get_bands_older_than`` stored function. This user can be used to connect to the instance remotely.
--   ``myapp.lua`` defines how data is stored in a database and includes a stored function.
+-   ``myapp.lua`` defines the data model and a stored function.
 
 The ``myapp.lua`` file looks as follows:
 


### PR DESCRIPTION
Updated the `Connecting from Go` tutorial:
https://docs.d.tarantool.io/en/doc/connectors/how-to/getting_started_go/

This tutorial has the same steps and uses the same database as the [Connecting to a database using net.box](https://www.tarantool.io/en/doc/latest/how-to/getting_started_net_box/) tutorial. The upcoming Python/C++ tutorials are going to have the same layout.

> Note that Sphinx expands a tab (which is used as default indentation in Go) to 8 spaces. There are two ways to fix this:
> - Replace tabs with spaces
> - Customize CSS for our site
> 
> Not sure should we fix this.