### PR TITLE
Add tt integrity check options

### DIFF
--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -112,6 +112,47 @@ and aborts in case of an error. To skip the validation, add the ``--force`` opti
 
     $ tt cluster publish myapp source.yaml --force
 
+.. _tt-cluster-publish-integrity:
+
+Publishing configuration with integrity check
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+..  admonition:: Enterprise Edition
+    :class: fact
+
+    The integrity check functionality is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
+
+When called with the ``-with-integrity-check`` option, ``tt cluster publish``
+generates a checksum of the configuration it publishes. It signs the checksum using
+the private key passed as the option argument, and writes it into the configuration store.
+
+.. code-block:: console
+
+    $ tt cluster publish "http://localhost:2379/myapp" source.yaml --with-integrity-check private.pem
+
+If an application configuration is published this way, it can be checked for integrity
+using the ``--integrity-check`` :ref:`global option <tt-global-options>`.
+
+.. code-block:: console
+
+    $ tt --integrity-check public.pem start myapp
+
+Learn more about integrity checks upon application startup and in runtime in the :ref:`tt start <tt-start-integrity-check>` reference.
+
+To update the configuration with integrity check, call ``tt cluster publish``
+with two options:
+
+-   ``--integrity-check PUBLIC_KEY`` global option checks that the configuration wasn't changed
+    since it was published
+-   ``--with-integrity-check PRIVATE_KEY`` generates new checksums and signatures
+    for future integrity checks of the updated configuration.
+
+.. code-block:: console
+
+    $ tt --integrity-check public.pem cluster publish \
+         --with-integrity-check private.pem \
+         "http://localhost:2379/myapp" source.yaml
+
 .. _tt-cluster-show:
 
 show

--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -135,6 +135,7 @@ using the ``--integrity-check`` :ref:`global option <tt-global-options>`.
 
 .. code-block:: console
 
+    $ tt --integrity-check public.pem cluster show myapp
     $ tt --integrity-check public.pem start myapp
 
 Learn more about integrity checks upon application startup and in runtime in the :ref:`tt start <tt-start-integrity-check>` reference.

--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -122,7 +122,7 @@ Publishing configurations with integrity check
 
     The integrity check functionality is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
 
-When called with the ``-with-integrity-check`` option, ``tt cluster publish``
+When called with the ``--with-integrity-check`` option, ``tt cluster publish``
 generates a hash of configurations it publishes. It signs the hash using
 the private key passed as the option argument, and writes it into the configuration store.
 

--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -114,8 +114,8 @@ and aborts in case of an error. To skip the validation, add the ``--force`` opti
 
 .. _tt-cluster-publish-integrity:
 
-Publishing configuration with integrity check
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Publishing configurations with integrity check
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  admonition:: Enterprise Edition
     :class: fact
@@ -123,7 +123,7 @@ Publishing configuration with integrity check
     The integrity check functionality is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
 
 When called with the ``-with-integrity-check`` option, ``tt cluster publish``
-generates a checksum of the configuration it publishes. It signs the checksum using
+generates a hash of configurations it publishes. It signs the hash using
 the private key passed as the option argument, and writes it into the configuration store.
 
 .. code-block:: console
@@ -139,12 +139,12 @@ using the ``--integrity-check`` :ref:`global option <tt-global-options>`.
 
 Learn more about integrity checks upon application startup and in runtime in the :ref:`tt start <tt-start-integrity-check>` reference.
 
-To update the configuration with integrity check, call ``tt cluster publish``
+To ensure the configuration integrity when updating it, call ``tt cluster publish``
 with two options:
 
 -   ``--integrity-check PUBLIC_KEY`` global option checks that the configuration wasn't changed
     since it was published
--   ``--with-integrity-check PRIVATE_KEY`` generates new checksums and signatures
+-   ``--with-integrity-check PRIVATE_KEY`` generates new hash and signature
     for future integrity checks of the updated configuration.
 
 .. code-block:: console
@@ -519,3 +519,5 @@ Options
     **Applicable to:** ``publish``
 
     Generate hashes and signatures for integrity checks.
+
+    See also: :ref:`tt-cluster-publish-integrity`

