### PR TITLE
Use the CRUD module in the 'Creating a sharded cluster' tutorial

### DIFF
--- a/doc/book/admin/instance_config.rst
+++ b/doc/book/admin/instance_config.rst
@@ -17,7 +17,7 @@ The main steps of creating and preparing the application for deployment are:
 
 3.  :ref:`admin-instance_config-package-app`.
 
-In this section, a `sharded_cluster <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster>`_ application is used as an example.
+In this section, a `sharded_cluster_crud <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud>`_ application is used as an example.
 This cluster includes 5 instances: one router and 4 storages, which constitute two replica sets.
 
 .. image:: /book/admin/admin_instances_dev.png
@@ -82,27 +82,27 @@ In this example, the application's layout is prepared manually and looks as foll
     ├── distfiles
     ├── include
     ├── instances.enabled
-    │   └── sharded_cluster
+    │   └── sharded_cluster_crud
     │       ├── config.yaml
     │       ├── instances.yaml
     │       ├── router.lua
-    │       ├── sharded_cluster-scm-1.rockspec
+    │       ├── sharded_cluster_crud-scm-1.rockspec
     │       └── storage.lua
     ├── modules
     ├── templates
     └── tt.yaml
 
 
-The ``sharded_cluster`` directory contains the following files:
+The ``sharded_cluster_crud`` directory contains the following files:
 
 -   ``config.yaml``: contains the :ref:`configuration <configuration>` of the cluster. This file might include the entire cluster topology or provide connection settings to a centralized configuration storage.
 -   ``instances.yml``: specifies instances to run in the current environment. For example, on the developer’s machine, this file might include all the instances defined in the cluster configuration. In the production environment, this file includes :ref:`instances to run on the specific machine <admin-instances_to_run>`.
 -   ``router.lua``: includes code specific for a :ref:`router <vshard-architecture-router>`.
--   ``sharded_cluster-scm-1.rockspec``: specifies the required external dependencies (for example, ``vshard``).
+-   ``sharded_cluster_crud-scm-1.rockspec``: specifies the required external dependencies (for example, ``vshard`` and ``crud``).
 -   ``storage.lua``: includes code specific for :ref:`storages <vshard-architecture-storage>`.
 
 You can find the full example here:
-`sharded_cluster <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster>`_.
+`sharded_cluster_crud <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud>`_.
 
 
 
@@ -116,7 +116,7 @@ Packaging the application
 To package the ready application, use the :ref:`tt pack <tt-pack>` command.
 This command can create an installable DEB/RPM package or generate ``.tgz`` archive.
 
-The structure below reflects the content of the packed ``.tgz`` archive for the `sharded_cluster <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster>`_ application:
+The structure below reflects the content of the packed ``.tgz`` archive for the `sharded_cluster_crud <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud>`_ application:
 
 .. code-block:: console
 
@@ -125,18 +125,15 @@ The structure below reflects the content of the packed ``.tgz`` archive for the 
     ├── bin
     │   ├── tarantool
     │   └── tt
-    ├── include
     ├── instances.enabled
-    │   └── sharded_cluster -> ../sharded_cluster
-    ├── modules
-    ├── sharded_cluster
+    │   └── sharded_cluster_crud -> ../sharded_cluster_crud
+    ├── sharded_cluster_crud
     │   ├── .rocks
     │   │   └── share
     │   │       └── ...
     │   ├── config.yaml
     │   ├── instances.yaml
     │   ├── router.lua
-    │   ├── sharded_cluster-scm-1.rockspec
     │   └── storage.lua
     └── tt.yaml
 
@@ -147,7 +144,7 @@ The application's layout looks similar to the one defined when :ref:`developing 
 
 -   ``instances.enabled``: contains a symlink to the packed ``sharded_cluster`` application.
 
