### PR TITLE
Document new 'config' API

### DIFF
--- a/doc/reference/reference_lua/config.rst
+++ b/doc/reference/reference_lua/config.rst
@@ -92,9 +92,9 @@ config API
     ..  method:: get([param, opts])
 
         Get a configuration applied to the current or remote instance.
-        Note that there is the following difference between getting a configuration for the current and remote instance:
+        Note the following differences between getting a configuration for the current and remote instance:
 
-        -   For the current instance, ``get()`` returns an instance configuration considering :ref:`environment variables <configuration_environment_variable>`.
+        -   For the current instance, ``get()`` returns its configuration considering :ref:`environment variables <configuration_environment_variable>`.
         -   For a remote instance, ``get()`` only considers a cluster configuration and ignores environment variables.
 
         :param string param: a configuration option name
@@ -179,7 +179,7 @@ config API
         **Example: configuration warnings**
 
         In the example below, the instance's state is ``check_warnings``.
-        The ``alerts`` section informs that privileges to the ``bands`` space for ``sampleuser`` cannot be granted because the ``bands`` space has not created yet:
+        The ``alerts`` section informs that privileges to the ``bands`` space for ``sampleuser`` cannot be granted because the ``bands`` space has not been created yet:
 
         ..  code-block:: tarantoolsession
 
@@ -259,7 +259,7 @@ config API
 
         Get a URI of the current or remote instance.
 
-        :param string uri_type: a URI type. There are the following URI types are supported:
+        :param string uri_type: a URI type. The following URI types are supported:
 
                                 * ``peer`` -- a URI used to advertise the instance to other cluster members. See also: :ref:`iproto.advertise.peer <configuration_reference_iproto_advertise_peer>`.
                                 * ``sharding`` -- a URI used to advertise the current instance to a router and rebalancer. See also: :ref:`iproto.advertise.sharding <configuration_reference_iproto_advertise_sharding>`.
@@ -318,7 +318,7 @@ config API
                 log.info("Connection URI for %q: %s:%s", instance_name, conn.host, conn.port)
             end
 
-        In this example, the same actions are performed for instances from the specific replica set:
+        In this example, the same actions are performed for instances from the specified replica set:
 
         ..  code-block:: lua
 

--- a/doc/reference/reference_lua/config.rst
+++ b/doc/reference/reference_lua/config.rst
@@ -108,7 +108,7 @@ config API
 
         The example below shows how to get the full instance configuration:
 
-        .. code-block:: console
+        .. code-block:: tarantoolsession
 
             app:instance001> require('config'):get()
             ---
@@ -122,7 +122,7 @@ config API
 
         This example shows how to get an ``iproto.listen`` option value:
 
-        .. code-block:: console
+        .. code-block:: tarantoolsession
 
             app:instance001> require('config'):get('iproto.listen')
             ---
@@ -161,71 +161,97 @@ config API
 
         -   ``alerts`` -- warnings or errors raised on an attempt to apply the configuration
 
-        **Examples:**
+        Below are a few examples demonstrating how the ``info()`` output might look.
 
-        Below are a few examples demonstrating how the ``info()`` output might look:
+        **Example: no configuration warnings or errors**
 
-        *   In the example below, an instance's state is ``ready`` and no warnings are shown:
+        In the example below, an instance's state is ``ready`` and no warnings are shown:
 
-            ..  code-block:: console
+        ..  code-block:: tarantoolsession
 
-                app:instance001> require('config'):info()
-                ---
-                - status: ready
-                  meta: []
-                  alerts: []
-                ...
+            app:instance001> require('config'):info('v2')
+            ---
+            - status: ready
+              meta:
+                last: &0 []
+                active: *0
+              alerts: []
+            ...
 
-        *   In the example below, the instance's state is ``check_warnings``.
-            The ``alerts`` section informs that privileges to the ``books`` space for ``sampleuser`` cannot be granted because the ``books`` space has not been created yet:
+        **Example: configuration warnings**
 
-            ..  code-block:: console
+        In the example below, the instance's state is ``check_warnings``.
+        The ``alerts`` section informs that privileges to the ``bands`` space for ``sampleuser`` cannot be granted because the ``bands`` space has not created yet:
 
-                app:instance001> require('config'):info()
-                ---
-                - status: check_warnings
-                  meta: []
-                  alerts:
-                  - type: warn
-                    message: box.schema.user.grant("sampleuser", "read,write", "space", "books") has
-                      failed because either the object has not been created yet, or the privilege
-                      write has failed (separate alert reported)
-                    timestamp: 2024-02-27T15:07:41.815785+0300
-                ...
+        ..  code-block:: tarantoolsession
 
-            This warning is cleared when the ``books`` space is created.
+            app:instance001> require('config'):info('v2')
+            ---
+            - status: check_warnings
+              meta:
+                last: &0 []
+                active: *0
+              alerts:
+              - type: warn
+                message: box.schema.user.grant("sampleuser", "read,write", "space", "bands") has
+                  failed because either the object has not been created yet, a database schema
+                  upgrade has not been performed, or the privilege write has failed (separate
+                  alert reported)
+                timestamp: 2024-07-03T18:09:18.826138+0300
+            ...
 
