### PR TITLE
Add tt commands: binaries list/switch, kill, download

### DIFF
--- a/doc/reference/tooling/tt_cli/binaries.rst
+++ b/doc/reference/tooling/tt_cli/binaries.rst
@@ -1,23 +1,88 @@
 .. _tt-binaries:
 
-Showing a list of installed binaries
-====================================
+Managing binaries in the current environment
+============================================
 
 ..  code-block:: console
 
-    $ tt binaries
+    $ tt binaries COMMAND [PROGRAM_NAME] [VERSION]
 
-``tt binaries`` shows a list of installed binaries and their versions.
+``tt binaries`` manages Tarantool and ``tt`` binaries installed in the current environment.
 
-Examples
---------
+``COMMAND`` is one of the following:
 
-Show a list of installed Tarantool versions:
+-   :ref:`list <tt-binaries-list>`
+-   :ref:`switch <tt-binaries-switch>`
+
+
+.. _tt-binaries-list:
+
+list
+----
 
 ..  code-block:: console
 
-    $ tt binaries
+    $ tt binaries list
+
+``tt binaries list`` shows a list of installed binaries and their versions.
+
+To show a list of installed Tarantool versions:
+
+..  code-block:: console
+
+    $ tt binaries list
     List of installed binaries:
        • tarantool:
-            2.11.1 [active]
-            2.10.8
+            3.1.0 [active]
+            2.11.2
+       • tt:
+            2.3.0
+            2.2.1 [active]
+
+.. _tt-binaries-switch:
+
+switch
+------
+
+..  code-block:: console
+
+    $ tt binaries switch [PROGRAM_NAME] [VERSION]
+
+``tt binaries switch`` switches binaries used in the current environment.
+The possible values of ``PROGRAM_NAME`` are:
+
+*   ``tarantool``: Tarantool Community Edition.
+*   ``tarantool-ee``: Tarantool Enterprise Edition.
+*   ``tt``: the ``tt`` command-line utility.
+
+When called without arguments, the command lets you choose the program and
+version interactively:
+
+..  code-block:: console
+
+    $ tt binaries switch
+    Use the arrow keys to navigate: ↓ ↑ → ←
+    ? Select program:
+      ▸ tarantool
+        tarantool-ee
+        tt
+
+You can also specify the program name and version in the call.
+
+To view ``tt`` versions installed in the current environment and switch
+between them:
+
+..  code-block:: console
+
+    $ tt binaries switch tt
+    Use the arrow keys to navigate: ↓ ↑ → ←
+    ? Select version:
+      ▸ 2.2.1
+        2.3.0 [active]
+
+To switch to a specific Tarantool EE version installed in the current environment:
+
+..  code-block:: console
+
+    $ tt binaries switch tarantool-ee 3.1.0
+

--- a/doc/reference/tooling/tt_cli/binaries.rst
+++ b/doc/reference/tooling/tt_cli/binaries.rst
@@ -5,7 +5,7 @@ Managing binaries in the current environment
 
 ..  code-block:: console
 
-    $ tt binaries COMMAND [PROGRAM_NAME] [VERSION]
+    $ tt binaries COMMAND [COMMAND_OPTION ...]
 
 ``tt binaries`` manages Tarantool and ``tt`` binaries installed in the current environment.
 

--- a/doc/reference/tooling/tt_cli/commands.rst
+++ b/doc/reference/tooling/tt_cli/commands.rst
@@ -50,6 +50,8 @@ help for the given command.
             -   Install Tarantool or ``tt``
         *   -   :doc:`instances <instances>`
             -   List enabled applications
+        *   -   :doc:`kill <kill>`
+            -   Terminate Tarantool applications or instances
         *   -   :doc:`logrotate <logrotate>`
             -   Rotate instance logs
         *   -   :doc:`pack <pack>`
@@ -59,7 +61,7 @@ help for the given command.
         *   -   :doc:`replicaset <replicaset>`
             -   Manage replica sets
         *   -   :doc:`restart <restart>`
