### PR TITLE
Add tt [cluster] replicaset promote/demote reference

### DIFF
--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -13,16 +13,28 @@ and with centralized configuration storages (:ref:`etcd <configuration_etcd>` or
 
 ``COMMAND`` is one of the following:
 
-*   ``publish``: publish a cluster configuration using an arbitrary YAML file as a source.
+*   ``publish``
 *   ``show``: print a cluster configuration.
+*   ``replicaset``
 
 
-.. _tt-cluster-local:
+.. _tt-cluster-publish:
 
-Managing local configurations
------------------------------
+publish
+-------
 
-``tt cluster`` can read and modify local cluster configurations stored in
+.. code-block:: console
+
+    $ tt cluster publish {APPLICATION[:APP_INSTANCE] | URI} [FILE] [OPTION ...]
+
+``tt cluster publish`` publishes a cluster configuration using an arbitrary YAML file as a source.
+
+.. _tt-cluster-publish-local:
+
+Publishing local configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tt cluster publish`` can modify local cluster configurations stored in
 ``config.yaml`` files inside application directories.
 
 To write a configuration to a local ``config.yaml``, run ``tt cluster publish``
@@ -35,20 +47,13 @@ with two arguments:
 
     $ tt cluster publish myapp source.yaml
 
-To print a local configuration from an application's ``config.yaml``,  run
-``tt cluster show`` with the application name:
-
-.. code-block:: console
-
-    $ tt cluster show myapp
-
-.. _tt-cluster-centralized:
+.. _tt-cluster-publish-centralized:
 
 Managing configurations in centralized storages
------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``tt cluster`` can manage centralized cluster configurations in storages of both
-supported types: :ref:`etcd <configuration_etcd>` or a Tarantool-based configuration storage.
+``tt cluster publish`` can modify :ref:`centralized cluster configurations <configuration_etcd>`
+in storages of both supported types: etcd or a Tarantool-based configuration storage.
 
 To publish a configuration from a file to a centralized configuration storage,
 run ``tt cluster publish`` with a URI of this storage's
@@ -61,7 +66,87 @@ to a local etcd instance running on the default port ``2379``:
 
 A URI must include a prefix that is unique for the application. It can also include
 credentials and other connection parameters. Find the detailed description of the
-URI format in :ref:`tt-cluster-centralized-uri`.
+URI format in :ref:`tt-cluster-uri`.
+
+.. _tt-cluster-publish-instance:
+
+Publishing configurations of specific instances
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to whole cluster configurations, ``tt cluster publish`` can manage
+configurations of specific instances within applications. In this case, it operates
+with YAML fragments that describe a single :ref:`instance configuration section <configuration_overview>`.
+For example, the following YAML file can be a source when publishing an instance configuration:
+
+.. code-block:: yaml
+
+    # instance_source.yaml
+    iproto:
+      listen:
+      - uri: 127.0.0.1:3311
+
+To send an instance configuration to a local ``config.yaml``, run ``tt cluster publish``
+with the ``application:instance`` pair as the target argument:
+
+.. code-block:: console
+
+    $ tt cluster publish myapp:instance-002 instance_source.yaml
+
+To send an instance configuration to a centralized configuration storage, specify
+the instance name in the ``name`` argument of the storage URI:
+
+.. code-block:: console
+
+    $ tt cluster publish "http://localhost:2379/myapp?name=instance-002" instance_source.yaml
+
+
+.. _tt-cluster-publish-validation:
+
+Configuration validation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tt cluster`` can validate configurations against the Tarantool configuration schema.
+
+``tt cluster publish`` validates configurations against the Tarantool configuration schema
+and aborts in case of an error. To skip the validation, add the ``--force`` option:
+
+.. code-block:: console
+
+    $ tt cluster publish myapp source.yaml --force
+
+.. _tt-cluster-show:
+
+show
+----
+
+.. code-block:: console
+
+    $ tt cluster show {APPLICATION[:APP_INSTANCE] | URI} [OPTION ...]
+
+``tt cluster show`` displays a cluster configuration.
+
+.. _tt-cluster-show-local:
+
+Displaying local configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tt cluster show`` can read local cluster configurations stored in ``config.yaml``
+files inside application directories.
+
+To print a local configuration from an application's ``config.yaml``, specify the
+application name as an argument:
+
+.. code-block:: console
+
+    $ tt cluster show myapp
+
+.. _tt-cluster-show-centralized:
+
+Displaying configurations from centralized storages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tt cluster show`` can display :ref:`centralized cluster configurations <configuration_etcd>`
+from configuration storages of both supported types: etcd  or a Tarantool-based configuration storage.
 
 To print a cluster configuration from a centralized storage, run ``tt cluster show``
 with a storage URI including the prefix identifying the application. For example, to print
@@ -71,10 +156,84 @@ with a storage URI including the prefix identifying the application. For example
 
     $ tt cluster show "http://localhost:2379/myapp"
 
-.. _tt-cluster-centralized-authentication:
+
+.. _tt-cluster-show-instance:
+
+Displaying configurations of specific instances
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to whole cluster configurations, ``tt cluster show`` can display
+configurations of specific instances within applications. In this case, it prints
+YAML fragments that describe a single :ref:`instance configuration section <configuration_overview>`.
+
+To print an instance configuration from a local ``config.yaml``, use the ``application:instance``
+argument:
+
+.. code-block:: console
+
+    $ tt cluster show myapp:instance-002
+
+To print an instance configuration from a centralized configuration storage, specify
+the instance name in the ``name`` argument of the URI:
+
+.. code-block:: console
+
+    $ tt cluster show "http://localhost:2379/myapp?name=instance-002"
+
+.. _tt-cluster-show-validation:
+
+Configuration validation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To validate configurations when printing them with ``tt cluster show``, enable the
+validation by adding the ``--validate`` option:
+
+.. code-block:: console
+
+    $ tt cluster show "http://localhost:2379/myapp" --validate
+
+.. _tt-cluster-replicaset:
+
+replicaset
+----------
+
+.. code-block:: console
+
+    $ tt cluster replicaset SUBCOMMAND {APPLICATION[:APP_INSTANCE] | URI} [OPTION ...]
+
+``tt cluster replicaset`` manages instances in a replica set. It supports the following
+subcommands:
+
+-   ``promote``
+-   ``demote``
+
+.. important::
+
+    ``tt cluster replicaset`` works only with centralized cluster configurations.
+    To manage replica set leaders in clusters with local YAML configurations,
+    use :ref:`tt replicaset promote <tt-replicaset-demote>` and :ref:`tt replicaset demote <tt-replicaset-demote>`.
+
+.. _tt-cluster-replicaset-promote:
+
+promote
+~~~~~~~
+
+``tt cluster replicaset promote`` promotes an instances in a replica set.
+
+.. _tt-cluster-replicaset-demote:
+
+demote
+~~~~~~
+
+``tt cluster replicaset demote`` demotes an instances in a replica set.
+
+
+
+
+.. _tt-cluster-authentication:
 
 Authentication
-~~~~~~~~~~~~~~
+--------------
 
 There are three ways to pass the credentials for connecting to the centralized configuration storage.
 They all apply to both etcd and Tarantool-based storages. The following list
@@ -104,10 +263,10 @@ shows these ways ordered by precedence, from highest to lowest:
 If connection encryption is enabled on the configuration storage, pass the required
 SSL parameters in the :ref:`URI arguments <tt-cluster-centralized-uri>`.
 
-.. _tt-cluster-centralized-uri:
+.. _tt-cluster-uri:
 
 URI format
-~~~~~~~~~~
+----------
 
 A URI of the cluster configuration storage has the following format:
 
@@ -129,75 +288,6 @@ A URI of the cluster configuration storage has the following format:
     *   ``ssl_ciphers`` -- a colon-separated (``:``) list of SSL cipher suites the connection can use (for Tarantool-based storage only).
     *   ``verify_host`` -- verify the certificate’s name against the host. Default ``true``.
     *   ``verify_peer`` -- verify the peer’s SSL certificate. Default ``true``.
-
-.. _tt-cluster-instance:
-
-Managing configurations of specific instances
----------------------------------------------
-
-In addition to whole cluster configurations, ``tt cluster`` can manage
-configurations of specific instances within applications. In this case, it operates
-with YAML fragments that describe a single :ref:`instance configuration section <configuration_overview>`.
-For example, the following YAML file can be a source when publishing an instance configuration:
-
-.. code-block:: yaml
-
-    # instance_source.yaml
-    iproto:
-      listen:
-      - uri: 127.0.0.1:3311
-
-To send an instance configuration to a local ``config.yaml``, run ``tt cluster publish``
-with the ``application:instance`` pair as the target argument:
-
-.. code-block:: console
-
-    $ tt cluster publish myapp:instance-002 instance_source.yaml
-
-To send an instance configuration to a centralized configuration storage, specify
-the instance name in the ``name`` argument of the storage URI:
-
-.. code-block:: console
-
-    $ tt cluster publish "http://localhost:2379/myapp?name=instance-002" instance_source.yaml
-
-``tt cluster show`` can print configurations of specific cluster instances as well.
-To print an instance configuration from a local ``config.yaml``, use the ``application:instance``
-argument:
-
-.. code-block:: console
-
-    $ tt cluster show myapp:instance-002
-
-To print an instance configuration from a centralized configuration storage, specify
-the instance name in the ``name`` argument of the URI:
-
-.. code-block:: console
-
-    $ tt cluster show "http://localhost:2379/myapp?name=instance-002"
-
-.. _tt-cluster-validation:
-
-Configuration validation
-------------------------
-
-``tt cluster`` can validate configurations against the Tarantool configuration schema.
-
-``tt cluster publish`` automatically performs the validation and aborts in case of an error.
-To skip the validation, add the ``--force`` option:
-
-.. code-block:: console
-
-    $ tt cluster publish myapp source.yaml --force
-
-To validate configurations when printing them with ``tt cluster show``, enable the
-validation by adding the ``--validate`` option:
-
-.. code-block:: console
-
-    $ tt cluster show "http://localhost:2379/myapp" --validate
-
-
 .. _tt-cluster-options:
 
 Options

--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -223,7 +223,7 @@ promote
 making it a leader of its replica set.
 This command works on Tarantool clusters with centralized configuration and
 with :ref:`failover modes <configuration_reference_replication_failover>`
-``off`` and ``manual``. It updates the cluster configuration file according to
+``off`` and ``manual``. It updates the centralized configuration according to
 the specified arguments and reloads it:
 
 -   ``off`` failover mode: the command sets :ref:`database.mode <configuration_reference_database_mode>`
@@ -260,7 +260,7 @@ with :ref:`failover mode <configuration_reference_replication_failover>`
 .. note::
 
     In clusters with ``manual`` failover mode, you can demote a read-write instance
-    by promoting a read-only instance from the same replica set with ``tt replicaset promote``.
+    by promoting a read-only instance from the same replica set with ``tt cluster replicaset promote``.
 
 The command sets the instance's :ref:`database.mode <configuration_reference_database_mode>`
 to ``ro`` and reloads the configuration.
@@ -292,7 +292,7 @@ a key for patching. You can skip the selection by adding the ``-f``/``--force`` 
 
 In this case, the command selects the key for patching automatically. A key's priority
 is determined by the detail level of the instance or replicaset configuration stored
-under this key. For example, when failover is "off", a key with
+under this key. For example, when failover is ``off``, a key with
 ``instance.database`` options takes precedence over a key with the only ``instance`` field.
 In case of equal priority, the first key in the lexicographical order is patched.
 
@@ -327,7 +327,7 @@ shows these ways ordered by precedence, from highest to lowest:
             $ tt cluster show "http://localhost:2379/myapp"
 
 If connection encryption is enabled on the configuration storage, pass the required
-SSL parameters in the :ref:`URI arguments <tt-cluster-centralized-uri>`.
+SSL parameters in the :ref:`URI arguments <tt-cluster-uri>`.
 
 .. _tt-cluster-uri:
 
@@ -354,6 +354,7 @@ A URI of the cluster configuration storage has the following format:
     *   ``ssl_ciphers`` -- a colon-separated (``:``) list of SSL cipher suites the connection can use (for Tarantool-based storage only).
     *   ``verify_host`` -- verify the certificate’s name against the host. Default ``true``.
     *   ``verify_peer`` -- verify the peer’s SSL certificate. Default ``true``.
+
 .. _tt-cluster-options:
 
 Options
@@ -363,13 +364,13 @@ Options
 
     A username for connecting to the configuration storage.
 
-    See also: :ref:`tt-cluster-centralized-authentication`.
+    See also: :ref:`tt-cluster-authentication`.
 
 ..  option:: -p, --password STRING
 
     A password for connecting to the configuration storage.
 
-    See also: :ref:`tt-cluster-centralized-authentication`.
+    See also: :ref:`tt-cluster-authentication`.
 
 ..  option:: --force
 

--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -252,7 +252,7 @@ demote
 
     $ tt cluster replicaset demote URI INSTANCE_NAME [OPTION ...]
 
-``tt cluster replicaset demote`` demotes an instances in a replica set.
+``tt cluster replicaset demote`` demotes an instance in a replica set.
 This command works on Tarantool clusters with centralized configuration and
 with :ref:`failover mode <configuration_reference_replication_failover>`
 ``off``.
@@ -291,7 +291,7 @@ a key for patching. You can skip the selection by adding the ``-f``/``--force`` 
     $ tt cluster replicaset promote "http://localhost:2379/myapp" storage-001-a --force
 
 In this case, the command selects the key for patching automatically. A key's priority
-is determined by the detail level of the instance or replicaset configuration stored
+is determined by the detail level of the instance or replica set configuration stored
 under this key. For example, when failover is ``off``, a key with
 ``instance.database`` options takes precedence over a key with the only ``instance`` field.
 In case of equal priority, the first key in the lexicographical order is patched.

--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -48,8 +48,8 @@ with two arguments:
 
 .. _tt-cluster-publish-centralized:
 
-Managing configurations in centralized storages
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Publishing configurations in centralized storages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``tt cluster publish`` can modify :ref:`centralized cluster configurations <configuration_etcd>`
 in storages of both supported types: etcd or a Tarantool-based configuration storage.

--- a/doc/reference/tooling/tt_cli/commands.rst
+++ b/doc/reference/tooling/tt_cli/commands.rst
@@ -57,7 +57,7 @@ help for the given command.
         *   -   :doc:`play <play>`
             -   Play the contents of ``.snap`` or ``.xlog`` files to another Tarantool instance
         *   -   :doc:`replicaset <replicaset>`
-            -   Manage a replica set
+            -   Manage replica sets
         *   -   :doc:`restart <restart>`
             -   Restart a Tarantool instance
         *   -   :doc:`rocks <rocks>`

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -76,8 +76,9 @@ promote
     # or
     $ tt rs promote {APPLICATION:APP_INSTANCE | URI} [OPTIONS ...]
 
-``tt replicaset promote`` (``tt rs promote``) make the specified instance a leader
-in its replicaset. This command works on Tarantool clusters with a local YAML
+``tt replicaset promote`` (``tt rs promote``) promotes the specified instance,
+making it a leader of its replica set.
+This command works on Tarantool clusters with a local YAML
 configuration and Cartridge clusters.
 
 .. note::
@@ -105,9 +106,8 @@ configuration file according to the specified arguments and reloads it:
         If failover is ``off``, the command doesn't consider the modes of other
         replica set members, so there can be any number of read-write instances in one replica set.
 
--   ``manual`` failover mode: the command updates the :ref:`leader <configuration_reference_replicasets_name_leader>`)
-    of the replica set to which the specified instance belongs. Other instances
-    of this replica set become read-only.
+-   ``manual`` failover mode: the command updates the :ref:`leader <configuration_reference_replicasets_name_leader>`
+    option of the replica set configuration. Other instances of this replica set become read-only.
 
 Example:
 
