### PR TITLE
Add new tt commands: tt rs expel, tt rs vshard bootstrap, tt cluster publish with new instance

### DIFF
--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -74,8 +74,10 @@ Publishing configurations of specific instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In addition to whole cluster configurations, ``tt cluster publish`` can manage
-configurations of specific instances within applications. In this case, it operates
-with YAML fragments that describe a single :ref:`instance configuration section <configuration_overview>`.
+configurations of specific instances within applications: rewrite configurations
+of existing instances and add new instance configurations.
+
+In this case, it operates with YAML fragments that describe a single :ref:`instance configuration section <configuration_overview>`.
 For example, the following YAML file can be a source when publishing an instance configuration:
 
 .. code-block:: yaml
@@ -98,6 +100,23 @@ the instance name in the ``name`` argument of the storage URI:
 .. code-block:: console
 
     $ tt cluster publish "http://localhost:2379/myapp?name=instance-002" instance_source.yaml
+
+If the instance already exists, this call overwrites its configuration with the one
+from the file.
+
+To add a new instance configuration from a YAML fragment, specify the name to assign to
+the new instance and its location in the cluster topology -- replica set and group --
+in the ``--replicaset`` and ``--group`` options.
+
+.. note::
+
+    The ``--group`` option can be omitted if the configuration contains only one group.
+
+To add a new instance ``instance-003`` to the ``replicaset-001`` replica set:
+
+.. code-block:: console
+
+    tt cluster publish "http://localhost:2379/myapp?name=instance-003" instance_source.yaml --replicaset replicaset-001
 
 
 .. _tt-cluster-publish-validation:
@@ -449,6 +468,18 @@ Options
     **Applicable to:** ``publish``
 
     Skip validation when publishing. Default: `false` (validation is enabled).
+
+..  option:: --group
+
+    **Applicable to:** ``publish``
+
+    A name of the configuration group to which the instance belongs.
+
+..  option:: --replicaset
+
+    **Applicable to:** ``publish``
+
+    A name of the replica set to which the instance belongs.
 
 ..  option:: -t, --timeout UINT
 

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -287,11 +287,11 @@ in the cluster.
 
     $ tt replicaset vshard bootstrap myapp
 
-With credentials:
+With a URI and credentials:
 
 ..  code-block:: console
 
-    $ tt replicaset vshard bootstrap myapp -u myuser -p p4$$w0rD
+    $ tt replicaset vshard bootstrap 192.168.10.10:3301 -u myuser -p p4$$w0rD
 
 You can specify the application name or the name of any cluster instance. The command
 automatically finds a `vshard` router in the cluster and calls :ref:`vshard.router.bootstrap() <router_api-bootstrap>` on it.

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -294,7 +294,7 @@ With a URI and credentials:
     $ tt replicaset vshard bootstrap 192.168.10.10:3301 -u myuser -p p4$$w0rD
 
 You can specify the application name or the name of any cluster instance. The command
-automatically finds a `vshard` router in the cluster and calls :ref:`vshard.router.bootstrap() <router_api-bootstrap>` on it.
+automatically finds a ``vshard`` router in the cluster and calls :ref:`vshard.router.bootstrap() <router_api-bootstrap>` on it.
 
 The command supports the ``--config``, ``--cartridge``, and ``--custom`` :ref:`options <tt-replicaset-options>`
 that force the use of a specific orchestrator.

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -221,26 +221,6 @@ The ``--timeout`` option can be used to specify the election completion timeout:
 
     $ tt replicaset demote my-app:storage-001-a --timeout=10
 
-.. _tt-replicaset-orchestrator:
-
-Selecting the application orchestrator manually
------------------------------------------------
-
-You can specify the orchestrator to use for the application  when calling ``tt replicaset``
-commands. The following options are available:
-
-*   ``--config`` for applications that use YAML cluster configuration (Tarantool 3.x or later).
-*   ``--cartridge`` for Cartridge applications (Tarantool 2.x).
-*   ``--custom`` for any other orchestrators used on Tarantool 2.x clusters.
-
-..  code-block:: console
-
-    $ tt replicaset status myapp --config
-    $ tt replicaset promote my-cartridge-app:storage-001-a --cartridge
-
-If an actual orchestrator that the application uses does not match the specified
-option, an error is raised.
-
 .. _tt-replicaset-expel:
 
 expel
