### PR TITLE
Update tt docs to 2.3.0 (misc changes)

### DIFF
--- a/doc/book/admin/server_introspection.rst
+++ b/doc/book/admin/server_introspection.rst
@@ -79,8 +79,8 @@ To check the instance status, run:
 .. code-block:: console
 
     $ tt status my_app
-    INSTANCE     STATUS      PID
-    my_app       RUNNING     67172
+    INSTANCE     STATUS      PID   MODE
+    my_app       RUNNING     67172 RW
 
     $ # - OR -
 

--- a/doc/book/admin/start_stop_instance.rst
+++ b/doc/book/admin/start_stop_instance.rst
@@ -73,20 +73,20 @@ To check the status of instances, execute :ref:`tt status <tt-status>`:
 .. code-block:: console
 
     $ tt status sharded_cluster
-    INSTANCE                          STATUS      PID
-    sharded_cluster:storage-a-001     RUNNING     2023
-    sharded_cluster:storage-a-002     RUNNING     2026
-    sharded_cluster:storage-b-001     RUNNING     2020
-    sharded_cluster:storage-b-002     RUNNING     2021
-    sharded_cluster:router-a-001      RUNNING     2022
+    INSTANCE                          STATUS      PID   MODE
+    sharded_cluster:storage-a-001     RUNNING     2023  RW
+    sharded_cluster:storage-a-002     RUNNING     2026  RO
+    sharded_cluster:storage-b-001     RUNNING     2020  RW
+    sharded_cluster:storage-b-002     RUNNING     2021  RO
+    sharded_cluster:router-a-001      RUNNING     2022  RW
 
 To check the status of a specific instance, you need to specify its name:
 
 .. code-block:: console
 
     $ tt status sharded_cluster:storage-a-001
-    INSTANCE                          STATUS      PID
-    sharded_cluster:storage-a-001     RUNNING     2023
+    INSTANCE                          STATUS      PID   MODE
+    sharded_cluster:storage-a-001     RUNNING     2023  RW
 
 
 .. _admin-start_stop_instance_connect:

--- a/doc/how-to/getting_started_db.rst
+++ b/doc/how-to/getting_started_db.rst
@@ -76,8 +76,8 @@ Starting an instance
     ..  code-block:: console
 
         $ tt status create_db
-        INSTANCE                       STATUS      PID
-        create_db:instance001          RUNNING     54560
+        INSTANCE                       STATUS      PID   MODE
+        create_db:instance001          RUNNING     54560 RW
 
 #.  Connect to the instance with :ref:`tt connect <tt-connect>`:
 

--- a/doc/how-to/getting_started_tcm.rst
+++ b/doc/how-to/getting_started_tcm.rst
@@ -253,10 +253,10 @@ To deploy a local cluster based on the configuration from etcd:
     .. code-block:: console
 
         $ tt status cluster
-        INSTANCE               STATUS      PID
-        cluster:instance-001     RUNNING     2058
-        cluster:instance-002     RUNNING     2059
-        cluster:instance-003     RUNNING     2060
+        INSTANCE                 STATUS      PID   MODE
+        cluster:instance-001     RUNNING     2058  RW
+        cluster:instance-002     RUNNING     2059  RO
+        cluster:instance-003     RUNNING     2060  RO
 
 ..  _getting_started_tcm_manage:
 

--- a/doc/how-to/replication/repl_bootstrap.rst
+++ b/doc/how-to/replication/repl_bootstrap.rst
@@ -137,9 +137,9 @@ Starting instances
     .. code-block:: console
 
         $ tt status manual_leader
-        INSTANCE                      STATUS      PID
-        manual_leader:instance001     RUNNING     15272
-        manual_leader:instance002     RUNNING     15273
+        INSTANCE                      STATUS      PID   MODE
+        manual_leader:instance001     RUNNING     15272 RW
+        manual_leader:instance002     RUNNING     15273  RO
 
 
 .. _replication-master_replica_status:
@@ -292,10 +292,10 @@ Starting an instance
     .. code-block:: console
 
         $ tt status manual_leader