@@ -124,7 +124,7 @@ them and reports an error. You can skip this check by adding the ``-f``/``--forc
     $ tt replicaset promote my-app:storage-001-a --force
 
 In the ``election`` failover mode, ``tt replicaset promote`` initiates the new leader
-election by calling :ref:`box_ctl-promote` on the specified instances. The
+election by calling :ref:`box_ctl-promote` on the specified instance. The
 ``--timeout`` option can be used to specify the election completion timeout:
 
 ..  code-block:: console
@@ -209,9 +209,9 @@ them and reports an error. You can skip this check by adding the ``-f``/``--forc
     $ tt replicaset demote my-app:storage-001-a --force
 
 In the ``election`` failover mode, ``tt replicaset demote`` initiates a leader
-election in the replica set. The specified instance's ref:`replication.election_mode <configuration_reference_replication_election_mode>`
-is changed to ``voter`` for this election, which guarantees that another member of
-the replica set is elected as a new leader.
+election in the replica set. The specified instance's :ref:`replication.election_mode <configuration_reference_replication_election_mode>`
+is changed to ``voter`` for this election, which guarantees that another instance
+is elected as a new replica set leader.
 
 The ``--timeout`` option can be used to specify the election completion timeout:
 
@@ -224,7 +224,8 @@ The ``--timeout`` option can be used to specify the election completion timeout:
 Selecting the application orchestrator manually
 -----------------------------------------------
 