--   ``sharded_cluster``: a packed application. In addition to files created during the application development, includes the ``.rocks`` directory containing application dependencies (for example, ``vshard``).
+-   ``sharded_cluster_crud``: a packed application. In addition to files created during the application development, includes the ``.rocks`` directory containing application dependencies (for example, ``vshard`` and ``crud``).
 
 -   ``tt.yaml``: a ``tt`` configuration file.
 
@@ -178,7 +175,7 @@ define instances to run on each machine by changing the content of the ``instanc
 
     ``instances.yaml``:
 
-    ..  literalinclude:: /code_snippets/snippets/sharding/instances.enabled/sharded_cluster/instances.yaml
+    ..  literalinclude:: /code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud/instances.yaml
         :language: yaml
         :dedent:
 

--- a/doc/book/admin/start_stop_instance.rst
+++ b/doc/book/admin/start_stop_instance.rst
@@ -17,7 +17,7 @@ To get more context on how the application's environment might look, refer to :r
 
 ..  NOTE::
 
-    In this section, a `sharded_cluster <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster>`_ application is used to demonstrate how to start, stop, and manage instances in a cluster.
+    In this section, a `sharded_cluster_crud <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud>`_ application is used to demonstrate how to start, stop, and manage instances in a cluster.
 
 
 .. _configuration_run_instance:
@@ -30,20 +30,20 @@ To start Tarantool instances use the :ref:`tt start <tt-start>` command:
 
 .. code-block:: console
 
-    $ tt start sharded_cluster
-       • Starting an instance [sharded_cluster:storage-a-001]...
-       • Starting an instance [sharded_cluster:storage-a-002]...
-       • Starting an instance [sharded_cluster:storage-b-001]...
-       • Starting an instance [sharded_cluster:storage-b-002]...
-       • Starting an instance [sharded_cluster:router-a-001]...
+    $ tt start sharded_cluster_crud
+       • Starting an instance [sharded_cluster_crud:storage-a-001]...
+       • Starting an instance [sharded_cluster_crud:storage-a-002]...
+       • Starting an instance [sharded_cluster_crud:storage-b-001]...
+       • Starting an instance [sharded_cluster_crud:storage-b-002]...
+       • Starting an instance [sharded_cluster_crud:router-a-001]...
 
 After the cluster has started and worked for some time, you can find its artifacts
 in the directories specified in the ``tt`` configuration. These are the default
 locations in the local :ref:`launch mode <tt-config_modes>`:
 
-*   ``sharded_cluster/var/log/<instance_name>/`` -- instance :ref:`logs <admin-logs>`.
-*   ``sharded_cluster/var/lib/<instance_name>/`` -- :ref:`snapshots and write-ahead logs <concepts-data_model-persistence>`.
-*   ``sharded_cluster/var/run/<instance_name>/`` -- control sockets and PID files.
+*   ``sharded_cluster_crud/var/log/<instance_name>/`` -- instance :ref:`logs <admin-logs>`.
+*   ``sharded_cluster_crud/var/lib/<instance_name>/`` -- :ref:`snapshots and write-ahead logs <concepts-data_model-persistence>`.
+*   ``sharded_cluster_crud/var/run/<instance_name>/`` -- control sockets and PID files.
 
 In the system launch mode, artifacts are created in these locations:
 
@@ -72,21 +72,21 @@ To check the status of instances, execute :ref:`tt status <tt-status>`:
 
 .. code-block:: console
 
-    $ tt status sharded_cluster
+    $ tt status sharded_cluster_crud
     INSTANCE                          STATUS      PID   MODE
-    sharded_cluster:storage-a-001     RUNNING     2023  RW
-    sharded_cluster:storage-a-002     RUNNING     2026  RO
-    sharded_cluster:storage-b-001     RUNNING     2020  RW
-    sharded_cluster:storage-b-002     RUNNING     2021  RO
-    sharded_cluster:router-a-001      RUNNING     2022  RW
+    sharded_cluster_crud:storage-a-001     RUNNING     2023  RW
+    sharded_cluster_crud:storage-a-002     RUNNING     2026  RO
+    sharded_cluster_crud:storage-b-001     RUNNING     2020  RW
+    sharded_cluster_crud:storage-b-002     RUNNING     2021  RO
+    sharded_cluster_crud:router-a-001      RUNNING     2022  RW
 
 To check the status of a specific instance, you need to specify its name:
 
 .. code-block:: console
 