-        INSTANCE                      STATUS      PID
-        manual_leader:instance001     RUNNING     15272
-        manual_leader:instance002     RUNNING     15273
-        manual_leader:instance003     RUNNING     15551
+        INSTANCE                      STATUS      PID   MODE
+        manual_leader:instance001     RUNNING     15272 RW
+        manual_leader:instance002     RUNNING     15273 RO
+        manual_leader:instance003     RUNNING     15551 RO
 
 
 ..  _replication-add_instances-reload-config:

--- a/doc/how-to/replication/repl_bootstrap.rst
+++ b/doc/how-to/replication/repl_bootstrap.rst
@@ -139,7 +139,7 @@ Starting instances
         $ tt status manual_leader
         INSTANCE                      STATUS      PID   MODE
         manual_leader:instance001     RUNNING     15272 RW
-        manual_leader:instance002     RUNNING     15273  RO
+        manual_leader:instance002     RUNNING     15273 RO
 
 
 .. _replication-master_replica_status:

--- a/doc/how-to/replication/repl_bootstrap_auto.rst
+++ b/doc/how-to/replication/repl_bootstrap_auto.rst
@@ -135,10 +135,10 @@ Starting instances
     .. code-block:: console
 
         $ tt status auto_leader
-        INSTANCE                    STATUS      PID
-        auto_leader:instance001     RUNNING     24768
-        auto_leader:instance002     RUNNING     24769
-        auto_leader:instance003     RUNNING     24767
+        INSTANCE                    STATUS      PID   MODE
+        auto_leader:instance001     RUNNING     24768 RO
+        auto_leader:instance002     RUNNING     24769 RW
+        auto_leader:instance003     RUNNING     24767 RO
 
 
 

--- a/doc/how-to/replication/repl_bootstrap_master_master.rst
+++ b/doc/how-to/replication/repl_bootstrap_master_master.rst
@@ -141,9 +141,9 @@ Starting instances
     .. code-block:: console
 
         $ tt status master_master
-        INSTANCE                      STATUS      PID
-        master_master:instance001     RUNNING     30818
-        master_master:instance002     RUNNING     30819
+        INSTANCE                      STATUS      PID   MODE
+        master_master:instance001     RUNNING     30818 RW
+        master_master:instance002     RUNNING     30819 RW
 
 
 .. _replication-master-master-check-status:

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -9,7 +9,7 @@ Configuration file
 ------------------
 
 The key artifact that defines the ``tt`` environment and various aspects of its
-execution is its configuration file. You can generate it with a :ref:`tt-init` call.
+execution is its configuration file. You can generate it with a :ref:`tt init <tt-init>` call.
 In the :ref:`default launch mode <tt-config_modes-default>`, the file is generated
 in the current directory, making it the environment root.
 

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -21,10 +21,10 @@ Name and location
 By default, the configuration file is called ``tt.yaml`` and located in the ``tt``
 environment root directory. It depends on the :ref:`launch mode <tt-config_modes>`.
 
-It is also possible to pass the configuration file and location explicitly using
+It is also possible to pass the configuration file name and location explicitly using
 the following ways:
 
-#.  ``--cfg`` :ref:`global option <tt-global-options>`
+#.  ``-c``/``--cfg`` :ref:`global option <tt-global-options>`
 #.  ``TT_CLI_CFG`` environment variable.
 
 The ``TT_CLI_CFG`` variable has a lower priority than the ``--cfg`` option.

--- a/doc/reference/tooling/tt_cli/configuration.rst
+++ b/doc/reference/tooling/tt_cli/configuration.rst
@@ -9,12 +9,30 @@ Configuration file
 ------------------
 
 The key artifact that defines the ``tt`` environment and various aspects of its
-execution is its configuration file.
+execution is its configuration file. You can generate it with a :ref:`tt-init` call.
+In the :ref:`default launch mode <tt-config_modes-default>`, the file is generated
+in the current directory, making it the environment root.
 