-            -   Restart a Tarantool instance
+            -   Restart Tarantool applications or instances
         *   -   :doc:`rocks <rocks>`
             -   Use the LuaRocks package manager
         *   -   :doc:`run <run>`
@@ -67,11 +69,11 @@ help for the given command.
         *   -   :doc:`search <search>`
             -   Search available Tarantool and ``tt`` versions
         *   -   :doc:`start <start>`
-            -   Start a Tarantool instance
+            -   Start Tarantool applications or instances
         *   -   :doc:`status <status>`
-            -   Get the current status of a Tarantool instance
+            -   Get the current status of applications or instances
         *   -   :doc:`stop <stop>`
-            -   Stop a Tarantool instance
+            -   Stop Tarantool applications or instances
         *   -   :doc:`tdg2 <tdg2>`
             -   Interact with `Tarantool Data Grid 2 <https://www.tarantool.io/ru/tdg/latest/>`_ clusters
         *   -   :doc:`uninstall <uninstall>`
@@ -101,6 +103,7 @@ help for the given command.
     init <init>
     install <install>
     instances <instances>
+    kill <kill>
     logrotate <logrotate>
     pack <pack>
     play <play>

--- a/doc/reference/tooling/tt_cli/commands.rst
+++ b/doc/reference/tooling/tt_cli/commands.rst
@@ -38,6 +38,8 @@ help for the given command.
             -   Create an application from a template
         *   -   :doc:`crud <crud>`
             -   Interact with the CRUD module (`Enterprise only <https://www.tarantool.io/compare/>`_)
+        *   -   :doc:`download <download>`
+            -   Download the Tarantool Enterprise SDK
         *   -   :doc:`export <export>`
             -   Export data to a file (`Enterprise only <https://www.tarantool.io/compare/>`_)
         *   -   :doc:`help <help>`
@@ -97,6 +99,7 @@ help for the given command.
     coredump <coredump>
     create <create>
     crud <crud>
+    download <download>
     export <export>
     help <help>
     import <import>

--- a/doc/reference/tooling/tt_cli/download.rst
+++ b/doc/reference/tooling/tt_cli/download.rst
@@ -28,7 +28,7 @@ To download the Tarantool Enterprise SDK using ``tt download``, you need to prov
 access credentials for the Tarantool customer zone. Use one of the following ways to pass
 the username and the password:
 
-*   A text file specified in the ``ee.credentials_path`` parameter of the
+*   A text file specified in the ``ee.credential_path`` parameter of the
     :ref:`tt environment configuration <tt-config_file>`:
 
     ..  code-block:: yaml

--- a/doc/reference/tooling/tt_cli/download.rst
+++ b/doc/reference/tooling/tt_cli/download.rst
@@ -25,11 +25,11 @@ Authentication
 ~~~~~~~~~~~~~~
 
 To download the Tarantool Enterprise SDK using ``tt download``, you need to provide
-access credentials for Tarantool customer zone. Use one of the following ways to pass
+access credentials for the Tarantool customer zone. Use one of the following ways to pass
 the username and the password:
 
 *   A text file specified in the ``ee.credentials_path`` parameter of the
-    :ref:`tt enviromnment configuration <tt-config_file>`:
+    :ref:`tt environment configuration <tt-config_file>`:
 
     ..  code-block:: yaml
 