--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -123,7 +123,7 @@ Publishing configurations with integrity check
     The integrity check functionality is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
 
 When called with the ``--with-integrity-check`` option, ``tt cluster publish``
-generates a hash of configurations it publishes. It signs the hash using
+generates a hash of the configurations it publishes. It signs the hash using
 the private key passed as the option argument, and writes it into the configuration store.
 
 .. code-block:: console

--- a/doc/reference/tooling/tt_cli/cluster.rst
+++ b/doc/reference/tooling/tt_cli/cluster.rst
@@ -123,7 +123,7 @@ Publishing configurations with integrity check
     The integrity check functionality is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
 
 When called with the ``--with-integrity-check`` option, ``tt cluster publish``
-generates a hash of the configurations it publishes. It signs the hash using
+generates a checksum of the configurations it publishes. It signs the checksum using
 the private key passed as the option argument, and writes it into the configuration store.
 
 .. code-block:: console

--- a/doc/reference/tooling/tt_cli/global_options.rst
+++ b/doc/reference/tooling/tt_cli/global_options.rst
@@ -26,6 +26,11 @@ Global options
 
 .. option:: --integrity-check PUBLIC_KEY
 
+    ..  admonition:: Enterprise Edition
+        :class: fact
+
+        This option is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
+
     Perform an integrity check using the specified public key before executing the operation.
     Learn more in :ref:`tt-start-integrity-check`.
 

--- a/doc/reference/tooling/tt_cli/global_options.rst
+++ b/doc/reference/tooling/tt_cli/global_options.rst
@@ -24,6 +24,11 @@ Global options
 
     Display help.
 
+.. option:: --integrity-check PUBLIC_KEY
+
+    Perform an integrity check using the specified public key before executing the operation.
+    Learn more in :ref:`tt-start-integrity-check`.
+
 .. option:: -I, --internal
 
     Force the use of an internal module even if there is an

--- a/doc/reference/tooling/tt_cli/pack.rst
+++ b/doc/reference/tooling/tt_cli/pack.rst
@@ -86,7 +86,7 @@ Generating files for integrity checks
 
     The integrity check functionality is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
 
-``tt pack`` can generate hashes and signatures to use for integrity checks
+``tt pack`` can generate checksums and signatures to use for integrity checks
 when running the application. These files are:
 
 -   ``hashes.json`` and ``hashes.json.sig`` in each application directory.
@@ -98,7 +98,7 @@ when running the application. These files are:
     similar files for the ``tt`` environment. They contain checksums for
     Tarantool and ``tt`` executables, and for the ``tt.yaml`` configuration file.
 
-To generate hashes and signatures for integrity check, use the ``--with-integrity-check``
+To generate checksums and signatures for integrity check, use the ``--with-integrity-check``
 option. Its argument must be an RSA private key.
 
 .. note::
@@ -116,7 +116,8 @@ To create a ``tar.gz`` archive with integrity check artifacts:
 
     $ tt pack tgz --with-integrity-check private.pem
 
-Learn how to perform integrity checks upon application startup and in runtime in the :ref:`tt start <tt-start-integrity-check>` reference.
+Learn how to perform integrity checks at the application startup and in runtime
+in the :ref:`tt start <tt-start-integrity-check>` reference.
 
 
 .. _tt-pack-options:
@@ -254,7 +255,7 @@ Options
 
 ..  option:: --with-integrity-check PRIVATE_KEY
 
-    Generate hashes and signatures for integrity checks at the application startup.
+    Generate checksums and signatures for integrity checks at the application startup.
 
     See also: :ref:`tt-pack-integrity-check`
 

--- a/doc/reference/tooling/tt_cli/pack.rst
+++ b/doc/reference/tooling/tt_cli/pack.rst
@@ -94,7 +94,7 @@ when running the application. These files are:
     and its configuration file. ``hashes.json.sig`` contains a digital signature
     for ``hashes.json``.
 
--   ``env-hashes.json`` and ``env-hashes.json.sig`` in the environment root are
+-   ``env_hashes.json`` and ``env_hashes.json.sig`` in the environment root are
     similar files for the ``tt`` environment. They contain checksums for
     Tarantool and ``tt`` executables, and for the ``tt.yaml`` configuration file.
 