-        *   In the example below, the instance's state is ``check_errors``.
-            The ``alerts`` section informs that the ``log.level`` configuration option has an incorrect value:
+        This warning is cleared when the ``bands`` space is created.
 
-            ..  code-block:: console
+        **Example: configuration errors**
 
-                app:instance001> require('config'):info()
-                ---
-                - status: check_errors
-                  meta: []
-                  alerts:
-                  - type: error
-                    message: '[cluster_config] log.level: Got 8, but only the following values are
-                      allowed: 0, fatal, 1, syserror, 2, error, 3, crit, 4, warn, 5, info, 6, verbose,
-                      7, debug'
-                    timestamp: 2024-02-29T12:55:54.366810+0300
-                ...
+        In the example below, the instance's state is ``check_errors``.
+        The ``alerts`` section informs that the ``log.level`` configuration option has an incorrect value:
 
-        *   In this example, an instance's state includes information about a :ref:`centralized storage <configuration_etcd>` the instance takes a configuration from:
+        ..  code-block:: tarantoolsession
 
-            ..  code-block:: console
+            app:instance001> require('config'):info('v2')
+            ---
+            - status: check_errors
+              meta:
+                last: []
+                active: []
+              alerts:
+              - type: error
+                message: '[cluster_config] log.level: Got 8, but only the following values are
+                  allowed: 0, fatal, 1, syserror, 2, error, 3, crit, 4, warn, 5, info, 6, verbose,
+                  7, debug'
+                timestamp: 2024-07-03T18:13:19.755454+0300
+            ...
 
-                app:instance001> require('config'):info()
-                ---
-                - status: ready
-                  meta:
-                    storage:
-                      revision: 8
-                      mod_revision:
-                        /myapp/config/all: 8
-                  alerts: []
-                ...
+        **Example: configuration errors (centralized configuration storage)**
+
+        In this example, the ``meta`` field includes information about a :ref:`centralized storage <configuration_etcd>` the instance takes a configuration from:
+
+        ..  code-block:: tarantoolsession
+
+            app:instance001> require('config'):info('v2')
+            ---
+            - status: check_errors
+              meta:
+                last:
+                  etcd:
+                    mod_revision:
+                      /myapp/config/all: 5
+                    revision: 5
+                active:
+                  etcd:
+                    mod_revision:
+                      /myapp/config/all: 2
+                    revision: 4
+              alerts:
+              - type: error
+                message: 'etcd source: invalid config at key "/myapp/config/all": [cluster_config]
+                  groups.group001.replicasets.replicaset001.instances.instance001.log.level: Got
+                  8, but only the following values are allowed: 0, fatal, 1, syserror, 2, error,
+                  3, crit, 4, warn, 5, info, 6, verbose, 7, debug'
+                timestamp: 2024-07-03T15:22:06.438275Z
+            ...
+
 
     .. _config_api_reference_instance_uri:
 

--- a/doc/reference/reference_lua/config.rst
+++ b/doc/reference/reference_lua/config.rst
@@ -147,19 +147,17 @@ config API
                                    * the ``active`` field includes information for the last successfully applied configuration
 
 
-        :return: a table containing an instance's state
+        :return: a table containing an instance's state. The returned state includes the following sections:
 
-        The returned state includes the following sections:
+                 -   ``status`` -- one of the following statuses:
 
-        -   ``status`` -- one of the following statuses:
+                     *   ``ready`` -- the configuration is applied successfully
+                     *   ``check_warnings`` -- the configuration is applied with warnings
+                     *   ``check_errors`` -- the configuration cannot be applied due to configuration errors
 
-            *   ``ready`` -- the configuration is applied successfully
-            *   ``check_warnings`` -- the configuration is applied with warnings
-            *   ``check_errors`` -- the configuration cannot be applied due to configuration errors
+                 -   ``meta`` -- additional configuration information
 
-        -   ``meta`` -- additional configuration information
-
-        -   ``alerts`` -- warnings or errors raised on an attempt to apply the configuration
+                 -   ``alerts`` -- warnings or errors raised on an attempt to apply the configuration
 
         Below are a few examples demonstrating how the ``info()`` output might look.
 
@@ -270,7 +268,12 @@ config API
 
                            -   ``instance`` -- the name of a remote instance whose URI should be obtained
 
-        :return: an instance URI
+        :return: a table representing an instance URI. This table might include the following fields:
+
+                 *   ``uri`` -- an instance URI
+                 *   ``login`` -- a username used to connect to this instance
+                 *   ``password`` -- a user's password
+                 *   ``params`` -- URI parameters used to connect to this instance
 
         **Example**
 

--- a/doc/reference/reference_lua/config.rst
+++ b/doc/reference/reference_lua/config.rst
@@ -293,13 +293,11 @@ config API
 
         List all instances of the cluster.
 
-        :return: a table containing information about instances
+        :return: a table containing information about instances. The returned table uses instance names as the keys and contains the following information for each instance:
 