--- a/doc/reference/tooling/tt_cli/download.rst
+++ b/doc/reference/tooling/tt_cli/download.rst
@@ -1,0 +1,65 @@
+.. _tt-download:
+
+Downloading Tarantool Enterprise SDK
+====================================
+
+..  code-block:: console
+
+    $ tt download VERSION [OPTION ...]
+
+``tt download`` downloads Tarantool Enterprise SDK from the customer zone.
+
+The ``VERSION`` is a part of the SDK archive name between ``tarantool-enterprise-sdk-``
+and the platform identifier. For example, to download ``tarantool-enterprise-sdk-gc64-3.0.0-0-gf58f7d82a-r23.linux.x86_64.tar.gz``,
+run:
+
+..  code-block:: console
+
+    $ tt download gc64-3.0.0-0-gf58f7d82a-r23
+
+``tt`` automatically chooses the bundle for the current platform.
+
+.. _tt-download-authentication:
+
+Authentication
+~~~~~~~~~~~~~~
+
+To download the Tarantool Enterprise SDK using ``tt download``, you need to provide
+access credentials for Tarantool customer zone. Use one of the following ways to pass
+the username and the password:
+
+*   A text file specified in the ``ee.credentials_path`` parameter of the
+    :ref:`tt enviromnment configuration <tt-config_file>`:
+
+    ..  code-block:: yaml
+
+        # tt.yaml
+        # ...
+        ee:
+          credential_path: cred.txt
+
+    `cred.txt` should contain a username and a password on separate lines:
+
+    .. code-block:: text
+
+        myuser@tarantool.io
+        p4$$w0rD
+
+*   Environment variables ``TT_CLI_EE_USERNAME`` and ``TT_CLI_EE_PASSWORD``:
+
+    ..  code-block:: console
+
+        $ export TT_CLI_EE_USERNAME=myuser@tarantool.io
+        $ export TT_CLI_EE_PASSWORD=p4$$w0rD
+        $ tt download gc64-3.0.0-0-gf58f7d82a-r23
+
+Options
+-------
+
+.. option:: --dev
+
+    Download a development build.
+
+.. option:: --directory-prefix STRING
+
+    The downloaded SDK location. Default: ``.`` (current directory).

--- a/doc/reference/tooling/tt_cli/install.rst
+++ b/doc/reference/tooling/tt_cli/install.rst
@@ -77,9 +77,9 @@ Authentication
 ~~~~~~~~~~~~~~
 
 To install Tarantool EE using ``tt install``, you need to provide access credentials
-for Tarantool customer zone. Use one of the following ways to pass the username and the password:
+for the Tarantool customer zone. Use one of the following ways to pass the username and the password:
 
-*   A text file specified in the ``ee.credentials_path`` parameter of the
+*   A text file specified in the ``ee.credential_path`` parameter of the
     :ref:`tt enviromnment configuration <tt-config_file>`:
 
     ..  code-block:: yaml

--- a/doc/reference/tooling/tt_cli/kill.rst
+++ b/doc/reference/tooling/tt_cli/kill.rst
@@ -1,0 +1,39 @@
+.. _tt-kill:
+
+Terminating Tarantool instances
+===============================
+
+..  code-block:: console
+
+    $ tt kill APPLICATION[:APP_INSTANCE]
+
+``tt kill`` terminates instances with ``SIGQUIT`` and ``SIGKILL`` signals.
+
+To terminate all instances of the ``app`` application:
+
+..  code-block:: console
+
+    $ tt stop app
+
+To terminate the ``storage-001-r`` instance of the ``app`` application without confirmation:
+
+..  code-block:: console
+
+    $ tt stop app:storage-001-r --force
+
+To terminate the ``storage-001-r`` instance of the ``app`` application and generate its core dump:
+
+..  code-block:: console
+
+    $ tt stop app:storage-001-r --dump
+
+Options
+-------
+
+.. option:: -d, --dump
+
+    Generate core dumps of terminated processes.
+
+.. option:: -f, --force
+
+    Kill instances without confirmation.


### PR DESCRIPTION
Resolves #4026, #4032, #4222

Add missing tt commands reference:
- [tt binaries list/switch ](https://docs.d.tarantool.io/en/doc/gh-4026-tt-binaries/reference/tooling/tt_cli/binaries/)(update the current page)
- [tt kill](https://docs.d.tarantool.io/en/doc/gh-4026-tt-binaries/reference/tooling/tt_cli/kill/)
- [tt download](https://docs.d.tarantool.io/en/doc/gh-4026-tt-binaries/reference/tooling/tt_cli/download/)

Deployment: https://docs.d.tarantool.io/en/doc/gh-4026-tt-binaries/reference/tooling/tt_cli/binaries/