-You can specify the orchestrator to use for the application using the following options:
+You can specify the orchestrator to use for the application  when calling ``tt replicaset``
+commands. The following options are available:
 
 *   ``--config`` for applications that use YAML cluster configuration (Tarantool 3.x or later).
 *   ``--cartridge`` for Cartridge applications (Tarantool 2.x).
@@ -233,7 +234,7 @@ You can specify the orchestrator to use for the application using the following 
 ..  code-block:: console
 
     $ tt replicaset status myapp --config
-    $ tt replicaset status my-cartridge-app --cartridge
+    $ tt replicaset promote my-cartridge-app:storage-001-a --cartridge
 
 If an actual orchestrator that the application uses does not match the specified
 option, an error is raised.

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -1,7 +1,7 @@
 .. _tt-replicaset:
 
-Working with replicasets
-=========================
+Managing replica sets
+=====================
 
 ..  code-block:: console
 
@@ -139,7 +139,7 @@ Promoting in Cartridge clusters
 
 ..  include:: _includes/cartridge_deprecation_note.rst
 
-``tt replicaset promote`` promotes instances in Cartridge clusters the following way:
+``tt replicaset promote`` promotes instances in Cartridge clusters as follows:
 
 -   ``disabled`` or ``eventual`` failover mode: the command changes the instance failover priority.
 

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -92,10 +92,112 @@ connecting to the instance:
         $ export TT_CLI_PASSWORD=p4$$w0rD
         $ tt replicaset status 192.168.10.10:3301
 