-By default, the configuration file is called ``tt.yaml``. The location
-where ``tt`` searches for it depends on the :ref:`launch mode <tt-config_modes>`.
-You can also pass the configuration file explicitly in the ``--cfg``
-:ref:`global option <tt-global-options>`.
+.. _tt-config_file_name:
+
+Name and location
+~~~~~~~~~~~~~~~~~
+
+By default, the configuration file is called ``tt.yaml`` and located in the ``tt``
+environment root directory. It depends on the :ref:`launch mode <tt-config_modes>`.
+
+It is also possible to pass the configuration file and location explicitly using
+the following ways:
+
+#.  ``--cfg`` :ref:`global option <tt-global-options>`
+#.  ``TT_CLI_CFG`` environment variable.
+
+The ``TT_CLI_CFG`` variable has a lower priority than the ``--cfg`` option.
+
+.. _tt-config_file_structure:
+
+Structure
+~~~~~~~~~
 
 The ``tt`` configuration file is a YAML file with the following structure:
 
@@ -158,6 +176,8 @@ configuration file. There are three launch modes:
 *   default
 *   system
 *   local
+
+.. _tt-config_modes-default:
 
 Default launch
 ~~~~~~~~~~~~~~

--- a/doc/reference/tooling/tt_cli/coredump.rst
+++ b/doc/reference/tooling/tt_cli/coredump.rst
@@ -15,12 +15,12 @@ on the host. Here is the :ref:`instruction on enabling core dumps on Unix system
 ``COMMAND`` is one of the following:
 
 *   :ref:`pack <tt-coredump-pack>`
-*   :ref:`promote <tt-replicaset-promote>`
-*   :ref:`demote <tt-replicaset-demote>`
+*   :ref:`unpack <tt-coredump-unpack>`
+*   :ref:`inspect <tt-coredump-inspect>`
 
 ..  important::
 
-        ``tt coredump`` does not support macOS.
+    ``tt coredump`` does not support macOS.
 
 .. _tt-coredump-pack:
 
@@ -69,17 +69,23 @@ inspect
 
 ..  code-block:: console
 
-    $ tt coredump inspect [ARCHIVE|DIRECTORY] [OPTION ...]
+    $ tt coredump inspect [ARCHIVE|DIRECTORY] [-s]
 
 Inspect a Tarantool core dump with the `GNU debugger <https://www.sourceware.org/gdb/>`__ (``gdb``).
 The command argument can be either an archive file produced with ``tt coredump pack``
 or directory where such an archive is extracted.
 
-Inspect the unpacked core dump with ``gdb``:
+Inspect the core dump archive with ``gdb``:
 
-    ..  code-block:: console
+..  code-block:: console
 
-        $ tt coredump inspect tarantool-core-dump
+    $ tt coredump inspect tarantool-core-dump.tar.gz
+
+Inspect the unpacked core dump directory with ``gdb``:
+
+..  code-block:: console
+
+    $ tt coredump inspect tarantool-core-dump
 
 
 Options

--- a/doc/reference/tooling/tt_cli/coredump.rst
+++ b/doc/reference/tooling/tt_cli/coredump.rst
@@ -20,7 +20,7 @@ on the host. Here is the :ref:`instruction on enabling core dumps on Unix system
 
 ..  important::
 
-    ``tt coredump`` does not support macOS.
+    ``tt coredump`` is not supported on macOS.
 
 .. _tt-coredump-pack:
 

--- a/doc/reference/tooling/tt_cli/coredump.rst
+++ b/doc/reference/tooling/tt_cli/coredump.rst
@@ -12,15 +12,20 @@ Manipulating Tarantool core dumps
 To be able to investigate Tarantool crashes, make sure that core dumps are enabled
 on the host. Here is the :ref:`instruction on enabling core dumps on Unix systems <admin-core_dumps>`.
 
+``COMMAND`` is one of the following:
+
+*   :ref:`pack <tt-coredump-pack>`
+*   :ref:`promote <tt-replicaset-promote>`
+*   :ref:`demote <tt-replicaset-demote>`
+
 ..  important::
 
         ``tt coredump`` does not support macOS.
 
-Commands
---------
+.. _tt-coredump-pack:
 
 pack
-~~~~
+----
 
 ..  code-block:: console
 
@@ -32,57 +37,56 @@ It includes:
 *   the Tarantool executable
 *   Tarantool version information
 *   OS information
-*   Shared libraries
+*   shared libraries
+*   the `GNU debugger <https://www.sourceware.org/gdb/>`__ with extensions.
 
