### PR TITLE
Add TCM releases section with 1.0 and 1.1

### DIFF
--- a/doc/reference/tooling/tcm/index.rst
+++ b/doc/reference/tooling/tcm/index.rst
@@ -44,3 +44,4 @@ to read data. LDAP authorization is supported as well.
     tcm_configuration
     tcm_backend_store
     tcm_configuration_reference
+    Releases <tcm_releases/index>

--- a/doc/reference/tooling/tcm/tcm_releases/index.rst
+++ b/doc/reference/tooling/tcm/tcm_releases/index.rst
@@ -3,7 +3,7 @@
 Tarantool Cluster Manager releases
 ==================================
 
-..  include:: index.rst
+..  include:: ../index.rst
     :start-after: ee_note_tcm_start
     :end-before: ee_note_tcm_end
 
@@ -24,20 +24,14 @@ Supported versions
 
         *   -   Series
             -   First release date
-            -   End of life
-            -   End of support
             -   Versions
 
         *   -   :ref:`1.1 <tcm_releases_1_1>`
-            -   **May 16, 2024**
-            -   **April 16, 2026**
-            -   **Not planned yet**
+            -   May 16, 2024
             -   1.1.0
 
         *   -   :ref:`1.0 <tcm_releases_1_0>`
-            -   **December 23, 2023**
-            -   **April 16, 2026**
-            -   **Not planned yet**
+            -   December 23, 2023
             -   | 1.0.4
                 | 1.0.3
                 | 1.0.2

--- a/doc/reference/tooling/tcm/tcm_releases/index.rst
+++ b/doc/reference/tooling/tcm/tcm_releases/index.rst
@@ -1,0 +1,51 @@
+.. _tcm_releases:
+
+Tarantool Cluster Manager releases
+==================================
+
+..  include:: index.rst
+    :start-after: ee_note_tcm_start
+    :end-before: ee_note_tcm_end
+
+This section contains the list of |tcm_full_name| releases along with descriptions
+of their key changes.
+
+For information about Tarantool releases, see :ref:`release`.
+
+.. _tcm_releases_supported:
+
+Supported versions
+------------------
+
+..  container:: table
+
+    ..  list-table::
+        :header-rows: 1
+
+        *   -   Series
+            -   First release date
+            -   End of life
+            -   End of support
+            -   Versions
+
+        *   -   :ref:`1.1 <tcm_releases_1_1>`
+            -   **May 16, 2024**
+            -   **April 16, 2026**
+            -   **Not planned yet**
+            -   1.1.0
+
+        *   -   :ref:`1.0 <tcm_releases_1_0>`
+            -   **December 23, 2023**
+            -   **April 16, 2026**
+            -   **Not planned yet**
+            -   | 1.0.4
+                | 1.0.3
+                | 1.0.2
+                | 1.0.1
+                | 1.0.0
+
+..  toctree::
+    :maxdepth: 1
+
+    tcm_1.1
+    tcm_1.0

--- a/doc/reference/tooling/tcm/tcm_releases/tcm_1.0.rst
+++ b/doc/reference/tooling/tcm/tcm_releases/tcm_1.0.rst
@@ -5,7 +5,7 @@ Tarantool Cluster Manager 1.0
 
 Release date: December 26, 2023
 
-Releases in series: 1.0.4, 1.0.3, 1.0.2, 1.0.1, 1.0.0
+Latest release in series: 1.0.4
 
 1.0 is the first public release series of |tcm_full_name|. It was introduced as a
 part of the :ref:`Tarantool EE 3.0 release <3-0-tarantool_cluster_manager>`.

--- a/doc/reference/tooling/tcm/tcm_releases/tcm_1.0.rst
+++ b/doc/reference/tooling/tcm/tcm_releases/tcm_1.0.rst
@@ -21,13 +21,15 @@ Multiple connected clusters
 
 To connect a cluster to |tcm|, you need to provide the endpoint URLs and connection
 parameters of its centralized configuration storage (for example, etcd).