@@ -263,6 +243,8 @@ that force the use of a specific orchestrator.
 
 To expel an instance from a Cartridge cluster:
 
+..  code-block:: console
+
     $ tt replicaset expel my-cartridge-app:storage-001-b --cartridge
 
 
@@ -276,6 +258,8 @@ vshard
     $ tt replicaset vshard COMMAND {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
     # or
     $ tt rs vshard COMMAND {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
+    # or
+    $ tt rs vs COMMAND {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
 
 ``tt replicaset vshard`` (``tt rs vs``) manages :ref:`vshard <vshard>` in the cluster.
 
@@ -303,12 +287,40 @@ in the cluster.
 
     $ tt replicaset vshard bootstrap myapp
 
+With credentials:
+
+..  code-block:: console
+
+    $ tt replicaset vshard bootstrap myapp -u myuser -p p4$$w0rD
+
 The command supports the ``--config``, ``--cartridge``, and ``--custom`` :ref:`options <tt-replicaset-options>`
 that force the use of a specific orchestrator.
 
 To bootstrap ``vshard`` in a Cartridge cluster:
 
+..  code-block:: console
+
     $ tt replicaset vshard bootstrap my-cartridge-app --cartridge
+
+.. _tt-replicaset-orchestrator:
+
+Selecting the application orchestrator manually
+-----------------------------------------------
+
+You can specify the orchestrator to use for the application  when calling ``tt replicaset``
+commands. The following options are available:
+
+*   ``--config`` for applications that use YAML cluster configuration (Tarantool 3.x or later).
+*   ``--cartridge`` for Cartridge applications (Tarantool 2.x).
+*   ``--custom`` for any other orchestrators used on Tarantool 2.x clusters.
+
+..  code-block:: console
+
+    $ tt replicaset status myapp --config
+    $ tt replicaset promote my-cartridge-app:storage-001-a --cartridge
+
+If an actual orchestrator that the application uses does not match the specified
+option, an error is raised.
 
 .. _tt-replicaset-authentication:
 

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -293,6 +293,9 @@ With credentials:
 
     $ tt replicaset vshard bootstrap myapp -u myuser -p p4$$w0rD
 
+You can specify the application name or the name of any cluster instance. The command
+automatically finds a `vshard` router in the cluster and calls :ref:`vshard.router.bootstrap() <router_api-bootstrap>` on it.
+
 The command supports the ``--config``, ``--cartridge``, and ``--custom`` :ref:`options <tt-replicaset-options>`
 that force the use of a specific orchestrator.
 

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -16,6 +16,8 @@ Managing replica sets
 *   :ref:`status <tt-replicaset-status>`
 *   :ref:`promote <tt-replicaset-promote>`
 *   :ref:`demote <tt-replicaset-demote>`
+*   :ref:`expel <tt-replicaset-expel>`
+*   :ref:`vshard <tt-replicaset-vshard>`
 
 
 .. _tt-replicaset-status:
@@ -238,6 +240,75 @@ commands. The following options are available:
 
 If an actual orchestrator that the application uses does not match the specified
 option, an error is raised.
+
+.. _tt-replicaset-expel:
+
+expel
+-----
+
+..  code-block:: console
+
+    $ tt replicaset expel APPLICATION:APP_INSTANCE [OPTIONS ...]
+    # or
+    $ tt rs expel  APPLICATION[:APP_INSTANCE] [OPTIONS ...]
+
+``tt replicaset expel`` (``tt rs expel``) expels an instance from the cluster.
+
+..  code-block:: console
+
+    $ tt replicaset expel myapp:storage-001-b
+
+The command supports the ``--config``, ``--cartridge``, and ``--custom`` :ref:`options <tt-replicaset-options>`
+that force the use of a specific orchestrator.
+
+To expel an instance from a Cartridge cluster:
+
+    $ tt replicaset expel my-cartridge-app:storage-001-b --cartridge
+
+
+.. _tt-replicaset-vshard:
+
+vshard
+-----
+
+..  code-block:: console
+
+    $ tt replicaset vshard COMMAND {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
+    # or
+    $ tt rs vshard COMMAND {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
+
+``tt replicaset vshard`` (``tt rs vs``) manages :ref:`vshard <vshard>` in the cluster.
+
+It has the following subcommands:
+
+-   :ref:`bootstrap <tt-replicaset-vshard-bootstrap>`
+
+.. _tt-replicaset-vshard-bootstrap:
+
+vshard bootstrap
+~~~~~~~~~~~~~~~~
+
+..  code-block:: console
+
+    $ tt replicaset vshard bootstrap {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
+    # or
+    $ tt rs vshard bootstrap {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
+    # or
+    $ tt rs vs bootstrap {APPLICATION[:APP_INSTANCE] | URI} [OPTIONS ...]
+
+``tt replicaset vshard bootstrap`` (``tt rs vs bootstrap``) bootstraps ``vshard``
+in the cluster.
+
+..  code-block:: console
+
+    $ tt replicaset vshard bootstrap myapp
+
+The command supports the ``--config``, ``--cartridge``, and ``--custom`` :ref:`options <tt-replicaset-options>`
+that force the use of a specific orchestrator.
+
+To bootstrap ``vshard`` in a Cartridge cluster:
+
+    $ tt replicaset vshard bootstrap my-cartridge-app --cartridge
 
 .. _tt-replicaset-authentication:
 

--- a/doc/reference/tooling/tt_cli/replicaset.rst
+++ b/doc/reference/tooling/tt_cli/replicaset.rst
@@ -378,7 +378,7 @@ Options
 
 ..  option:: -u USERNAME, --username USERNAME
 
-    A Tarantool user for connecting to the instance.
+    A Tarantool user for connecting to the instance using a URI.
 
 ..  option:: -p PASSWORD, --password PASSWORD
 
@@ -386,22 +386,25 @@ Options
 
 ..  option:: --sslcertfile FILEPATH
 
-    The path to an SSL certificate file for encrypted connections.
+    The path to an SSL certificate file for encrypted connections for the URI case.
 
 ..  option:: --sslkeyfile FILEPATH
 
-    The path to a private SSL key file for encrypted connections.
+    The path to a private SSL key file for encrypted connections for the URI case.
 
 ..  option:: --sslcafile FILEPATH
 
-    The path to a trusted certificate authorities (CA) file for encrypted connections.
+    The path to a trusted certificate authorities (CA) file for encrypted connections for the URI case.
 
 ..  option:: --sslciphers STRING
 
-    The list of SSL cipher suites used for encrypted connections, separated by colons (``:``).
+    The list of SSL cipher suites used for encrypted connections for the URI case, separated by colons (``:``).
 
 ..  option:: --timeout
 
-    **Applicable to:** ``promote``, ``demote``
+    **Applicable to:** ``promote``, ``demote``, ``expel``, ``vshard``
 
-    The timeout for completing the promotion or demotion, in seconds. Default: ``3``.
+    The timeout for completing the operation, in seconds. Default:
+
+    -   ``3`` for ``promote``, ``demote``, ``expel``
+    -   ``10`` for ``vshard``


### PR DESCRIPTION
Resolves #4142 #4261, #4241

Add new subsections to `tt replicaset` and `tt cluster` reference:
- [tt rs expel](https://docs.d.tarantool.io/en/doc/gh-4241-tt-replicaset-expel/reference/tooling/tt_cli/replicaset/#expel)
- [tt rs vshard](https://docs.d.tarantool.io/en/doc/gh-4241-tt-replicaset-expel/reference/tooling/tt_cli/replicaset/#vshard) with `bootstrap` subcommand
- [tt cluster publish](https://docs.d.tarantool.io/en/doc/gh-4241-tt-replicaset-expel/reference/tooling/tt_cli/cluster/#publishing-configurations-of-specific-instances) - add example of publishing a new instance config and corresponding [options](https://docs.d.tarantool.io/en/doc/gh-4241-tt-replicaset-expel/reference/tooling/tt_cli/cluster/#options) `--replicaset` and `--group`.

Deployment: https://docs.d.tarantool.io/en/doc/gh-4241-tt-replicaset-expel/reference/tooling/tt_cli/replicaset/#expel