-.. _tt-replicaset-status-force:
+.. _tt-replicaset-promote:
+
+promote
+-------
+
+..  code-block:: console
+
+    $ tt replicaset promote {APPLICATION:APP_INSTANCE | URI} [OPTIONS ...]
+    # or
+    $ tt rs status  {APPLICATION:APP_INSTANCE | URI} [OPTIONS ...]
+
+``tt replicaset promote`` (``tt rs promote``) promotes an instance in a Tarantool
+cluster with a local YAML configuration or a Cartridge cluster.
+
+.. note::
+
+    To promote an instance in a Tarantool cluster with a centralized configuration,
+    use ``tt cluster replicaset promote``.
+
+.. _tt-replicaset-promote-config:
+
+Promoting in clusters with local YAML configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tt replicaset promote`` can promote instances in Tarantool clusters with local
+YAML configurations with :ref:`failover modes <configuration_reference_replication_failover>`
+``off``, ``manual``, and ``election``.
+
+In failover modes ``off`` or ``manual``, ``tt replicaset promote`` updates the cluster
+configuration file according to the command arguments and reloads it:
+
+-   ``off`` failover mode: the command sets :ref:`configuration_reference_database_mode` to ``rw``
+    on the specified instance.
+
+    .. important::
+
+        If failover is ``off``, the command considers the modes of cluster instances
+        independently, so there can be any number of read-write instances in a replica set.
+
+-   ``manual`` failover mode: the command updates the leader (:ref:`configuration_reference_replicasets_name_leader`)
+    of the replica set to which the specified instance belongs. Other instances
+    of this replica set become read-only.
+
+Example:
+
+..  code-block:: console
+
+    $ tt replicaset promote my-app:storage-001-a
+
+With ``-f``/``--force`` option, ``tt replicaset promote`` skips instances not running
+in the same ``tt`` environment:
+
+..  code-block:: console
+
+    $ tt replicaset promote my-app:storage-001-a --force
+
+In the ``election`` failover mode, ``tt replicaset promote`` initiates the new leader
+election by calling :ref:`box_ctl-promote` on the specified instances. The
+``--timeout`` option can be used to specify the election completion timeout:
+
+..  code-block:: console
+
+    $ tt replicaset promote my-app:storage-001-a --timeout=10
+
+
+.. _tt-replicaset-promote-config:
+
+Promoting in Cartridge clusters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+..  include:: _includes/cartridge_deprecation_note.rst
+
+``tt replicaset promote`` can promote instances in Cartridge clusters:
+
+-   ``disabled`` or ``eventual`` failover mode: the command changes the instance failover priority.
+
+    .. important::
+
+        In these cases, consistency is not guaranteed and replication conflicts may occur.
+
+-   ``eventual`` or ``raft`` failover mode: the command calls ``cartridge.failover_promote()``
+    and waits until the instance transitions to the read-write mode. If the ``-f``/``--force``
+    option is specified, the ``force_inconsistency`` option of `cartridge.failover_promote <https://www.tarantool.io/en/doc/2.11/book/cartridge/cartridge_api/modules/cartridge/#failover-promote-replicaset-uuid-opts>`_
+    is set to ``true``.
+
+..  code-block:: console
+
+    $ tt replicaset promote my-cartridge-app:storage-001-a --force
+
+Learn more about `Cartridge failover modes <https://www.tarantool.io/en/doc/2.11/book/cartridge/cartridge_dev/#leader-appointment-rules>`_.
+
+
+.. _tt-replicaset-demote:
+
+demote
+------
+
+``tt replicaset demote`` (``tt rs demote``) demotes an instance.
+
+
+To demote an instance in a cluster with a centralized configuration, use ``tt cluster replicaset demote``
+
+.. _tt-replicaset-orchestrator:
 
 Selecting the application orchestrator manually
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------
 
 You can specify the orchestrator to use for the application using the following options:
 