+To learn more, see :ref:`tcm_connect_clusters`.
 
 .. _tcm_releases_1_0_stateboard:
 
 Cluster stateboard
 ------------------
 
-The cluster stateboard visualizes the information about a connected cluster:
+The cluster *stateboard* is a main |tcm| page that visualizes the information about
+the selected cluster:
 
 -   Cluster topology visualized as a table or a graph
 -   Tarantool versions running on instances
@@ -49,7 +51,7 @@ configurations as a YAML file in the browser. Once you're done editing the confi
 you can send the changes to the configuration storage in one click or save them locally
 to continue editing them later.
 
-To learn more, see :ref:`tcm_cluster_config`.
+To learn more, see :ref:`tcm_configuring_clusters`.
 
 .. _tcm_releases_1_0_access:
 
@@ -57,22 +59,22 @@ Role-based access control
 -------------------------
 
 |tcm| features its own role-based access control system. It defines users that can
-log into |tcm| and actions that the can perform in its web interface.
+log into |tcm| and their permissions to perform various actions or access clusters
+in its web interface.
 
 You can use built-in roles or create new ones with permissions you need. Users'
 access can be limited to specific clusters and operations on them, for example,
-editing the configuration or viewing stored data.
+editing the configuration or calling stored functions.
+To learn more, see :ref:`tcm_access_control`.
 
 |tcm| also supports LDAP authentication.
-
-To learn more, see :ref:`tcm_access_control`.
 
 .. _tcm_releases_1_0_audit:
 
 Audit logging
 -------------
 
-|tcm| has a built-in audit logging mechanism. When enabled, it saves information
+|tcm| has a built-in audit logging mechanism. When enabled, it records information
 about events that occur in |tcm| and users' actions to dedicated audit log files.
 You can define events to write to the audit log and adjust logging parameters, such
 as filename, log rotation, or compression.

--- a/doc/reference/tooling/tcm/tcm_releases/tcm_1.0.rst
+++ b/doc/reference/tooling/tcm/tcm_releases/tcm_1.0.rst
@@ -1,0 +1,80 @@
+.. _tcm_releases_1_0:
+
+Tarantool Cluster Manager 1.0
+=============================
+
+Release date: December 26, 2023
+
+Releases in series: 1.0.4, 1.0.3, 1.0.2, 1.0.1, 1.0.0
+
+1.0 is the first public release series of |tcm_full_name|. It was introduced as a
+part of the :ref:`Tarantool EE 3.0 release <3-0-tarantool_cluster_manager>`.
+Below is an overview of key features of TCM 1.0.
+
+.. _tcm_releases_1_0_clusters:
+
+Multiple connected clusters
+---------------------------
+
+|tcm| works as a standalone application. You can connect any number of Tarantool EE
+3.0+ clusters to a single |tcm| instance and switch between them on the fly.
+
+To connect a cluster to |tcm|, you need to provide the endpoint URLs and connection
+parameters of its centralized configuration storage (for example, etcd).
+
+.. _tcm_releases_1_0_stateboard:
+
+Cluster stateboard
+------------------
+
+The cluster stateboard visualizes the information about a connected cluster:
+
+-   Cluster topology visualized as a table or a graph
+-   Tarantool versions running on instances
+-   Memory statistics
+-   Errors and warnings that happen on instances
+
+From the stateboard, you can navigate to specific instances to view their details
+or connect to their interactive consoles.
+
+To learn more, see :ref:`tcm_cluster_monitoring`.
+
+.. _tcm_releases_1_0_config:
+
+Cluster configuration management
+--------------------------------
+
+|tcm| includes a visual editor for cluster configuration. It allows editing cluster
+configurations as a YAML file in the browser. Once you're done editing the configuration,
+you can send the changes to the configuration storage in one click or save them locally
+to continue editing them later.
+
+To learn more, see :ref:`tcm_cluster_config`.
+
+.. _tcm_releases_1_0_access:
+
+Role-based access control
+-------------------------
+
+|tcm| features its own role-based access control system. It defines users that can
+log into |tcm| and actions that the can perform in its web interface.
+
+You can use built-in roles or create new ones with permissions you need. Users'
+access can be limited to specific clusters and operations on them, for example,
+editing the configuration or viewing stored data.
+
+|tcm| also supports LDAP authentication.
+
+To learn more, see :ref:`tcm_access_control`.
+
+.. _tcm_releases_1_0_audit:
+
+Audit logging
+-------------
+
+|tcm| has a built-in audit logging mechanism. When enabled, it saves information
+about events that occur in |tcm| and users' actions to dedicated audit log files.
+You can define events to write to the audit log and adjust logging parameters, such
+as filename, log rotation, or compression.
+
+To learn more, see :ref:`tcm_audit_log`.