--- a/doc/reference/tooling/tt_cli/pack.rst
+++ b/doc/reference/tooling/tt_cli/pack.rst
@@ -81,6 +81,11 @@ An example of the ``systemd-unit-params.yml`` file:
 Generating files for integrity checks
 -------------------------------------
 
+..  admonition:: Enterprise Edition
+    :class: fact
+
+    The integrity check functionality is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
+
 ``tt pack`` can generate hashes and signatures to use for integrity checks
 when running the application. These files are:
 

--- a/doc/reference/tooling/tt_cli/pack.rst
+++ b/doc/reference/tooling/tt_cli/pack.rst
@@ -256,6 +256,8 @@ Options
 
     Generate hashes and signatures for integrity checks at the application startup.
 
+    See also: :ref:`tt-pack-integrity-check`
+
 ..  option:: --with-tarantool-deps
 
     Add Tarantool and ``tt`` as package dependencies.

--- a/doc/reference/tooling/tt_cli/pack.rst
+++ b/doc/reference/tooling/tt_cli/pack.rst
@@ -90,12 +90,12 @@ Generating files for integrity checks
 when running the application. These files are:
 
 -   ``hashes.json`` and ``hashes.json.sig`` in each application directory.
-    ``hashes.json`` containsSHA256 checksums of executable files that the application uses
+    ``hashes.json`` contains SHA256 checksums of executable files that the application uses
     and its configuration file. ``hashes.json.sig`` contains a digital signature
     for ``hashes.json``.
 
 -   ``env-hashes.json`` and ``env-hashes.json.sig`` in the environment root are
-    a similar files for the ``tt`` environment. They contain checksums for
+    similar files for the ``tt`` environment. They contain checksums for
     Tarantool and ``tt`` executables, and for the ``tt.yaml`` configuration file.
 
 To generate hashes and signatures for integrity check, use the ``--with-integrity-check``
@@ -116,7 +116,7 @@ To create a ``tar.gz`` archive with integrity check artifacts:
 
     $ tt pack tgz --with-integrity-check private.pem
 
-Learn how to perform integrity checks upon application startup and in runtime in the :ref:``tt start <tt-start>`` reference.
+Learn how to perform integrity checks upon application startup and in runtime in the :ref:`tt start <tt-start-integrity-check>` reference.
 
 
 .. _tt-pack-options:

--- a/doc/reference/tooling/tt_cli/pack.rst
+++ b/doc/reference/tooling/tt_cli/pack.rst
@@ -103,7 +103,7 @@ option. Its argument must be an RSA private key.
 
 .. note::
 
-    You can generate a key pair using `OpenSSL <https://www.openssl.org/>`__  as follows:
+    You can generate a key pair using `OpenSSL 3 <https://www.openssl.org/>`__  as follows:
 
     .. code-block:: console
 

--- a/doc/reference/tooling/tt_cli/pack.rst
+++ b/doc/reference/tooling/tt_cli/pack.rst
@@ -76,6 +76,43 @@ An example of the ``systemd-unit-params.yml`` file:
       INSTANCE: "inst:%i"
       TARANTOOL_WORKDIR: "/tmp"
 
+.. _tt-pack-integrity-check:
+
+Generating files for integrity checks
+-------------------------------------
+
+``tt pack`` can generate hashes and signatures to use for integrity checks
+when running the application. These files are:
+
+-   ``hashes.json`` and ``hashes.json.sig`` in each application directory.
+    ``hashes.json`` containsSHA256 checksums of executable files that the application uses
+    and its configuration file. ``hashes.json.sig`` contains a digital signature
+    for ``hashes.json``.
+
+-   ``env-hashes.json`` and ``env-hashes.json.sig`` in the environment root are
+    a similar files for the ``tt`` environment. They contain checksums for
+    Tarantool and ``tt`` executables, and for the ``tt.yaml`` configuration file.
+
+To generate hashes and signatures for integrity check, use the ``--with-integrity-check``
+option. Its argument must be an RSA private key.
+
+.. note::
+
+    You can generate a key pair using `OpenSSL <https://www.openssl.org/>`__  as follows:
+
+    .. code-block:: console
+
+        $ openssl genrsa -traditional -out private.pem 2048
+        $ openssl rsa -in private.pem -pubout > public.pem
+
+To create a ``tar.gz`` archive with integrity check artifacts:
+
+.. code-block:: console
+
+    $ tt pack tgz --with-integrity-check private.pem
+
+Learn how to perform integrity checks upon application startup and in runtime in the :ref:``tt start <tt-start>`` reference.
+
 
 .. _tt-pack-options:
 