-Option: a path to a core dump file.
+Pack a ``tar.gz`` file with a Tarantool core dump and supporting data:
+
+..  code-block:: console
+
+    $ tt coredump pack name.core
+
+.. _tt-coredump-unpack:
 
 unpack
-~~~~~~
+------
 
 ..  code-block:: console
 
     $ tt coredump unpack ARCHIVE
 
-Unpack a Tarantool core dump created with ``tt coredump pack`` into a new directory.
-
-Option: a path to a ``tar.gz`` archive packed by ``tt coredump pack``.
-
-inspect
-~~~~~~~
+Unpack a Tarantool core dump archive created with ``tt coredump pack`` into a new directory:
 
 ..  code-block:: console
 
-    $ tt coredump inspect DIRECTORY
-
-Inspect a Tarantool core dump directory with the `GNU debugger <https://www.sourceware.org/gdb/>`__ (``gdb``)
-The directory being inspected must have the same structure as the core dump archive
-created by ``tt coredump pack``.
-
-.. note::
-
-    ``tt coredump inspect`` requires ``gdb`` installed on the host.
-
-Option: a path to a directory with an unpacked core dump archive.
-
-Examples
---------
-
-*   Pack a ``tar.gz`` file with a Tarantool core dump and supporting data:
-
-    ..  code-block:: console
-
-        $ tt coredump pack name.core
+    $ tt coredump unpack tarantool-core-dump.tar.gz
 
 
-*   Unpack a ``tar.gz`` archive packed by ``tt coredump pack``:
+.. _tt-coredump-inspect:
 
-    ..  code-block:: console
+inspect
+-------
 
-        $ tt coredump unpack tarantool-core-dump.tar.gz
+..  code-block:: console
 
+    $ tt coredump inspect [ARCHIVE|DIRECTORY] [OPTION ...]
 
-*   Inspect the unpacked core dump with ``gdb``:
+Inspect a Tarantool core dump with the `GNU debugger <https://www.sourceware.org/gdb/>`__ (``gdb``).
+The command argument can be either an archive file produced with ``tt coredump pack``
+or directory where such an archive is extracted.
+
+Inspect the unpacked core dump with ``gdb``:
 
     ..  code-block:: console
 
         $ tt coredump inspect tarantool-core-dump
+
+
+Options
+-------
+
+..  option:: -s
+
+    **Applicable to**: ``inspect``
+
+    Specify the location of Tarantool sources.

--- a/doc/reference/tooling/tt_cli/create.rst
+++ b/doc/reference/tooling/tt_cli/create.rst
@@ -14,7 +14,7 @@ Creating an application from a template
 defining their initial structure and content. A template can include application
 code, configuration, build scripts, and other resources.
 
-``tt`` comes with built-in templates for popular use-cases. You can also create
+``tt`` comes with built-in templates for popular use cases. You can also create
 custom templates for specific purposes.
 
 .. _tt-create-built-in:
@@ -25,7 +25,7 @@ Built-in templates
 There are the following built-in templates:
 
 -   ``vshard_cluster``: a sharded cluster application for Tarantool 3.0 or later.
--   ``single_instance``: a single-instance-application for Tarantool 3.0 or later
+-   ``single_instance``: a single-instance application for Tarantool 3.0 or later
 -   ``cartridge``: a Cartridge cluster application for Tarantool 2.x.
 
     .. important::
@@ -33,14 +33,15 @@ There are the following built-in templates:
         The Tarantool Cartridge framework is deprecated and is not compatible with
         Tarantool 3.0 and later.
 