--- a/doc/reference/tooling/tcm/tcm_releases/tcm_1.1.rst
+++ b/doc/reference/tooling/tcm/tcm_releases/tcm_1.1.rst
@@ -5,7 +5,7 @@ Tarantool Cluster Manager 1.1
 
 Release date: May 16, 2024
 
-Releases in series: 1.1.0
+Latest release in series: 1.1.0
 
 |tcm_full_name| 1.1 introduces a number of new features that extend and improve its
 cluster management capabilities. Below is an overview of its key updates.
@@ -28,7 +28,7 @@ It allows you to add new and edit existing spaces.
 
 For clusters that use the `CRUD <https://github.com/tarantool/crud>`__ module,
 there is also the *CRUD explorer* that enables access to data in user spaces across
-the entire cluster on one page. The CRUD explorer is located on the **Tuples** page.
+the entire cluster. The CRUD explorer is located on the **Tuples** page.
 
 .. _tcm_releases_1_1_acl:
 
@@ -53,7 +53,7 @@ The tools for managing ACL are located on the new **ACL** page.
 API tokens
 ----------
 
-|tcm| 1.1.0 supports token authentication of external requests. Users can generate
+|tcm| 1.1 supports token authentication of external requests. Users can generate
 API tokens in their user settings dialog. An API token has the same permissions
 as its creator.
 
@@ -62,7 +62,7 @@ as its creator.
 Stateboard improvements
 -----------------------
 
-|tcm| 1.1.0 extends the functionality of the cluster stateboard to improve the
+|tcm| 1.1 extends the functionality of the cluster stateboard to improve the
 cluster management experience. Here are the key updates of the stateboard:
 
 -   More flexible instance grouping.
@@ -76,8 +76,7 @@ Instance interaction
 
 The instance management dialog has been extended with new functions:
 
--   A new terminal that uses the ``tt`` console instead of the Tarantool interactive
-    console.
+-   A new terminal that uses the :ref:`tt interactive console <tt-interactive-console>`.
 -   SQL query execution terminal.
 -   Stored functions editor.
 -   Slab visualization.
@@ -113,5 +112,5 @@ checks and highlights possible semantic issues, such as:
 Onboarding tutorial
 -------------------
 
-|tcm| 1.1.0 includes an interactive tutorial that takes new users though its
+|tcm| 1.1.0 includes an interactive tutorial that takes new users through its
 main features and pages. It opens automatically after the first start.

--- a/doc/reference/tooling/tcm/tcm_releases/tcm_1.1.rst
+++ b/doc/reference/tooling/tcm/tcm_releases/tcm_1.1.rst
@@ -7,39 +7,39 @@ Release date: May 16, 2024
 
 Releases in series: 1.1.0
 
-|tcm_full_name| 1.1.0 introduces a number of new features that extend and improve its
-functionality. Below is an overview of its key updates.
+|tcm_full_name| 1.1 introduces a number of new features that extend and improve its
+cluster management capabilities. Below is an overview of its key updates.
 
 .. _tcm_releases_1_1_data_access:
 
 Data access
 -----------
 