@@ -209,6 +246,10 @@ Options
 ..  option:: --with-binaries
 
     Include Tarantool and ``tt`` binaries in a bundle.
+
+..  option:: --with-integrity-check PRIVATE_KEY
+
+    Generate hashes and signatures for integrity checks at the application startup.
 
 ..  option:: --with-tarantool-deps
 

--- a/doc/reference/tooling/tt_cli/pack.rst
+++ b/doc/reference/tooling/tt_cli/pack.rst
@@ -58,7 +58,7 @@ option to the ``tt pack`` call:
 
 .. important::
 
-   The ``systemd-unit-params.yml`` file has a higher priority than the ``--unit-params-file`` option.
+    The ``systemd-unit-params.yml`` file has a higher priority than the ``--unit-params-file`` option.
     If this file exists, it overrides parameters from the file passed in the option.
 
 ``tt pack`` supports the following systemd unit parameters:

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -31,7 +31,7 @@ When called without arguments, starts all enabled applications in the current en
 
 ..  code-block:: console
 
-        $ tt start
+    $ tt start
 
 .. _tt-start-app-layout:
 
@@ -91,7 +91,7 @@ the application using ``tt pack`` with the ``--with-integrity-check`` option.
 This option generates and signs checksums of executables and configuration files in the current ``tt``
 environment. Learn more in :ref:`tt-pack-integrity-check`.
 
-To enable the configuration integrity check, publish the configuration to a centralized
+To add the configuration at the centralized storage integrity check, publish the configuration to a centralized
 storage using ``tt cluster publish`` with the ``--with-integrity-check`` option.
 This option generates and signs configuration checksums and saves them to the storage.
 Learn more in :ref:`tt-cluster-publish-integrity`.

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -86,12 +86,12 @@ Integrity check
 ``tt start`` can perform initial and periodical integrity checks of the environment,
 application, and centralized configuration.
 
-To enable the integrity checks of environment and application files, you need to pack
+To enable integrity checks of environment and application files, you need to pack
 the application using ``tt pack`` with the ``--with-integrity-check`` option.
 This option generates and signs checksums of executables and configuration files in the current ``tt``
 environment. Learn more in :ref:`tt-pack-integrity-check`.
 
-To enable the integrity check of the configuration at the centralized storage,
+To enable integrity check of the configuration at the centralized storage,
 publish the configuration to this storage using ``tt cluster publish`` with the ``--with-integrity-check`` option.
 This option generates and signs configuration checksums and saves them to the storage.
 Learn more in :ref:`tt-cluster-publish-integrity`.
@@ -116,7 +116,7 @@ by adding the ``--integrity-check-period`` option:
     $ tt --integrity-check public.pem start myapp --integrity-check-period 60
 
 Additionally, Tarantool checks the integrity of the modules that the application uses