-    $ tt status sharded_cluster:storage-a-001
+    $ tt status sharded_cluster_crud:storage-a-001
     INSTANCE                          STATUS      PID   MODE
-    sharded_cluster:storage-a-001     RUNNING     2023  RW
+    sharded_cluster_crud:storage-a-001     RUNNING     2023  RW
 
 
 .. _admin-start_stop_instance_connect:
@@ -98,18 +98,18 @@ To connect to the instance, use the :ref:`tt connect <tt-connect>` command:
 
 ..  code-block:: console
 
-    $ tt connect sharded_cluster:storage-a-001
+    $ tt connect sharded_cluster_crud:storage-a-001
        • Connecting to the instance...
-       • Connected to sharded_cluster:storage-a-001
+       • Connected to sharded_cluster_crud:storage-a-001
 
-    sharded_cluster:storage-a-001>
+    sharded_cluster_crud:storage-a-001>
 
 In the instance's console, you can execute commands provided by the :ref:`box <box-module>` module.
 For example, :ref:`box.info <box_introspection-box_info>` can be used to get various information about a running instance:
 
-..  code-block:: console
+..  code-block:: tarantoolsession
 
-    sharded_cluster:storage-a-001> box.info.ro
+    sharded_cluster_crud:storage-a-001> box.info.ro
     ---
     - false
     ...
@@ -125,15 +125,15 @@ To restart an instance, use :ref:`tt restart <tt-restart>`:
 
 .. code-block:: console
 
-    $ tt restart sharded_cluster:storage-a-002
+    $ tt restart sharded_cluster_crud:storage-a-002
 
 After executing ``tt restart``, you need to confirm this operation:
 
 .. code-block:: console
 
-    Confirm restart of 'sharded_cluster:storage-a-002' [y/n]: y
-       • The Instance sharded_cluster:storage-a-002 (PID = 2026) has been terminated.
-       • Starting an instance [sharded_cluster:storage-a-002]...
+    Confirm restart of 'sharded_cluster_crud:storage-a-002' [y/n]: y
+       • The Instance sharded_cluster_crud:storage-a-002 (PID = 2026) has been terminated.
+       • Starting an instance [sharded_cluster_crud:storage-a-002]...
 
 
 .. _admin-start_stop_instance_stop:
@@ -145,18 +145,18 @@ To stop the specific instance, use :ref:`tt stop <tt-stop>` as follows:
 
 .. code-block:: console
 
-    $ tt stop sharded_cluster:storage-a-002
+    $ tt stop sharded_cluster_crud:storage-a-002
 
 You can also stop all the instances at once as follows:
 
 .. code-block:: console
 
-    $ tt stop sharded_cluster
-       • The Instance sharded_cluster:storage-b-001 (PID = 2020) has been terminated.
-       • The Instance sharded_cluster:storage-b-002 (PID = 2021) has been terminated.
-       • The Instance sharded_cluster:router-a-001 (PID = 2022) has been terminated.
-       • The Instance sharded_cluster:storage-a-001 (PID = 2023) has been terminated.
-       • can't "stat" the PID file. Error: "stat /home/testuser/myapp/instances.enabled/sharded_cluster/var/run/storage-a-002/tt.pid: no such file or directory"
+    $ tt stop sharded_cluster_crud
+       • The Instance sharded_cluster_crud:storage-b-001 (PID = 2020) has been terminated.
+       • The Instance sharded_cluster_crud:storage-b-002 (PID = 2021) has been terminated.
+       • The Instance sharded_cluster_crud:router-a-001 (PID = 2022) has been terminated.
+       • The Instance sharded_cluster_crud:storage-a-001 (PID = 2023) has been terminated.
+       • can't "stat" the PID file. Error: "stat /home/testuser/myapp/instances.enabled/sharded_cluster_crud/var/run/storage-a-002/tt.pid: no such file or directory"
 
 ..  note::
 