-An important update of |tcm| 1.1.0 is a set of features that enable access to data
-stored on your clusters.
+An important update of |tcm| 1.1.0 is a set of features that enable access to clusters'
+stored data.
 
 The instance *space explorer* shows all spaces that exist on an instance, including
 system spaces. On its pages, you can view and edit the stored data. To open the instance explorer,
 find the instance on the cluster stateboard and click its name to open its details page.
 Then click **Explorer** in the **Actions** menu in the top right corner.
 
-In the development mode, the instance explorer also includes the *schema editor**.
+In the development mode, the instance explorer also includes the *schema editor*.
 It allows you to add new and edit existing spaces.
 
-For clusters that use the crud module, there is also the *CRUD explorer* that
-enables access to data in user spaces across the entire cluster on one page.
-The CRUD explorer is located on the **Tuples** page.
+For clusters that use the `CRUD <https://github.com/tarantool/crud>`__ module,
+there is also the *CRUD explorer* that enables access to data in user spaces across
+the entire cluster on one page. The CRUD explorer is located on the **Tuples** page.
 
 .. _tcm_releases_1_1_acl:
 
 Access control list
 -------------------
 
-The *access control list* (*ACL*) enables control over users' access to particular spaces
-and stored functions through |tcm|.
+|tcm|'s *access control list* (*ACL*) enables control over user access to particular spaces
+and stored functions in the web interface.
 
 For each user that has access to a cluster, you can enable the use of ACL on this cluster.
-This restricts the user's access to the cluster's spaces and functions unless they
+This restricts this user's access to the cluster's spaces and functions unless they
 are explicitly specified in the ACL. The ACL must contain an entry for each such
 space and function.
 
@@ -76,7 +76,7 @@ Instance interaction
 
 The instance management dialog has been extended with new functions:
 
--   A new web terminal that uses the ``tt`` console instead of the Tarantool interactive
+-   A new terminal that uses the ``tt`` console instead of the Tarantool interactive
     console.
 -   SQL query execution terminal.
 -   Stored functions editor.
@@ -104,9 +104,9 @@ Previously, |tcm| was able to highlight the syntax errors in configurations, for
 incorrect spelling of option names or hierarchy. In |tcm| 1.1.0, the editor
 checks and highlights possible semantic issues, such as:
 
--   users without passwords
--   users with ``super`` role
--   the absence of leader instances in replicasets
+-   Users without passwords.
+-   Users with the ``super`` role.
+-   Absence of leader instances in replica sets.
 
 .. _tcm_releases_1_1_tutorial:
 
@@ -115,4 +115,3 @@ Onboarding tutorial
 
 |tcm| 1.1.0 includes an interactive tutorial that takes new users though its
 main features and pages. It opens automatically after the first start.
-