-To create the ``app1`` application in the current ``tt` environment from the built-in
+To create the ``app1`` application in the current ``tt`` environment from the built-in
 ``vshard_cluster`` template:
 
 ..  code-block:: console
 
     $ tt create vshard_cluster --name app1 -dst /opt/tt/apps/
 
-The command requests the cluster topology parameters interactively during the execution.
+The command requests the cluster topology parameters, such as the number of shards
+or routers, interactively during the execution.
 
 To create the application in the ``/opt/tt/apps`` directory with default cluster
 topology and force rewrite the application directory if it already exists:
@@ -58,7 +59,7 @@ Creating custom application templates
 ``tt`` searches for custom templates in the directories specified in the ``templates``
 section of its :ref:`configuration file <tt-config_file>`.
 
-To create the application ``app1`` from the ``simple_app`` user-defined template in the current directory:
+To create the application ``app1`` from the ``simple_app`` custom template in the current directory:
 
 ..  code-block:: console
 
@@ -202,13 +203,12 @@ You can combine different ways of passing variables in a single call of ``tt cre
 .. _tt-create-custom-directory:
 
 Application directory
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 By default, the application appears in the directory named after the provided
 application name (``--name`` value).
 
 To change the application location, use the ``-dst`` option.
-
 
 .. _tt-create-options:
 

--- a/doc/reference/tooling/tt_cli/create.rst
+++ b/doc/reference/tooling/tt_cli/create.rst
@@ -10,42 +10,61 @@ Creating an application from a template
 
 ``tt create`` creates a new Tarantool application from a template.
 
-Options
--------
-
-.. option:: -d PATH, --dst PATH
-
-    Path to the directory where the application will be created.
-
-.. option:: -f, --force
-
-    Force rewrite the application directory if it already exists.
-
-.. option:: --name NAME
-
-    Application name.
-
-.. option:: -s, --non-interactive
-
-    Non-interactive mode.
-
-.. option:: --var [VAR=VALUE ...]
-
-    Variable definition. Usage: ``--var var_name=value``.
-
-.. option:: --vars-file FILEPATH
-
-    Path to the file with variable definitions.
-
-Details
--------
-
 *Application templates* speed up the development of Tarantool applications by
 defining their initial structure and content. A template can include application
 code, configuration, build scripts, and other resources.
 
-``tt`` searches templates in the directories specified in the ``templates`` section
-of its :ref:`configuration file <tt-config_file>`.
+``tt`` comes with built-in templates for popular use-cases. You can also create
+custom templates for specific purposes.
+
+.. _tt-create-built-in:
+
+Built-in templates
+------------------
+
+There are the following built-in templates:
+
+-   ``vshard_cluster``: a sharded cluster application for Tarantool 3.0 or later.
+-   ``single_instance``: a single-instance-application for Tarantool 3.0 or later
+-   ``cartridge``: a Cartridge cluster application for Tarantool 2.x.
+
+    .. important::
+
+        The Tarantool Cartridge framework is deprecated and is not compatible with
+        Tarantool 3.0 and later.
+
+To create the ``app1`` application in the current ``tt` environment from the built-in
+``vshard_cluster`` template:
+
+..  code-block:: console
+
+    $ tt create vshard_cluster --name app1 -dst /opt/tt/apps/
+
+The command requests the cluster topology parameters interactively during the execution.
+
+To create the application in the ``/opt/tt/apps`` directory with default cluster
+topology and force rewrite the application directory if it already exists:
+
+..  code-block:: console
+
+    $ tt create vshard_cluster --name app1 -f --non-interactive -dst /opt/tt/apps/
+
+
+.. _tt-create-custom:
+
+Creating custom application templates
+-------------------------------------
+
+``tt`` searches for custom templates in the directories specified in the ``templates``
+section of its :ref:`configuration file <tt-config_file>`.
+
+To create the application ``app1`` from the ``simple_app`` user-defined template in the current directory:
+
+..  code-block:: console
+
+    $ tt create simple_app --name app1
+
+.. _tt-create-custom-structure:
 
 Template structure
 ~~~~~~~~~~~~~~~~~~