@@ -112,10 +214,10 @@ If an actual orchestrator that the application uses does not match the specified
 option, an error is raised.
 
 
-.. _tt-replicaset-status-options:
+.. _tt-replicaset-options:
 
 Options
-~~~~~~~
+-------
 
 ..  option:: --cartridge
 
@@ -128,6 +230,12 @@ Options
 ..  option:: --custom
 
     Force a custom orchestrator for Tarantool 2.x clusters.
+
+..  option:: -f, --force
+
+    **Applicable to:** ``promote``, ``demote``
+
+    Skip promotion or demotion if the specified instance is not running in the same environment.
 
 ..  option:: -u USERNAME, --username USERNAME
 
@@ -153,19 +261,8 @@ Options
 
     The list of SSL cipher suites used for encrypted connections, separated by colons (``:``).
 
-.. _tt-replicaset-promote:
+..  option:: --timeout
 
-promote
--------
+    **Applicable to:** ``promote``, ``demote``
 
-``tt replicaset promote`` (``tt rs promote``) promotes an instance.
-
-.. _tt-replicaset-demote:
-
-demote
-------
-
-``tt replicaset demote`` (``tt rs demote``) demotes an instance.
-
-
-
+    The timeout for completing the promotion or demotion, in seconds. Default: ``3``.

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -101,7 +101,7 @@ promote
 
     $ tt replicaset promote {APPLICATION:APP_INSTANCE | URI} [OPTIONS ...]
     # or