--- a/doc/reference/tooling/tcm/tcm_releases/tcm_1.1.rst
+++ b/doc/reference/tooling/tcm/tcm_releases/tcm_1.1.rst
@@ -1,0 +1,118 @@
+.. _tcm_releases_1_1:
+
+Tarantool Cluster Manager 1.1
+=============================
+
+Release date: May 16, 2024
+
+Releases in series: 1.1.0
+
+|tcm_full_name| 1.1.0 introduces a number of new features that extend and improve its
+functionality. Below is an overview of its key updates.
+
+.. _tcm_releases_1_1_data_access:
+
+Data access
+-----------
+
+An important update of |tcm| 1.1.0 is a set of features that enable access to data
+stored on your clusters.
+
+The instance *space explorer* shows all spaces that exist on an instance, including
+system spaces. On its pages, you can view and edit the stored data. To open the instance explorer,
+find the instance on the cluster stateboard and click its name to open its details page.
+Then click **Explorer** in the **Actions** menu in the top right corner.
+
+In the development mode, the instance explorer also includes the *schema editor**.
+It allows you to add new and edit existing spaces.
+
+For clusters that use the crud module, there is also the *CRUD explorer* that
+enables access to data in user spaces across the entire cluster on one page.
+The CRUD explorer is located on the **Tuples** page.
+
+.. _tcm_releases_1_1_acl:
+
+Access control list
+-------------------
+
+The *access control list* (*ACL*) enables control over users' access to particular spaces
+and stored functions through |tcm|.
+
+For each user that has access to a cluster, you can enable the use of ACL on this cluster.
+This restricts the user's access to the cluster's spaces and functions unless they
+are explicitly specified in the ACL. The ACL must contain an entry for each such
+space and function.
+
+Users with ACL off have access to all spaces and functions on clusters according
+to their cluster permissions.
+
+The tools for managing ACL are located on the new **ACL** page.
+
+.. _tcm_releases_1_1_api_tokens:
+
+API tokens
+----------
+
+|tcm| 1.1.0 supports token authentication of external requests. Users can generate
+API tokens in their user settings dialog. An API token has the same permissions
+as its creator.
+
+.. _tcm_releases_1_1_stateboard:
+
+Stateboard improvements
+-----------------------
+
+|tcm| 1.1.0 extends the functionality of the cluster stateboard to improve the
+cluster management experience. Here are the key updates of the stateboard:
+
+-   More flexible instance grouping.
+-   Stateful failover and switchover controls.
+-   Runtime issues on the stateboard.
+
+.. _tcm_releases_1_1_instance:
+
+Instance interaction
+--------------------
+
+The instance management dialog has been extended with new functions:
+
+-   A new web terminal that uses the ``tt`` console instead of the Tarantool interactive
+    console.
+-   SQL query execution terminal.
+-   Stored functions editor.
+-   Slab visualization.
+
+.. _tcm_releases_1_1_metrics:
+
+Cluster metrics
+---------------
+
+Starting from version 1.1.0, |tcm| displays metrics of connected clusters.
+You can view metrics in |tcm| one by one, visualizing them as charts or tables.
+The cluster metrics are shown on the new **Cluster metrics** page.
+
+For more complex monitoring, you can use dedicated solutions, for example, Prometheus.
+It can integrate with |tcm| using the :ref:`API tokens <tcm_releases_1_1_api_tokens>`.
+
+.. _tcm_releases_1_1_config:
+
+Configuration validation
+------------------------
+
+The cluster configuration editor now validates the configuration semantically.
+Previously, |tcm| was able to highlight the syntax errors in configurations, for example,
+incorrect spelling of option names or hierarchy. In |tcm| 1.1.0, the editor
+checks and highlights possible semantic issues, such as:
+
+-   users without passwords
+-   users with ``super`` role
+-   the absence of leader instances in replicasets
+
+.. _tcm_releases_1_1_tutorial:
+
+Onboarding tutorial
+-------------------
+
+|tcm| 1.1.0 includes an interactive tutorial that takes new users though its
+main features and pages. It opens automatically after the first start.
+


### PR DESCRIPTION
Resolves #3602 

- Add new page [TCM > Releases](https://docs.d.tarantool.io/en/doc/gh-3602-tcm-releases/reference/tooling/tcm/tcm_releases/) with a list of released versions
- Add [What's new in TCM 1.0](https://docs.d.tarantool.io/en/doc/gh-3602-tcm-releases/reference/tooling/tcm/tcm_releases/tcm_1.0/#tcm-releases-1-0)
- Add [What's new in TCM 1.1](https://docs.d.tarantool.io/en/doc/gh-3602-tcm-releases/reference/tooling/tcm/tcm_releases/tcm_1.0/#tcm-releases-1-1)

Deployment: https://docs.d.tarantool.io/en/doc/gh-3602-tcm-releases/reference/tooling/tcm/tcm_releases/