@@ -101,7 +120,7 @@ adjusted for each application with the help of :ref:`template variables <templat
 During the instantiation, the variables in these files are replaced with provided
 values and the ``*.tt.template`` extension is removed.
 
-.. _template-variables:
+.. _tt-create-custom-variables:
 
 Variables
 ~~~~~~~~~
@@ -180,6 +199,8 @@ from the manifest is used.
 
 You can combine different ways of passing variables in a single call of ``tt create``.
 
+.. _tt-create-custom-directory:
+
 Application directory
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -188,20 +209,32 @@ application name (``--name`` value).
 
 To change the application location, use the ``-dst`` option.
 
-Examples
---------
 
-*   Create the application ``app1`` from the ``simple_app`` user-defined template in the current directory:
+.. _tt-create-options:
 
-    ..  code-block:: console
+Options
+-------
 
-        $ tt create simple_app --name app1
+.. option:: -d PATH, --dst PATH
 
+    Path to the directory where the application will be created.
 
-*   Create the ``app1`` application in ``/opt/tt/apps`` from the built-in ``vshard_cluster`` template,
-    force rewrite the application directory if it already exists.
-    User interaction is disabled.
+.. option:: -f, --force
 
-    ..  code-block:: console
+    Force rewrite the application directory if it already exists.
 
-        $ tt create vshard_cluster --name app1 -f --non-interactive -dst /opt/tt/apps/
+.. option:: --name NAME
+
+    Application name.
+
+.. option:: -s, --non-interactive
+
+    Non-interactive mode.
+
+.. option:: --var [VAR=VALUE ...]
+
+    Variable definition. Usage: ``--var var_name=value``.
+
+.. option:: --vars-file FILEPATH
+
+    Path to the file with variable definitions.

--- a/doc/reference/tooling/tt_cli/create.rst
+++ b/doc/reference/tooling/tt_cli/create.rst
@@ -25,7 +25,7 @@ Built-in templates
 There are the following built-in templates:
 
 -   ``vshard_cluster``: a sharded cluster application for Tarantool 3.0 or later.
--   ``single_instance``: a single-instance application for Tarantool 3.0 or later
+-   ``single_instance``: a single-instance application for Tarantool 3.0 or later.
 -   ``cartridge``: a Cartridge cluster application for Tarantool 2.x.
 
     .. important::
@@ -40,7 +40,7 @@ To create the ``app1`` application in the current ``tt`` environment from the bu
 
     $ tt create vshard_cluster --name app1 -dst /opt/tt/apps/
 
-The command requests the cluster topology parameters, such as the number of shards
+The command requests cluster topology parameters, such as the number of shards
 or routers, interactively during the execution.
 
 To create the application in the ``/opt/tt/apps`` directory with default cluster

--- a/doc/reference/tooling/tt_cli/global_options.rst
+++ b/doc/reference/tooling/tt_cli/global_options.rst
@@ -14,9 +14,11 @@ Global options
 
 ``tt`` has the following global options:
 
-.. option:: -c=FILE, --cfg=FILE,
+.. option:: -c=file, --cfg=file,
 
     Path to the :ref:`configuration file <tt-config_file>`.
+
+    Alternatively, this path can be passed in the ``TT_CLI_CFG`` environment variable.
 
 .. option:: -h, --help
 

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -123,6 +123,24 @@ Below are the rules if some fields are missing in input data or space:
 *   If a space has fields that are not specified in input data, ``tt [crud] import`` tries to insert ``null`` values.
 *   If input data contains fields missing in a target space, these fields are ignored.
 
+.. _tt-import-bucket-id:
+
+Importing bucket_id into sharded clusters
+-----------------------------------------
+
+When importing data into a CRUD-enabled sharded cluster, ``tt crud import`` ignores
+the ``bucket_id`` field values. This allows CRUD to automatically manage data
+distribution in the cluster by assigning a new ``bucket_id`` to each tuple.
+
+If you need to preserve the original ``bucket_id`` values, use the ``--keep-bucket-id`` option:
+
+.. code-block:: console
+
+    $ tt crud import localhost:3301 customers.csv:customers \
+                     --keep-bucket-id \
+                     --header \
+                     --match=header
+
 .. _tt-import-duplicate-error:
 
 Handling duplicate primary key errors
@@ -268,6 +286,14 @@ Options
     In this case, field values start from the second line.
 
     See also: :ref:`Matching of input and space fields <tt-import-match-fields>`.
+
+..  option:: --keep-bucket-id
+
+    **Applicable to:** ``tt crud import``
+
+    Preserve original values of the ``bucket_id`` field.
+
+    See also: :ref:`tt-import-bucket-id`.
 
 ..  option:: --log STRING
 

--- a/doc/reference/tooling/tt_cli/import.rst
+++ b/doc/reference/tooling/tt_cli/import.rst
@@ -129,8 +129,9 @@ Importing bucket_id into sharded clusters
 -----------------------------------------
 
 When importing data into a CRUD-enabled sharded cluster, ``tt crud import`` ignores
-the ``bucket_id`` field values. This allows CRUD to automatically manage data
-distribution in the cluster by assigning a new ``bucket_id`` to each tuple.
+the ``bucket_id`` field values from the input file. This allows CRUD to automatically
+manage data distribution in the cluster by generating new ``bucket_id`` for tuples
+during import.
 
 If you need to preserve the original ``bucket_id`` values, use the ``--keep-bucket-id`` option:
 

--- a/doc/reference/tooling/tt_cli/status.rst
+++ b/doc/reference/tooling/tt_cli/status.rst
@@ -5,24 +5,42 @@ Checking instance status
 
 ..  code-block:: console
 
-    $ tt status APPLICATION[:APP_INSTANCE]
+    $ tt status [APPLICATION[:APP_INSTANCE]] [-p|--pretty]
 
-``tt status`` prints the current status of Tarantool applications and instances
-in the current environment. When called without arguments, prints the status of
-all enabled applications in the current environment.
+``tt status`` prints the information about Tarantool applications and instances
+in the current environment. This includes:
+
+- Application and instance names
+- Instance statuses: running or not
+- PIDs
+- Instance modes: read-write or read-only
+
+When called without arguments, prints the status of all enabled applications in the current environment.
 
 Examples
 --------
 
-*   Check the status of all instances of the ``app`` application:
+*   Print the status of all instances of the ``app`` application:
 
     ..  code-block:: console
 
         $ tt status app
 
-*   Check the status of the ``replica`` instance of the ``app`` application:
+*   Print the status of the ``replica`` instance of the ``app`` application:
 
     ..  code-block:: console
 
         $ tt status app:replica
 
+*   Pretty-print the status of the ``replica`` instance of the ``app`` application:
+
+    ..  code-block:: console
+
+        $ tt status app:replica --pretty
+
+Options
+-------
+
+..  option:: -p, --pretty
+
+    Print the status as a pretty-formatted table.


### PR DESCRIPTION
Resolves #4188, #4288, #4289, #4290, #4291

Update `tt` documentation to various changes of 2.3.0 version:
- New `TT_CLI_CFG` env variable: add TT_CLI_CFG to [tt configuration](https://docs.d.tarantool.io/en/doc/gh-4289-tt-small-updates/reference/tooling/tt_cli/configuration/) and [tt global options](https://docs.d.tarantool.io/en/doc/gh-4289-tt-small-updates/reference/tooling/tt_cli/global_options/) pages
- [tt coredump](https://docs.d.tarantool.io/en/doc/gh-4289-tt-small-updates/reference/tooling/tt_cli/coredump/) updates: 
  - archive as `inspect` argument
  - GDB with extensions included in `pack` archive
  - `-s` option for `inspect`
- [tt status](https://docs.d.tarantool.io/en/doc/gh-4289-tt-small-updates/reference/tooling/tt_cli/status/) changed output and `--pretty` option: update `tt status output` description, add `-p/--pretty` option, update output examples across documentation.
- [tt crud import](https://docs.d.tarantool.io/en/doc/gh-4289-tt-small-updates/reference/tooling/tt_cli/import/) ignoring `bucket_id` and `--keep-bucket-id` option: add subsection about handling bucket_id, add `--keep-bucket-id` option.
- [tt create](https://docs.d.tarantool.io/en/doc/gh-4289-tt-small-updates/reference/tooling/tt_cli/create/) new template `single_instance`: add a subsection about all built-in templates, move content about custom templates to a separate subsection.
 

Deployment: https://docs.d.tarantool.io/en/doc/gh-4289-tt-small-updates/reference/tooling/tt_cli/commands/