-    $ tt rs status  {APPLICATION:APP_INSTANCE | URI} [OPTIONS ...]
+    $ tt rs promote {APPLICATION:APP_INSTANCE | URI} [OPTIONS ...]
 
 ``tt replicaset promote`` (``tt rs promote``) promotes an instance in a Tarantool
 cluster with a local YAML configuration or a Cartridge cluster.
@@ -157,7 +157,7 @@ election by calling :ref:`box_ctl-promote` on the specified instances. The
     $ tt replicaset promote my-app:storage-001-a --timeout=10
 
 
-.. _tt-replicaset-promote-config:
+.. _tt-replicaset-promote-cartridge:
 
 Promoting in Cartridge clusters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -189,10 +189,63 @@ Learn more about `Cartridge failover modes <https://www.tarantool.io/en/doc/2.11
 demote
 ------
 
-``tt replicaset demote`` (``tt rs demote``) demotes an instance.
+..  code-block:: console
 
+    $ tt replicaset demote APPLICATION:APP_INSTANCE [OPTIONS ...]
+    # or
+    $ tt rs demote APPLICATION:APP_INSTANCE [OPTIONS ...]
 
-To demote an instance in a cluster with a centralized configuration, use ``tt cluster replicaset demote``
+``tt replicaset demote`` (``tt rs demote``) demotes an instance in a Tarantool
+cluster with a local YAML configuration.
+
+.. note::
+
+    To demote an instance in a Tarantool cluster with a centralized configuration,
+    use ``tt cluster replicaset demote``.
+
+.. _tt-replicaset-demote-config:
+
+Demoting in clusters with local YAML configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tt replicaset demote`` can demote instances in Tarantool clusters with local
+YAML configurations with :ref:`failover modes <configuration_reference_replication_failover>`
+``off`` and ``election``.
+
+.. note::
+
+    In clusters with ``manual`` failover mode, you can demote a read-write instance
+    by promoting a read-only instance from the same replica set with ``tt replicaset promote``.
+
+In the ``off`` failover mode, ``tt replicaset demote`` sets the configuration parameter
+:ref:`configuration_reference_database_mode` to ``ro`` for the specified instance and reloads
+the configuration.
+
+.. important::
+
+    If failover is ``off``, the command considers the modes of cluster instances
+    independently, so there can be any number of read-write instances in a replica set.
+
+With ``-f``/``--force`` option, ``tt replicaset demote`` skips instances not running
+in the same ``tt`` environment:
+
+..  code-block:: console
+
+    $ tt replicaset demote my-app:storage-001-a --force
+
+In the ``election`` failover mode, ``tt replicaset demote`` does the following:
+
+#.  Checks if the specified instance is a replica set leader.
+#.  Sets the specified instance's:ref:`configuration_reference_replication_election_mode`
+    to ``voter`` and reloads the configuration.
+#.  After a new leader is elected and the instance is read-only, sets the instance's
+    ``replication.election_mode`` back to ``candidate``.
+
+The ``--timeout`` option can be used to specify the election completion timeout:
+
+..  code-block:: console
+
+    $ tt replicaset demote my-app:storage-001-a --timeout=10
 
 .. _tt-replicaset-orchestrator:
 

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -62,7 +62,7 @@ For a replica outside the current ``tt`` environment, specify its URI and access
 
     $ tt replicaset status 192.168.10.10:3301 -u myuser -p p4$$w0rD
 
-Learn about other ways to provide user credentials in :ref:`tt-replicaset-status-authentication`.
+Learn about other ways to provide user credentials in :ref:`tt-replicaset-authentication`.
 
 
 .. _tt-replicaset-promote:


### PR DESCRIPTION
Resolves #4088 #4109 #4121

- [tt replicaset reference page](https://docs.d.tarantool.io/en/doc/gh-4088-tt-replicaset-promote/reference/tooling/tt_cli/replicaset/):
  - add new sections for `promote` and `demote` commands 
  - move subsections **Authorization** and **Options** to the top level
- [tt cluster reference page](https://docs.d.tarantool.io/en/doc/gh-4088-tt-replicaset-promote/reference/tooling/tt_cli/cluster/):
  -  make top-level subsections for each subcommand and reorganize content accordingly
  - add `tt cluster replicaset`, `promote` and `demote` subsections

Deployment: https://docs.d.tarantool.io/en/doc/gh-4088-tt-replicaset-promote/reference/tooling/tt_cli/replicaset/#tt-replicaset-promote