-        The returned table uses instance names as the keys and contains the following information for each instance:
-
-        -   ``instance_name`` -- an instance name
-        -   ``replicaset_name`` -- the name of a replica set the instance belongs to
-        -   ``group_name`` -- the name of a group the instance belongs to
+                 -   ``instance_name`` -- an instance name
+                 -   ``replicaset_name`` -- the name of a replica set the instance belongs to
+                 -   ``group_name`` -- the name of a group the instance belongs to
 
         **Example**
 
@@ -378,7 +376,7 @@ The ``config.storage`` API allows you to interact with a Tarantool-based :ref:`c
         :end-at: cluster_config_handle:close()
         :dedent:
 
-    Example on GitHub: `tarantool_config_storage <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/centralized_config/instances.enabled/tarantool_config_storage>`_.
+    Example on GitHub: `tarantool_config_storage <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/centralized_config/instances.enabled/tarantool_config_storage>`_
 
 
 .. _config_storage_api_reference_get:
@@ -419,7 +417,7 @@ The ``config.storage`` API allows you to interact with a Tarantool-based :ref:`c
         :end-at: get('/myapp/')
         :dedent:
 
-    Example on GitHub: `tarantool_config_storage <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/centralized_config/instances.enabled/tarantool_config_storage>`_.
+    Example on GitHub: `tarantool_config_storage <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/centralized_config/instances.enabled/tarantool_config_storage>`_
 
 .. _config_storage_api_reference_delete:
 
@@ -459,7 +457,7 @@ The ``config.storage`` API allows you to interact with a Tarantool-based :ref:`c
         :end-at: delete('/')
         :dedent:
 
-    Example on GitHub: `tarantool_config_storage <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/centralized_config/instances.enabled/tarantool_config_storage>`_.
+    Example on GitHub: `tarantool_config_storage <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/centralized_config/instances.enabled/tarantool_config_storage>`_
 
 
 .. _config_storage_api_reference_info:
@@ -520,4 +518,4 @@ The ``config.storage`` API allows you to interact with a Tarantool-based :ref:`c
         :end-at: })
         :dedent:
 
-    Example on GitHub: `tarantool_config_storage <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/centralized_config/instances.enabled/tarantool_config_storage>`_.
+    Example on GitHub: `tarantool_config_storage <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/centralized_config/instances.enabled/tarantool_config_storage>`_

--- a/doc/reference/reference_lua/config.rst
+++ b/doc/reference/reference_lua/config.rst
@@ -275,6 +275,10 @@ config API
                  *   ``password`` -- a user's password
                  *   ``params`` -- URI parameters used to connect to this instance
 
+                 ..  NOTE::
+
+                     Note that the resulting URI object can be passed to the :ref:`connect() <net_box-connect>` function of the ``net.box`` module.
+
         **Example**
 
         The example below shows how to get a URI used to advertise ``storage-b-003`` to other cluster members:

--- a/doc/reference/reference_lua/config.rst
+++ b/doc/reference/reference_lua/config.rst
@@ -308,11 +308,27 @@ config API
         ..  code-block:: lua
 
             local config = require('config')
+            local connpool = require('experimental.connpool')
+            local log = require('log')
+
             for instance_name in pairs(config:instances()) do
-                local connpool = require('experimental.connpool')
                 local conn = connpool.connect(instance_name)
-                local log = require('log')
-                log.info(string.format("Connection URI for '%s': %s:%s", instance_name, conn.host, conn.port))
+                log.info("Connection URI for %q: %s:%s", instance_name, conn.host, conn.port)
+            end
+
+        In this example, the same actions are performed for instances from the specific replica set:
+
+        ..  code-block:: lua
+
+            local config = require('config')
+            local connpool = require('experimental.connpool')
+            local log = require('log')
+
+            for instance_name, def in pairs(config:instances()) do
+                if def.replicaset_name == 'storage-b' then
+                    local conn = connpool.connect(instance_name)
+                    log.info("Connection URI for %q: %s:%s", instance_name, conn.host, conn.port)
+                end
             end
 
 


### PR DESCRIPTION
Updated reference for the `config` module. Fixed doc issues:

- https://github.com/tarantool/doc/issues/4105
- https://github.com/tarantool/doc/issues/4120
- https://github.com/tarantool/doc/issues/4094

Staging:

- A new `opts` argument in [config:get()](https://docs.d.tarantool.io/en/doc/config_module_new_api/reference/reference_lua/config/#lua-function.config.get) (in particular, `opts.instance`)
- A new `version` argument in [config:info()](https://docs.d.tarantool.io/en/doc/config_module_new_api/reference/reference_lua/config/#config-api-reference-info)
- A new [config:instance_uri()](https://docs.d.tarantool.io/en/doc/config_module_new_api/reference/reference_lua/config/#config-api-reference-instance-uri) function
- A new [config:instances()](https://docs.d.tarantool.io/en/doc/config_module_new_api/reference/reference_lua/config/#config-api-reference-instances) function

> [!NOTE]
> New code examples are created using the [sharded_cluster_crud_docker](https://github.com/andreyaksenov/sharded_cluster_crud_docker) demo application.