-at the load time, that is, when ``require(\`module\`)`` is called.
+at the load time, that is, when ``require('module')`` is called.
 
 If an integrity check fails, ``tt`` stops the application.
 

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -91,8 +91,8 @@ the application using ``tt pack`` with the ``--with-integrity-check`` option.
 This option generates and signs checksums of executables and configuration files in the current ``tt``
 environment. Learn more in :ref:`tt-pack-integrity-check`.
 
-To add the configuration at the centralized storage integrity check, publish the configuration to a centralized
-storage using ``tt cluster publish`` with the ``--with-integrity-check`` option.
+To enable the integrity check of the configuration at the centralized storage,
+publish the configuration to a this storage using ``tt cluster publish`` with the ``--with-integrity-check`` option.
 This option generates and signs configuration checksums and saves them to the storage.
 Learn more in :ref:`tt-cluster-publish-integrity`.
 
@@ -114,6 +114,9 @@ by adding the ``--integrity-check-period`` option:
 ..  code-block:: console
 
     $ tt --integrity-check public.pem start myapp --integrity-check-period 60
+
+Additionally, Tarantool checks the integrity of the modules that the application uses
+at the load time, that is, when ``require(\`module\`)`` is called.
 
 If an integrity check fails, ``tt`` stops the application.
 

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -92,7 +92,7 @@ This option generates and signs checksums of executables and configuration files
 environment. Learn more in :ref:`tt-pack-integrity-check`.
 
 To enable the integrity check of the configuration at the centralized storage,
-publish the configuration to a this storage using ``tt cluster publish`` with the ``--with-integrity-check`` option.
+publish the configuration to this storage using ``tt cluster publish`` with the ``--with-integrity-check`` option.
 This option generates and signs configuration checksums and saves them to the storage.
 Learn more in :ref:`tt-cluster-publish-integrity`.
 

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -83,14 +83,21 @@ Integrity check
 
     The integrity check functionality is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
 
-``tt start`` can perform initial and periodical integrity checks of applications
-that it starts. To make the integrity checks possible, you need to pack the application
-using ``tt pack`` with the ``--with-integrity-check`` option. This option generates
-and signs checksums of executables and configuration files in the current ``tt``
+``tt start`` can perform initial and periodical integrity checks of the environment,
+application, and centralized configuration.
+
+To enable the integrity checks of environment and application files, you need to pack
+the application using ``tt pack`` with the ``--with-integrity-check`` option.
+This option generates and signs checksums of executables and configuration files in the current ``tt``
 environment. Learn more in :ref:`tt-pack-integrity-check`.
 
-To check the environment and application integrity when running the application,
-start it with the :ref:`global option <tt-global-options>` ``--integrity-check``.
+To enable the configuration integrity check, publish the configuration to a centralized
+storage using ``tt cluster publish`` with the ``--with-integrity-check`` option.
+This option generates and signs configuration checksums and saves them to the storage.
+Learn more in :ref:`tt-cluster-publish-integrity`.
+
+To perform the integrity checks when running the application, start it with the
+``--integrity-check`` :ref:`global option <tt-global-options>`.
 Its argument must be a public key matching the private key that was used for
 generating checksums.
 
@@ -98,9 +105,9 @@ generating checksums.
 
     $ tt --integrity-check public.pem start myapp
 
-After such a call, ``tt`` checks the environment and application integrity using
-the checksums and starts the application in case of the success. Then, integrity
-checks are performed periodically when the application is running. By default,
+After such a call, ``tt`` checks the environment, application, and configuration integrity
+using the checksums and starts the application in case of the success. Then, integrity
+checks are performed periodically while the application is running. By default,
 they are performed once every 24 hours. You can adjust the integrity check period
 by adding the ``--integrity-check-period`` option:
 

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -108,6 +108,7 @@ by adding the ``--integrity-check-period`` option:
 
     $ tt --integrity-check public.pem start myapp --integrity-check-period 60
 
+If an integrity check fails, ``tt`` stops the application.
 
 .. _tt-start-options:
 
@@ -118,3 +119,5 @@ Options
 
     Integrity check interval in seconds. Default: 86400 (24 hours).
     Set this option to ``0`` to disable periodic checks.
+
+    See also: :ref:`tt-start-integrity-check`

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -12,9 +12,28 @@ inside the ``instances_enabled`` directory specified in the :ref:`tt configurati
 For detailed instructions on preparing and running Tarantool applications, see
 :ref:`admin-instance-environment-overview` and :ref:`admin-start_stop_instance`.
 
-When called without arguments, starts all enabled applications in the current environment.
-
 See also: :ref:`tt-stop`, :ref:`tt-restart`, :ref:`tt-status`.
+
+To start all instances of the application stored in the ``app`` directory inside
+``instances_enabled`` in accordance with its ``instances.yml``:
+
+..  code-block:: console
+
+    $ tt start app
+
+To start the ``router`` instance of the ``app`` application:
+
+..  code-block:: console
+
+    $ tt start app:router
+
+When called without arguments, starts all enabled applications in the current environment:
+
+..  code-block:: console
+
+        $ tt start
+
+.. _tt-start-app-layout:
 
 Application layout
 ------------------
@@ -38,6 +57,8 @@ For more information about Tarantool application layout, see :ref:`admin-instanc
     which is considered a legacy approach since Tarantool 3.0. For information
     about using ``tt`` with such applications, refer to the Tarantool 2.11 documentation.
 
+.. _tt-start-background:
+
 Running in the background
 -------------------------
 
@@ -52,19 +73,43 @@ process for status checks (:ref:`tt status <tt-status>`) and application stoppin
     If you start such an application with ``tt start``, ``tt`` won't be able to check
     the application status or stop it using the corresponding commands.
 
-Examples
---------
+.. _tt-start-integrity-check:
 
-*   Start instances of the application stored in the ``app`` directory inside
-    ``instances_enabled`` in accordance with its ``instances.yml``:
+Integrity check
+---------------
 
-    ..  code-block:: console
+``tt start`` can perform initial and periodical integrity checks of applications
+that it starts. To make the integrity checks possible, you need to pack the application
+using ``tt pack`` with the ``--with-integrity-check`` option. This option generates
+and signs checksums of executables and configuration files in the current ``tt``
+environment. Learn more in :ref:`tt-pack-integrity-check`.
 
-        $ tt start app
+To check the environment and application integrity when running the application,
+start it with the :ref:`global option <tt-global-options>` ``--integrity-check``.
+Its argument must be a public key matching the private key that was used for
+generating checksums.
 
-*   Start the ``router`` instance of the ``app`` application:
+..  code-block:: console
 
-    ..  code-block:: console
+    $ tt --integrity-check public.pem start myapp
 
-        $ tt start app:router
+After such a call, ``tt`` checks the environment and application integrity using
+the checksums and starts the application in case of the success. Then, integrity
+checks are performed periodically when the application is running. By default,
+they are performed once every 24 hours. You can adjust the integrity check period
+by adding the ``--integrity-check-period`` option:
 
+..  code-block:: console
+
+    $ tt --integrity-check public.pem start myapp --integrity-check-period 60
+
+
+.. _tt-start-options:
+
+Options
+-------
+
+..  option:: --integrity-check-interval NUMBER
+
+    Integrity check interval in seconds. Default: 86400 (24 hours).
+    Set this option to ``0`` to disable periodic checks.

--- a/doc/reference/tooling/tt_cli/start.rst
+++ b/doc/reference/tooling/tt_cli/start.rst
@@ -78,6 +78,11 @@ process for status checks (:ref:`tt status <tt-status>`) and application stoppin
 Integrity check
 ---------------
 
+..  admonition:: Enterprise Edition
+    :class: fact
+
+    The integrity check functionality is supported by the `Enterprise Edition <https://www.tarantool.io/compare/>`_ only.
+
 ``tt start`` can perform initial and periodical integrity checks of applications
 that it starts. To make the integrity checks possible, you need to pack the application
 using ``tt pack`` with the ``--with-integrity-check`` option. This option generates


### PR DESCRIPTION
Resolves: https://github.com/tarantool/enterprise_doc/issues/261, https://github.com/tarantool/enterprise_doc/issues/262, https://github.com/tarantool/enterprise_doc/issues/263

Added information about integrity checks in tt-ee:
- [tt global options](https://docs.d.tarantool.io/en/doc/gh-261ee-tt-integrity-check/reference/tooling/tt_cli/global_options/): new option `--integrity-check`
- [tt pack](https://docs.d.tarantool.io/en/doc/gh-261ee-tt-integrity-check/reference/tooling/tt_cli/pack/#generating-files-for-integrity-checks): a subsection about generating files for integrity check,  ``--with-integrity-check`` option
- [tt start](https://docs.d.tarantool.io/en/doc/gh-261ee-tt-integrity-check/reference/tooling/tt_cli/start/#integrity-check): a subsection about starting apps with integrity check, ``--integrity-check-period`` option
- [tt cluster](https://docs.d.tarantool.io/en/doc/gh-261ee-tt-integrity-check/reference/tooling/tt_cli/cluster/#publishing-configurations-with-integrity-check): a subsection about publishing config with the integrity check artifacts.

Deployment: https://docs.d.tarantool.io/en/doc/gh-261ee-tt-integrity-check/reference/tooling/tt_cli/start/#integrity-check