@@ -172,12 +172,12 @@ The :ref:`tt clean <tt-clean>` command removes instance artifacts (such as logs 
 
 .. code-block:: console
 
-    $ tt clean sharded_cluster
+    $ tt clean sharded_cluster_crud
        • List of files to delete:
 
-       • /home/testuser/myapp/instances.enabled/sharded_cluster/var/log/storage-a-001/tt.log
-       • /home/testuser/myapp/instances.enabled/sharded_cluster/var/lib/storage-a-001/00000000000000001062.snap
-       • /home/testuser/myapp/instances.enabled/sharded_cluster/var/lib/storage-a-001/00000000000000001062.xlog
+       • /home/testuser/myapp/instances.enabled/sharded_cluster_crud/var/log/storage-a-001/tt.log
+       • /home/testuser/myapp/instances.enabled/sharded_cluster_crud/var/lib/storage-a-001/00000000000000001062.snap
+       • /home/testuser/myapp/instances.enabled/sharded_cluster_crud/var/lib/storage-a-001/00000000000000001062.xlog
        • ...
 
     Confirm [y/n]:
@@ -201,20 +201,20 @@ Tarantool supports loading and running chunks of Lua code before starting instan
 To load or run Lua code immediately upon Tarantool startup, specify the ``TT_PRELOAD``
 environment variable. Its value can be either a path to a Lua script or a Lua module name:
 
-*   To run the Lua script ``preload_script.lua`` from the ``sharded_cluster`` directory, set ``TT_PRELOAD`` as follows:
+*   To run the Lua script ``preload_script.lua`` from the ``sharded_cluster_crud`` directory, set ``TT_PRELOAD`` as follows:
 
     .. code-block:: console
 
-        $ TT_PRELOAD=preload_script.lua tt start sharded_cluster
+        $ TT_PRELOAD=preload_script.lua tt start sharded_cluster_crud
 
     Tarantool runs the ``preload_script.lua`` code, waits for it to complete, and
     then starts instances.
 
-*   To load the ``preload_module`` from the ``sharded_cluster`` directory, set ``TT_PRELOAD`` as follows:
+*   To load the ``preload_module`` from the ``sharded_cluster_crud`` directory, set ``TT_PRELOAD`` as follows:
 
     .. code-block:: console
 
-        $ TT_PRELOAD=preload_module tt start sharded_cluster
+        $ TT_PRELOAD=preload_module tt start sharded_cluster_crud
 
     .. note::
 
@@ -226,7 +226,7 @@ by semicolons:
 
 .. code-block:: console
 
-    $ TT_PRELOAD="preload_script.lua;preload_module" tt start sharded_cluster
+    $ TT_PRELOAD="preload_script.lua;preload_module" tt start sharded_cluster_crud
 
 If an error happens during the execution of the preload script or module, Tarantool
 reports the problem and exits.

--- a/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/README.md
+++ b/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster/README.md
@@ -1,16 +1,70 @@
 # Sharded cluster
 
-A sample application created in the [Creating a sharded cluster](https://www.tarantool.io/en/doc/latest/how-to/vshard_quick/) tutorial.
+A sample application demonstrating how to configure a [sharded](https://www.tarantool.io/en/doc/latest/concepts/sharding/) cluster.
 
 ## Running
 
-To learn how to run the cluster, see the [Working with the cluster](https://www.tarantool.io/en/doc/latest/how-to/vshard_quick/#working-with-the-cluster) section.
+To run the cluster, go to the `sharding` directory in the terminal and perform the following steps:
 
+1. Install dependencies defined in the `*.rockspec` file:
 
-## Packaging
+   ```console
+   $ tt build sharded_cluster
+   ```
+   
+2. Run the cluster:
 
-To package an application into a `.tgz` archive, use the `tt pack` command:
+   ```console
+   $ tt start sharded_cluster
+   ```
 
-```console
-$ tt pack tgz --app-list sharded_cluster
-```
+3. Connect to the router:
+
+   ```console
+   $ tt connect sharded_cluster:router-a-001
+   ```
+   
+4. Call `vshard.router.bootstrap()` to perform the initial cluster bootstrap:
+
+   ```console
+   sharded_cluster:router-a-001> vshard.router.bootstrap()
+   ---
+   - true
+   ...
+   ```
+
+5. Insert test data:
+
+   ```console
+   sharded_cluster:router-a-001> insert_data()
+   ---
+   ...
+   ```
+   
+6. Connect to storages in different replica sets to see how data is distributed across nodes:
+
+   a. `storage-a-001`:
+
+      ```console
+      sharded_cluster:storage-a-001> box.space.bands:select()
+      ---
+      - - [1, 614, 'Roxette', 1986]
+        - [2, 986, 'Scorpions', 1965]
+        - [5, 755, 'Pink Floyd', 1965]
+        - [7, 998, 'The Doors', 1965]
+        - [8, 762, 'Nirvana', 1987]
+      ...
+      ```
+   
+   b. `storage-b-001`:
+
+      ```console
+      sharded_cluster:storage-b-001> box.space.bands:select()
+      ---
+      - - [3, 11, 'Ace of Base', 1987]
+        - [4, 42, 'The Beatles', 1960]
+        - [6, 55, 'The Rolling Stones', 1962]
+        - [9, 299, 'Led Zeppelin', 1968]
+        - [10, 167, 'Queen', 1970]
+      ...
+      ```

--- a/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud/README.md
+++ b/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud/README.md
@@ -1,57 +1,7 @@
 # Sharded cluster with CRUD
 
-A sample application demonstrating how to set up a sharded cluster with the [crud](https://github.com/tarantool/crud) module.
+A sample application created in the [Creating a sharded cluster](https://www.tarantool.io/en/doc/latest/how-to/vshard_quick/) tutorial.
 
 ## Running
 
-Before running the cluster, execute the `tt build` command in the [sharding](../../../sharding) directory:
-
-```shell
-$ tt build sharded_cluster_crud
-```
-
-Then, start all instances in the cluster using `tt start`:
-
-```shell
-$ tt start sharded_cluster_crud
-```
-
-## Bootstrapping a cluster
-
-After starting instances, you need to bootstrap the cluster.
-Connect to the router instance using `tt connect`:
-
-```shell
-$ tt connect sharded_cluster_crud:router-a-001
-   • Connecting to the instance...
-   • Connected to sharded_cluster_crud:router-a-001
-```
-
-Call `vshard.router.bootstrap()` to perform the initial cluster bootstrap:
-
-```shell
-sharded_cluster_crud:router-a-001> vshard.router.bootstrap()
----
-- true
-...
-```
-
-
-## Inserting data
-
-To insert sample data, call `crud.insert_many()` on the router:
-
-```lua
-crud.insert_many('bands', {
-    { 1, box.NULL, 'Roxette', 1986 },
-    { 2, box.NULL, 'Scorpions', 1965 },
-    { 3, box.NULL, 'Ace of Base', 1987 },
-    { 4, box.NULL, 'The Beatles', 1960 },
-    { 5, box.NULL, 'Pink Floyd', 1965 },
-    { 6, box.NULL, 'The Rolling Stones', 1962 },
-    { 7, box.NULL, 'The Doors', 1965 },
-    { 8, box.NULL, 'Nirvana', 1987 },
-    { 9, box.NULL, 'Led Zeppelin', 1968 },
-    { 10, box.NULL, 'Queen', 1970 }
-})
-```
+To learn how to run the cluster, see the [Working with the cluster](https://www.tarantool.io/en/doc/latest/how-to/vshard_quick/#working-with-the-cluster) section.

--- a/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud/config.yaml
+++ b/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud/config.yaml
@@ -34,10 +34,14 @@ groups:
             iproto:
               listen:
               - uri: '127.0.0.1:3302'
+              advertise:
+                client: '127.0.0.1:3302'
           storage-a-002:
             iproto:
               listen:
               - uri: '127.0.0.1:3303'
+              advertise:
+                client: '127.0.0.1:3303'
       storage-b:
         leader: storage-b-001
         instances:
@@ -45,10 +49,14 @@ groups:
             iproto:
               listen:
               - uri: '127.0.0.1:3304'
+              advertise:
+                client: '127.0.0.1:3304'
           storage-b-002:
             iproto:
               listen:
               - uri: '127.0.0.1:3305'
+              advertise:
+                client: '127.0.0.1:3305'
   routers:
     roles: [ roles.crud-router ]
     roles_cfg:
@@ -70,3 +78,5 @@ groups:
             iproto:
               listen:
               - uri: '127.0.0.1:3301'
+              advertise:
+                client: '127.0.0.1:3301'

--- a/doc/how-to/vshard_quick.rst
+++ b/doc/how-to/vshard_quick.rst
@@ -133,6 +133,7 @@ In this section, the following options are configured:
 
 The cluster topology defined in the :ref:`following section <vshard-quick-start-configuring-cluster-topology>` also specifies the ``iproto.advertise.client`` option for each instance.
 This option accepts a URI used to advertise the instance to clients.
+For example, |tcm_full_name| uses these URIs to :ref:`connect <tcm_connect_clusters>` to cluster instances.
 
 
 ..  _vshard-quick-start-configuring-cluster-bucket-count:

--- a/doc/how-to/vshard_quick.rst
+++ b/doc/how-to/vshard_quick.rst
@@ -6,10 +6,10 @@ Creating a sharded cluster
 **Example on GitHub**: `sharded_cluster_crud <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/sharding/instances.enabled/sharded_cluster_crud>`_
 
 In this tutorial, you get a sharded cluster up and running on your local machine and learn how to manage the cluster using the tt utility.
-In this tutorial, the following external modules are used:
+This cluster uses the following external modules:
 
 -   :ref:`vshard <vshard>` enables sharding in the cluster.
--   `crud <https://github.com/tarantool/crud>`__ allows you to perform CRUD operations in the sharded cluster.
+-   `crud <https://github.com/tarantool/crud>`__ allows you to manipulate data in the sharded cluster.
 
 The cluster created in this tutorial includes 5 instances: one router and 4 storages, which constitute two replica sets.
 
@@ -51,7 +51,7 @@ In this tutorial, the application layout is prepared manually:
 3.  Inside ``instances.enabled/sharded_cluster_crud``, create the following files:
 
     -   ``instances.yml`` specifies instances to run in the current environment.
-    -   ``config.yaml`` specifies the cluster's :ref:`configuration <configuration_overview>`.
+    -   ``config.yaml`` specifies the cluster :ref:`configuration <configuration_overview>`.
     -   ``storage.lua`` contains code specific for :ref:`storages <vshard-architecture-storage>`.
     -   ``router.lua`` contains code specific for a :ref:`router <vshard-architecture-router>`.
     -   ``sharded_cluster_crud-scm-1.rockspec`` specifies external dependencies required by the application.
@@ -133,7 +133,7 @@ In this section, the following options are configured:
 
 The cluster topology defined in the :ref:`following section <vshard-quick-start-configuring-cluster-topology>` also specifies the ``iproto.advertise.client`` option for each instance.
 This option accepts a URI used to advertise the instance to clients.
-For example, |tcm_full_name| uses these URIs to :ref:`connect <tcm_connect_clusters>` to cluster instances.
+For example, :ref:`Tarantool Cluster Manager <tcm>` uses these URIs to :ref:`connect <tcm_connect_clusters>` to cluster instances.
 
 
 ..  _vshard-quick-start-configuring-cluster-bucket-count:
@@ -155,13 +155,13 @@ Specify the total number of :ref:`buckets <vshard-vbuckets>` in a sharded cluste
 Step 4: Defining the cluster topology
 *************************************
 
-Define the cluster's topology inside the :ref:`groups <configuration_reference_groups>` section.
+Define the cluster topology inside the :ref:`groups <configuration_reference_groups>` section.
 The cluster includes two groups:
 
 *   ``storages`` includes two replica sets. Each replica set contains two instances.
 *   ``routers`` includes one router instance.
 
-Here is a schematic view of the cluster's topology:
+Here is a schematic view of the cluster topology:
 
 .. code-block:: yaml
 
@@ -326,7 +326,7 @@ After starting instances, you need to bootstrap the cluster as follows:
            • Connecting to the instance...
            • Connected to sharded_cluster_crud:router-a-001
 
-2.  Call :ref:`vshard.router.bootstrap() <router_api-bootstrap>` to perform the initial cluster bootstrap:
+2.  Call :ref:`vshard.router.bootstrap() <router_api-bootstrap>` to perform the initial cluster bootstrap and distribute all buckets across the replica sets:
 
     ..  code-block:: tarantoolsession
 
@@ -338,10 +338,10 @@ After starting instances, you need to bootstrap the cluster as follows:
 
 .. _vshard-quick-start-working-status:
 
-Checking the cluster's status
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Checking the cluster status
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To check the cluster's status, execute :ref:`vshard.router.info() <router_api-info>` on the router:
+To check the cluster status, execute :ref:`vshard.router.info() <router_api-info>` on the router:
 
 .. code-block:: tarantoolsession
 
@@ -416,7 +416,7 @@ Writing and selecting data
             { 10, box.NULL, 'Queen', 1970 }
         })
 
-    Calling this function :ref:`distributes data <vshard-quick-start-working-adding-data>` evenly across the cluster's nodes.
+    Calling this function :ref:`distributes data <vshard-quick-start-working-adding-data>` evenly across the cluster nodes.
 
 2.  To get a tuple by the specified ID, call the ``crud.get()`` function:
 
@@ -464,7 +464,7 @@ Writing and selecting data
 Checking data distribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To check how data is distributed across the cluster's nodes, follow the steps below:
+To check how data is distributed across the replica sets, follow the steps below:
 
 1.  Connect to any storage in the ``storage-a`` replica set:
 


### PR DESCRIPTION
Previous update (migrating tutorial to a new config): https://github.com/tarantool/doc/pull/4042.

Fixes https://github.com/tarantool/doc/issues/4282.

- Updated Get Started to using the `crud` module: [Creating a sharded cluster](https://docs.d.tarantool.io/en/doc/sharded_cluster_use_crud/how-to/vshard_quick/). A new configuration also includes the `iproto.advertise.client` option specified for each instance (see [Step 4: Defining the cluster topology](https://docs.d.tarantool.io/en/doc/sharded_cluster_use_crud/how-to/vshard_quick/#step-4-defining-the-cluster-topology)). So, along with using the `crud` module the resulting cluster can be managed by TCM and can be used to demonstrate TCM capabilities.
- Updated related topics to using the `sharded_cluster_crud` sample: 
   - [Application environment](https://docs.d.tarantool.io/en/doc/sharded_cluster_use_crud/book/admin/instance_config/)
   - [Starting and stopping instances](https://docs.d.tarantool.io/en/doc/sharded_cluster_use_crud/book/admin/start_stop_instance/)
- Updated READMEs for the `sharded_cluster_crud` and `sharded_cluster` samples.

Note that the old `sharded_cluster` sample still exists and its code snippets are referenced in the [Sharding with vshard](https://www.tarantool.io/en/doc/latest/book/admin/vshard_admin/) topic.