### PR TITLE
Add TCM access control list and API tokens documentation

### DIFF
--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -244,6 +244,61 @@ There are the following password policy settings:
     -   **Digits (0-9)**
     -   **Symbols (such as !@#$%^&\*()_+№"':,.;=][{}`?>/.)**
 
+.. _tcm_access_control_acl:
+
+Access to stored data and functions
+-----------------------------------
+
+|tcm|'s *access control list* (*ACL*) determines user access to data and stored
+functions of connected clusters. You can use it to allow or deny access to specific
+stored objects one by one.
+
+required permissions: cluster.space.data.* and cluster.func.*
+
+Each ACL entry specifies a |tcm| user's privileges for a space or a function stored
+in a connected cluster. There are three access privileges that can be granted in ACL:
+read, write, and execute (for stored functions only). The privileges work as follows:
+
+-   Spaces:
+
+    - ``Read``: the user sees the space on the **Tuples** page and view its tuples
+    - ``Write``: the user can add new and edit existing tuples of the space on the **Tuples** page
+
+-   Functions:
+
+    - ``Read``: the user sees the function on the cluster instance details page (**Functions** tab)
+    - ``Write``: the user can edit or delete the function on the cluster instance details page (**Functions** tab)
+    - ``Execute``: the user can call the function on the cluster instance details page (**Functions** tab)
+
+To manage a user's access to objects with ACL, enable the use of ACL in this user's
+account settings:
+
+#.  Go to users and click **Edit** in the **Actions** menu of the corresponding table row.
+
+#.  In the user's **Clusters** list, add a cluster on which you want to use ACL
+    or click the pencil icon if the cluster is already on the list.
+
+#.  Select the **Use Access Control List (ACL)** checkbox and save changes.
+
+#.  Repeat two previous steps for each cluster on which you want to use ACL for this user.
+
+#.  Click **Update** to save the user account.
+
+If the user doesn't exist yet, you can do the same when creating it.
+
+The tools for managing ACL are located on the **ACL** page.
+
+To add an ACL entry:
+
+#.  Click **Add**.
+#.  Select a user to which you want to grant access.
+#.  Select a cluster that stores the target object.
+#.  Select the target object type (space or function) and enter its name.
+#.  Select the priveleges.
+
+To delete an ACL entry, click **Delete** in the **Actions** menu of the corresponding table row.
+
+
 .. _tcm_access_control_sessions:
 
 Sessions
@@ -326,9 +381,6 @@ The following administrative permissions are available in |tcm|:
     *   -   ``admin.passwordpolicy.write``
         -   Manage password policy
 
-    *   -   ``admin.devmode.toggle``
-        -   Toggle development mode
-
     *   -   ``admin.secrets.read``
         -   View information about users' secrets
 
@@ -338,11 +390,20 @@ The following administrative permissions are available in |tcm|:
     *   -   ``user.password.change``
         -   User's permission to change their own password
 
-    *   -   ``admin.lowlevel.state.read``
-        -   Read low-level information from |tcm| storage (for debug purposes)
+    *   -   ``user.api-token.read``
+        -   User's permission to read their own API tokens information
 
-    *   -   ``admin.lowlevel.state.write``
-        -   Write low-level information to |tcm| storage (for debug purposes)
+    *   -   ``user.api-token.write``
+        -   User's permission to modify their own API tokens
+
+    *   -   ``admin.metrics``
+        -   Read |tcm| metrics
+
+    *   -   ``admin.acl.read``
+        -   View the access control list (ACL)
+
+    *   -   ``admin.acl.write``
+        -   Add and delete ACL entries
 
 .. _tcm_access_control_permissions_cluster:
 
@@ -367,17 +428,14 @@ The following cluster permissions are available in |tcm|:
     *   -   ``cluster.stateboard.read``
         -   View cluster stateboard
 
-    *   -   ``cluster.explorer.read``
-        -   Read data from cluster instances
+    *   -   ``cluster.func.read``
+        -   View cluster's stored functions
 
-    *   -   ``cluster.explorer.write``
-        -   Write data to cluster instances
+    *   -   ``cluster.func.write``
+        -   Edit cluster's stored functions
 
-    *   -   ``cluster.explorer.call``
+    *   -   ``cluster.func.call``
         -   Execute stored functions on cluster instances
-
-    *   -   ``cluster.explorer.eval``
-        -   Execute code on cluster instances
 
     *   -   ``cluster.space.read``
         -   Read cluster data schema
@@ -385,8 +443,23 @@ The following cluster permissions are available in |tcm|:
     *   -   ``cluster.space.write``
         -   Modify cluster data schema
 
-    *   -   ``cluster.lowlevel.state.read``
-        -   Read low-level information about cluster configuration (for debug purposes)
+    *   -   ``cluster.space.data.read``
+        -   Read stored data from cluster
 
-    *   -   ``cluster.lowlevel.state.write``
-        -   Write low-level information about cluster configuration (for debug purposes)
+    *   -   ``cluster.space.data.write``
+        -   Edit stored data on cluster
+
+    *   -   ``cluster.failover.read``
+        -   Read cluster failover information
+
+    *   -   ``cluster.failover.write``
+        -   Write cluster failover commands
+
+    *   -   ``cluster.terminal``
+        -   Connect to cluster instances with ``tt`` terminal from |TCM|
+
+    *   -   ``cluster.sql``
+        -   Execute SQL queries
+
+    *   -   ``cluster.metrics``
+        -   View cluster metrics

--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -278,6 +278,11 @@ read, write, and execute (for stored functions only). The privileges work as fol
     ACL only increases the access control granularity to particular objects.
     Make sure that users have these permissions before enabling ACL for them.
 
+.. _tcm_access_control_acl_enable:
+
+Enabling ACL for a user
+~~~~~~~~~~~~~~~~~~~~~~~
+
 To granularly manage a user's access to particular objects in a cluster, enable
 the use of ACL in the user profile:
 
@@ -298,6 +303,11 @@ If the user doesn't exist yet, you can do the same when creating it.
 
     When ACL use is enabled for a user, this user loses access to all spaces and
     functions of the selected cluster except the ones explicitly specified in the ACL.
+
+.. _tcm_access_control_acl_manage:
+
+Managing ACL
+~~~~~~~~~~~~
 
 The tools for managing ACL are located on the **ACL** page.
 
@@ -322,6 +332,51 @@ are listed on the **Sessions** page. To revoke a session, click **Revoke** in th
 
 To revoke all sessions of a user, go to **Users** and click **Revoke all sessions**
 in the **Actions** menu of the corresponding table row.
+
+.. _tcm_access_control_api_tokens:
+
+API tokens
+----------
+
+|tcm| uses the Bearer HTTP authentication scheme with *API tokens* to authenticate
+external applications' requests to |tcm|. For example, these can be Prometheus
+jobs that retrieve metrics of connected Tarantool clusters.
+
+Each |tcm| API token belongs to the user that created it and has the same :ref:`access permissions <tcm_access_control_permissions>`.
+Thus, if a user has a permission to view a cluster's metrics in |tcm|, this user's
+API tokens can be used to read this cluster's metrics with Prometheus.
+
+API tokens have expiration dates that is set during their creation.
+
+.. _tcm_access_control_api_tokens_manage:
+
+Managing API tokens
+~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    Each user, including **Default Admin** and other administrators, can create only
+    their own tokens. There is no way to create a token for another user.
+
+To create a |tcm| API token:
+
+#. Open the user settings by clicking the user's name in the top-right corner.
+#. Go to the **API tokens** tab and click **Add**.
+#. Specify the token expiration date and an optional description and click **Add**.
+
+The created token is shown in a dialog.
+
+.. important::
+
+    An API token is shown only once after its creation. There is no way to view
+    it again after you close the dialog. Make sure to copy the token in a safe place.
+
+To delete an API token, click **Delete** in the actions menu of the corresponding
+**API tokens** table row.
+
+Administrators can also view information about users' API tokens and and delete them
+on the **Secrets** page. To open a user's secrets, click **Secrets** in the **Actions**
+menu of the corresponding **Users** table row.
 
 .. _tcm_access_control_permissions_ref:
 

--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -253,7 +253,7 @@ Access control list
 and functions stored in clusters. You can use it to allow or deny access to specific
 stored objects one by one.
 
-Each ACL entry specifies privileges that a |tcm| user's privileges has on a particular
+Each ACL entry specifies privileges that a |tcm| user has on a particular
 space or a function. There are three access privileges that can be granted in the ACL:
 read, write, and execute (for stored functions only). The privileges work as follows:
 
@@ -268,18 +268,17 @@ read, write, and execute (for stored functions only). The privileges work as fol
     - ``Write``: the user can edit or delete the function
     - ``Execute``: the user can call the function
 
-
 .. important::
 
-    Users' access to space data and stored functions is primarily defined by the
+    User access to space data and stored functions is primarily defined by the
     :ref:`cluster permissions <tcm_access_control_permissions_cluster>` ``cluster.space.data.*`` and ``cluster.func.*``.
     ACL only increases the access control granularity to particular objects.
     Make sure that users have these permissions before enabling ACL for them.
 
 To granularly manage a user's access to particular objects in a cluster, enable
-the use of ACL in this user's account settings:
+the use of ACL in the user profile:
 
-#.  Go to users and click **Edit** in the **Actions** menu of the corresponding table row.
+#.  Go to **Users** and click **Edit** in the **Actions** menu of the corresponding table row.
 
 #.  In the user's **Clusters** list, add a cluster on which you want to use ACL
     or click the pencil icon if the cluster is already on the list.
@@ -308,7 +307,6 @@ To add an ACL entry:
 #.  Select the privileges you want to grant.
 
 To delete an ACL entry, click **Delete** in the **Actions** menu of the corresponding table row.
-
 
 .. _tcm_access_control_sessions:
 

--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -162,9 +162,9 @@ Passwords
 ---------
 
 |tcm| uses the general term *secret* for user authentication keys. A secret is any
-pair of a public and a private key that can be used for authentication. In |tcm| |tcm_version|,
-*password* is the only supported secret type. In this case, the public key is a username,
-and the private key is a password.
+pair of a public and a private key that can be used for authentication. A *password*
+combined with a *username* is a secret type used for |tcm| user authentication.
+In this case, the public key is a username, and the private key is a password.
 
 Users receive their first passwords during their :ref:`account creation <tcm_access_control_users_manage>`.
 

--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -246,31 +246,35 @@ There are the following password policy settings:
 
 .. _tcm_access_control_acl:
 
-Access to stored data and functions
------------------------------------
+Access control list
+-------------------
 
-|tcm|'s *access control list* (*ACL*) determines user access to data and stored
-functions of connected clusters. You can use it to allow or deny access to specific
+|tcm|'s *access control list* (*ACL*) determines user access to particular data
+and functions stored in clusters. You can use it to allow or deny access to specific
 stored objects one by one.
 
-required permissions: cluster.space.data.* and cluster.func.*
+.. note::
 
-Each ACL entry specifies a |tcm| user's privileges for a space or a function stored
-in a connected cluster. There are three access privileges that can be granted in ACL:
+    Users' access to space data and stored functions is primarily defined by the
+    :ref:`cluster permissions <tcm_access_control_permissions_cluster>` ``cluster.space.data.*`` and ``cluster.func.*``.
+    ACL only increases the access control granularity to particular objects.
+
+Each ACL entry specifies privileges that a |tcm| user's privileges has on a particular
+space or a function. There are three access privileges that can be granted in the ACL:
 read, write, and execute (for stored functions only). The privileges work as follows:
 
 -   Spaces:
 
-    - ``Read``: the user sees the space on the **Tuples** page and view its tuples
-    - ``Write``: the user can add new and edit existing tuples of the space on the **Tuples** page
+    - ``Read``: the user sees the space and its tuples on the **Tuples** and **Explorer** pages
+    - ``Write``: the user can add new and edit existing tuples of the space
 
 -   Functions:
 
-    - ``Read``: the user sees the function on the cluster instance details page (**Functions** tab)
-    - ``Write``: the user can edit or delete the function on the cluster instance details page (**Functions** tab)
-    - ``Execute``: the user can call the function on the cluster instance details page (**Functions** tab)
+    - ``Read``: the user sees the function on the **Functions** tab of the instance details page.
+    - ``Write``: the user can edit or delete the function
+    - ``Execute``: the user can call the function
 
-To manage a user's access to objects with ACL, enable the use of ACL in this user's
+To manage a user's access to a cluster with ACL, enable the use of ACL in this user's
 account settings:
 
 #.  Go to users and click **Edit** in the **Actions** menu of the corresponding table row.
@@ -286,15 +290,20 @@ account settings:
 
 If the user doesn't exist yet, you can do the same when creating it.
 
+.. important::
+
+    When ACL use is enabled for a user, this user loses access to all spaces and
+    functions of the selected cluster except the ones explicitly specified in the ACL.
+
 The tools for managing ACL are located on the **ACL** page.
 
 To add an ACL entry:
 
 #.  Click **Add**.
 #.  Select a user to which you want to grant access.
-#.  Select a cluster that stores the target object.
-#.  Select the target object type (space or function) and enter its name.
-#.  Select the priveleges.
+#.  Select a cluster that stores the target object: a space or a function.
+#.  Select the target object type and enter its name.
+#.  Select the privileges you want to grant.
 
 To delete an ACL entry, click **Delete** in the **Actions** menu of the corresponding table row.
 

--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -17,7 +17,7 @@ and users (or user accounts). They work as follows:
 -   Roles are predefined sets of *administrative* permissions to
     assign to users.
 -   Users have roles that define their access rights to |tcm| functions and objects, and
-    *cluster* permissions that are assigned for each cluster separately.
+    *cluster* permissions that are assigned for each cluster individually.
 
 ..  note::
 

--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -346,7 +346,8 @@ Each |tcm| API token belongs to the user that created it and has the same :ref:`
 Thus, if a user has a permission to view a cluster's metrics in |tcm|, this user's
 API tokens can be used to read this cluster's metrics with Prometheus.
 
-API tokens have expiration dates that is set during their creation.
+API tokens have expiration dates that are set during the token creation and cannot
+be changed.
 
 .. _tcm_access_control_api_tokens_manage:
 

--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -22,7 +22,7 @@ and users (or user accounts). They work as follows:
 ..  note::
 
     |tcm| users, roles, and permissions are not to be confused with similar subjects
-    of the :ref:`Tarantool access control system <authentication>`. To access Tarantool
+    of the :ref:`Tarantool access control system <access_control>`. To access Tarantool
     instances directly, Tarantool users with corresponding roles are required.
 
 .. _tcm_access_control_permissions:
@@ -55,6 +55,9 @@ There are two types of permissions in |tcm|: *administrative* and *cluster* perm
     see the **Configuration** page when this cluster is selected.
 
     Cluster permissions are assigned to users individually when creating or editing them.
+
+    For a fine-grained control over user access to particular spaces and functions stored
+    in clusters, there is the :ref:`access control list <tcm_access_control_acl>`.
 
 Permissions are predefined in |tcm|, there is no way to change, add, or delete them.
 The complete lists of administrative and cluster permissions in |tcm| are provided

--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -253,12 +253,6 @@ Access control list
 and functions stored in clusters. You can use it to allow or deny access to specific
 stored objects one by one.
 
-.. note::
-
-    Users' access to space data and stored functions is primarily defined by the
-    :ref:`cluster permissions <tcm_access_control_permissions_cluster>` ``cluster.space.data.*`` and ``cluster.func.*``.
-    ACL only increases the access control granularity to particular objects.
-
 Each ACL entry specifies privileges that a |tcm| user's privileges has on a particular
 space or a function. There are three access privileges that can be granted in the ACL:
 read, write, and execute (for stored functions only). The privileges work as follows:
@@ -274,8 +268,16 @@ read, write, and execute (for stored functions only). The privileges work as fol
     - ``Write``: the user can edit or delete the function
     - ``Execute``: the user can call the function
 
-To manage a user's access to a cluster with ACL, enable the use of ACL in this user's
-account settings:
+
+.. important::
+
+    Users' access to space data and stored functions is primarily defined by the
+    :ref:`cluster permissions <tcm_access_control_permissions_cluster>` ``cluster.space.data.*`` and ``cluster.func.*``.
+    ACL only increases the access control granularity to particular objects.
+    Make sure that users have these permissions before enabling ACL for them.
+
+To granularly manage a user's access to particular objects in a cluster, enable
+the use of ACL in this user's account settings:
 
 #.  Go to users and click **Edit** in the **Actions** menu of the corresponding table row.
 

--- a/doc/reference/tooling/tcm/tcm_access_control.rst
+++ b/doc/reference/tooling/tcm/tcm_access_control.rst
@@ -374,7 +374,7 @@ The created token is shown in a dialog.
 To delete an API token, click **Delete** in the actions menu of the corresponding
 **API tokens** table row.
 
-Administrators can also view information about users' API tokens and and delete them
+Administrators can also view information about users' API tokens and delete them
 on the **Secrets** page. To open a user's secrets, click **Secrets** in the **Actions**
 menu of the corresponding **Users** table row.
 

--- a/prolog.rst
+++ b/prolog.rst
@@ -40,5 +40,5 @@
 
 .. |tcm| replace:: TCM
 
-.. |tcm_version| replace:: 1.0.0
+.. |tcm_version| replace:: 1.1.0
 


### PR DESCRIPTION
Resolves #4246, #4247

- TCM **Access control** page: 
  - add new section [Access Control List](https://docs.d.tarantool.io/en/doc/gh-4246-tcm-acl/reference/tooling/tcm/tcm_access_control/#access-control-list) about Access Control List
  - update [permissions reference](https://docs.d.tarantool.io/en/doc/gh-4246-tcm-acl/reference/tooling/tcm/tcm_access_control/#permissions-reference)
  - add new section [API tokens](https://docs.d.tarantool.io/en/doc/gh-4246-tcm-acl/reference/tooling/tcm/tcm_access_control/#api-tokens)

Deployment: https://docs.d.tarantool.io/en/doc/gh-4246-tcm-acl/reference/tooling/tcm/tcm_access_control/#access-control-list