### PR TITLE
Add `compat` configuration options reference

### DIFF
--- a/doc/book/box/limitations.rst
+++ b/doc/book/box/limitations.rst
@@ -62,7 +62,7 @@ Limitations
 
 **Number of spaces**
 
-    The theoretical maximum is 2147483647 (``box.schema.SPACE_MAX``)
+    The theoretical maximum is 2147483646 (``box.schema.SPACE_MAX``)
     but the practical maximum is around 65,000.
 
 .. _limitations_number_of_connections:

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -392,6 +392,278 @@ audit_log.syslog.*
     | Default: box.NULL
     | Environment variable: TT_AUDIT_LOG_SYSLOG_SERVER
 
+..  _configuration_reference_compat:
+
+compat
+------
+
+The ``compat`` section defines values of the :ref:`compat <compat-module>` module options.
+
+..  NOTE::
+
+    ``compat`` can be defined in any :ref:`scope <configuration_scopes>`.
+
+* :ref:`compat.binary_data_decoding <configuration_reference_compat_binary_decoding>`
+* :ref:`compat.box_cfg_replication_sync_timeout <configuration_reference_compat_replication_timeout>`
+* :ref:`compat.box_error_serialize_verbose <configuration_reference_compat_error_serialize>`
+* :ref:`compat.box_error_unpack_type_and_code <configuration_reference_compat_error_unpack>`
+* :ref:`compat.box_info_cluster_meaning <configuration_reference_compat_yaml_pretty>`
+* :ref:`compat.box_session_push_deprecation <configuration_reference_compat_session_push>`
+* :ref:`compat.box_space_execute_priv <configuration_reference_compat_space_execute>`
+* :ref:`compat.box_space_max <configuration_reference_compat_space_max>`
+* :ref:`compat.box_tuple_extension <configuration_reference_compat_tuple_extension>`
+* :ref:`compat.box_tuple_new_vararg <configuration_reference_compat_tuple_new>`
+* :ref:`compat.c_func_iproto_multireturn <configuration_reference_compat_iproto_multireturn>`
+* :ref:`compat.fiber_channel_close_mode <configuration_reference_compat_fiber_channel>`
+* :ref:`compat.fiber_slice_default <configuration_reference_compat_cluster_meaning>`
+* :ref:`compat.json_escape_forward_slash <configuration_reference_compat_json_escape>`
+* :ref:`compat.sql_priv <configuration_reference_compat_sql_priv>`
+* :ref:`compat.sql_seq_scan_default <configuration_reference_compat_sql_scan>`
+* :ref:`compat.yaml_pretty_multiline <configuration_reference_compat_yaml_pretty>`
+
+
+* :ref:` ??? compat.console_session_scope_vars <configuration_reference_compat_session_scope>`
+
+
+.. _configuration_reference_compat_binary_decoding:
+
+.. confval:: compat.binary_data_decoding
+
+    Whether a binary data field should be stored in a varbinary object ('new') or a plain
+    string ('old') when decoded in Lua.
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_BINARY_DATA_DECODING
+
+.. _configuration_reference_compat_replication_timeout:
+
+.. confval:: compat.box_cfg_replication_sync_timeout
+
+    Sets a default replication sync timeout: 0 ('new') or 300 seconds ('old')
+
+    .. important::
+
+        This value is set during the initial ``box.cfg{}`` call and cannot be changed later.
+
+    See also: :ref:`compat-option-replication-timeout`
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_BOX_CFG_REPLICATION_SYNC_TIMEOUT
+
+.. _configuration_reference_compat_error_serialize:
+
+.. confval:: compat.box_error_serialize_verbose
+
+    Controls the verbosity of ``box.error`` serialization. Before, only the error
+    message was serialized, omitting all other potentially useful fields. Now, a
+    more verbose representation is used.
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'old'
+    | Environment variable: TT_COMPAT_BOX_ERROR_SERIALIZE_VERBOSE
+
+.. _configuration_reference_compat_error_unpack:
+
+.. confval:: compat.box_error_unpack_type_and_code
+
+    Whether to show redundant fields in ``box.error.unpack()``. The new behaviour
+    is not to show ``base_type`` and ``custom_type`` fields. The ``code`` field is also not
+    shown if it is 0. Note that ``base_type`` is still accessible for error object.
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'old'
+    | Environment variable: TT_COMPAT_BOX_ERROR_UNPACK_TYPE_AND_CODE
+
+.. _configuration_reference_compat_cluster_meaning:
+
+.. confval:: compat.box_info_cluster_meaning
+
+    Whether ``box.info.cluster`` should show the current replica set ('old') or
+    the whole cluster with all its replica sets ('new')).
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_BOX_INFO_CLUSTER_MEANING
+
+
+.. _configuration_reference_compat_session_push:
+
+.. confval:: compat.box_session_push_deprecation
+
+    Whether to raise errors on attempts to call the deprecated function ``box.session.push``:
+
+    -   'old': do not raise an error
+    -   'new': raise an error
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'old'
+    | Environment variable: TT_COMPAT_BOX_SESSION_PUSH_DEPRECATION
+
+.. _configuration_reference_compat_space_execute:
+
+.. confval:: compat.box_space_execute_priv
+
+    Whether the ``execute`` privilege can be granted on spaces:
+
+    -   'old': the privilege can be granted with no actual effect
+    -   'new': an error is raised
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_BOX_SPACE_EXECUTE_PRIV
+
+.. _configuration_reference_compat_space_max:
+
+.. confval:: compat.box_space_max
+
+    Controls the max space id (``box.schema.SPACE_MAX``). The old limit is 2147483647.
+    The new limit is 2147483646. The limit was decremented because the old value is
+    used as an error indicator in the ``box`` C API.
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_BOX_SPACE_MAX
+
+.. _configuration_reference_compat_tuple_extension:
+
+.. confval:: compat.box_tuple_extension
+
+    Controls ``IPROTO_FEATURE_CALL_RET_TUPLE_EXTENSION`` and
+    ``IPROTO_FEATURE_CALL_ARG_TUPLE_EXTENSION`` feature bits.
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_BOX_TUPLE_EXTENSION
+
+.. _configuration_reference_compat_tuple_new:
+
+.. confval:: compat.box_tuple_new_vararg
+
+    Whether ``box.tuple.new`` should interpret an argument list as an array of
+    tuple fields ('old'), or as a value with a tuple format ('new').
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_BOX_TUPLE_NEW_VARARG
+
+
+.. _configuration_reference_compat_iproto_multireturn:
+
+.. confval:: compat.c_func_iproto_multireturn
+
+    Whether the multiple results of a stored C function should be wrapped into
+    a msgpack array when returning them via iproto ('old') or returned consistently
+    with a local call via ``box.func` ('new').
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_C_FUNC_IPROTO_MULTIRETURN
+
+.. _configuration_reference_compat_session_scope:
+
+.. confval:: compat.console_session_scope_vars
+
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'old'
+    | Environment variable: TT_COMPAT_CONSOLE_SESSION_SCOPE_VARS
+
+.. _configuration_reference_compat_fiber_channel:
+
+.. confval:: compat.fiber_channel_close_mode
+
+    Whether fiber channel should be marked read-only on close ('new') instead of being destroyed ('old').
+
+    See also: :ref:`compat-option-fiber-channel`
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_FIBER_CHANNEL_CLOSE_MODE
+
+.. _configuration_reference_compat_json_escape:
+
+.. confval:: compat.json_escape_forward_slash
+
+    Whether to escape the forward slash symbol '/' using a backslash in a ``json.encode()`` result.
+
+    See also: :ref:`compat-option-json-slash`
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_JSON_ESCAPE_FORWARD_SLASH
+
+.. _configuration_reference_compat_sql_priv:
+
+.. confval:: compat.sql_priv
+
+    Whether to enable access checks for SQL requests ('new') or allow any user
+    to execute SQL over iproto ('old').
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_SQL_PRIV
+
+.. _configuration_reference_compat_sql_scan:
+
+.. confval:: compat.sql_seq_scan_default
+
+    Whether seq_seq_scan session setting should be set to true ('old') or false ('new')
+    during initialization or new session creation.
+
+    See also: :ref:`compat-option-sql-scan`
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_SQL_SEQ_SCAN_DEFAULT
+
+.. _configuration_reference_compat_yaml_pretty:
+
+.. confval:: compat.yaml_pretty_multiline
+
+    Whether to encode in block scalar style all multiline strings or ones containing "\n\n" substring.
+
+    See also: :ref:`compat-option-lyaml`
+
+    |
+    | Type: string
+    | Possible values: 'new', 'old'
+    | Default: 'new'
+    | Environment variable: TT_COMPAT_YAML_PRETTY_MULTILINE
+
 ..  _configuration_reference_config:
 
 config

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -459,8 +459,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Controls the verbosity of :ref:`error objects <box_error-error_object>` serialization:
 
+    -   ``new``: serialize the error message together with other potentially useful fields
     -   ``old``: serialize only the error message
-    -   ``new``: serialize the error message together with other potentially useful fields.
 
     |
     | Type: string
@@ -504,8 +504,9 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Whether to raise errors on attempts to call the deprecated function ``box.session.push``:
 
-    -   ``old``: do not raise an error
     -   ``new``: raise an error
+    -   ``old``: do not raise an error
+
 
     |
     | Type: string
@@ -519,8 +520,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Whether the ``execute`` privilege can be granted on spaces:
 
-    -   ``old``: the privilege can be granted with no actual effect
     -   ``new``: an error is raised
+    -   ``old``: the privilege can be granted with no actual effect
 
     |
     | Type: string
@@ -534,8 +535,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Controls the max space id (``box.schema.SPACE_MAX``):
 
-    -   ``old``: 2147483647
     -   ``new``: 2147483646
+    -   ``old``: 2147483647
 
     The limit was decremented because the old max value is used as an error indicator in the ``box`` C API.
 
@@ -568,8 +569,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Controls how ``box.tuple.new`` interprets an argument list:
 
-    -   ``old``: as an array of tuple fields
     -   ``new``: as a value with a tuple format
+    -   ``old``: as an array of tuple fields
 
     |
     | Type: string
@@ -584,8 +585,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Controls wrapping of multiple results of a stored C function when returning them via iproto:
 
-    -   ``old``: wrap results into a MessagePack array
     -   ``new``: return without wrapping (consistently with a local call via ``box.func``)
+    -   ``old``: wrap results into a MessagePack array
 
     |
     | Type: string
@@ -600,7 +601,7 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
     Defines the behavior of filber channels after closing:
 
     -   ``new``: mark the channel read-only
-    -   `old``: destroy the channel object
+    -   ``old``: destroy the channel object
 
     See also: :ref:`compat-option-fiber-channel`
 
@@ -616,8 +617,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Whether to escape the forward slash symbol '/' using a backslash in a ``json.encode()`` result:
 
-    -   ``new``: escape the forward slash
-    -   ``old``: do not escape the forward slash
+    -   ``new``: do not escape the forward slash
+    -   ``old``: escape the forward slash
 
     See also: :ref:`compat-option-json-slash`
 
@@ -665,8 +666,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Whether to encode in block scalar style all multiline strings or ones containing the ``\n\n`` substring:
 
-    -   ``new``: encode all multiline strings in the block scalar style
-    -   ``old``: encode only strings containing the ``\n\n`` substring: in the block scalar style
+    -   ``new``: all multiline strings
+    -   ``old``: only strings containing the ``\n\n`` substring
 
     See also: :ref:`compat-option-lyaml`
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -422,15 +422,12 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 * :ref:`compat.yaml_pretty_multiline <configuration_reference_compat_yaml_pretty>`
 
 
-* :ref:` ??? compat.console_session_scope_vars <configuration_reference_compat_session_scope>`
-
-
 .. _configuration_reference_compat_binary_decoding:
 
 .. confval:: compat.binary_data_decoding
 
-    Whether a binary data field should be stored in a varbinary object ('new') or a plain
-    string ('old') when decoded in Lua.
+    Whether a binary data field should be stored in a varbinary object (`new`) or a plain
+    string (`old`) when decoded in Lua.
 
     |
     | Type: string
@@ -442,7 +439,7 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_cfg_replication_sync_timeout
 
-    Sets a default replication sync timeout: 0 ('new') or 300 seconds ('old')
+    Sets a default replication sync timeout: 0 (`new`) or 300 seconds (`old`)
 
     .. important::
 
@@ -460,9 +457,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_error_serialize_verbose
 
-    Controls the verbosity of ``box.error`` serialization. Before, only the error
-    message was serialized, omitting all other potentially useful fields. Now, a
-    more verbose representation is used.
+    Controls the verbosity of :ref:`error objects <box_error-error_object>` serialization:
+
+    -   ``old``: serialize only the error message
+    -   ``new``: serialize the error message together with other potentially useful fields.
 
     |
     | Type: string
@@ -474,9 +472,11 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_error_unpack_type_and_code
 
-    Whether to show redundant fields in ``box.error.unpack()``. The new behaviour
-    is not to show ``base_type`` and ``custom_type`` fields. The ``code`` field is also not
-    shown if it is 0. Note that ``base_type`` is still accessible for error object.
+    Whether to show error fields in ``box.error.unpack()``:
+
+    -   ``new``: do not show ``base_type`` and ``custom_type`` fields; do not show
+        the ``code`` field if it is 0. Note that ``base_type`` is still accessible for error object.
+    -   ``old``: show all fields
 
     |
     | Type: string
@@ -488,8 +488,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_info_cluster_meaning
 
-    Whether ``box.info.cluster`` should show the current replica set ('old') or
-    the whole cluster with all its replica sets ('new')).
+    Whether ``box.info.cluster`` should show the current replica set (`old`) or
+    the whole cluster with all its replica sets (`new`).
 
     |
     | Type: string
@@ -504,8 +504,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Whether to raise errors on attempts to call the deprecated function ``box.session.push``:
 
-    -   'old': do not raise an error
-    -   'new': raise an error
+    -   ``old``: do not raise an error
+    -   ``new``: raise an error
 
     |
     | Type: string
@@ -519,8 +519,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
     Whether the ``execute`` privilege can be granted on spaces:
 
-    -   'old': the privilege can be granted with no actual effect
-    -   'new': an error is raised
+    -   ``old``: the privilege can be granted with no actual effect
+    -   ``new``: an error is raised
 
     |
     | Type: string
@@ -532,9 +532,12 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_space_max
 
-    Controls the max space id (``box.schema.SPACE_MAX``). The old limit is 2147483647.
-    The new limit is 2147483646. The limit was decremented because the old value is
-    used as an error indicator in the ``box`` C API.
+    Controls the max space id (``box.schema.SPACE_MAX``):
+
+    -   ``old``: 2147483647
+    -   ``new``: 2147483646
+
+    The limit was decremented because the old max value is used as an error indicator in the ``box`` C API.
 
     |
     | Type: string
@@ -547,7 +550,11 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 .. confval:: compat.box_tuple_extension
 
     Controls ``IPROTO_FEATURE_CALL_RET_TUPLE_EXTENSION`` and
-    ``IPROTO_FEATURE_CALL_ARG_TUPLE_EXTENSION`` feature bits.
+    ``IPROTO_FEATURE_CALL_ARG_TUPLE_EXTENSION`` feature bits that
+    define tuple encoding in iproto ``call`` and ``eval`` requests.
+
+    -   ``new``: tuples with formats are encoded as ``MP_TUPLE``
+    -   ``old``: tuples with formats are encoded as ``MP_ARRAY``
 
     |
     | Type: string
@@ -559,8 +566,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_tuple_new_vararg
 
-    Whether ``box.tuple.new`` should interpret an argument list as an array of
-    tuple fields ('old'), or as a value with a tuple format ('new').
+    Controls how ``box.tuple.new`` interprets an argument list:
+
+    -   ``old``: as an array of tuple fields
+    -   ``new``: as a value with a tuple format
 
     |
     | Type: string
@@ -573,9 +582,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.c_func_iproto_multireturn
 
-    Whether the multiple results of a stored C function should be wrapped into
-    a msgpack array when returning them via iproto ('old') or returned consistently
-    with a local call via ``box.func` ('new').
+    Controls wrapping of multiple results of a stored C function when returning them via iproto:
+
+    -   ``old``: wrap results into a MessagePack array
+    -   ``new``: return without wrapping (consistently with a local call via ``box.func``)
 
     |
     | Type: string
@@ -583,22 +593,14 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
     | Default: 'new'
     | Environment variable: TT_COMPAT_C_FUNC_IPROTO_MULTIRETURN
 
-.. _configuration_reference_compat_session_scope:
-
-.. confval:: compat.console_session_scope_vars
-
-
-    |
-    | Type: string
-    | Possible values: 'new', 'old'
-    | Default: 'old'
-    | Environment variable: TT_COMPAT_CONSOLE_SESSION_SCOPE_VARS
-
 .. _configuration_reference_compat_fiber_channel:
 
 .. confval:: compat.fiber_channel_close_mode
 
-    Whether fiber channel should be marked read-only on close ('new') instead of being destroyed ('old').
+    Defines the behavior of filber channels after closing:
+
+    -   ``new``: mark the channel read-only
+    -   `old``: destroy the channel object
 
     See also: :ref:`compat-option-fiber-channel`
 
@@ -612,7 +614,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.json_escape_forward_slash
 
-    Whether to escape the forward slash symbol '/' using a backslash in a ``json.encode()`` result.
+    Whether to escape the forward slash symbol '/' using a backslash in a ``json.encode()`` result:
+
+    -   ``new``: escape the forward slash
+    -   ``old``: do not escape the forward slash
 
     See also: :ref:`compat-option-json-slash`
 
@@ -626,8 +631,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.sql_priv
 
-    Whether to enable access checks for SQL requests ('new') or allow any user
-    to execute SQL over iproto ('old').
+    Whether to enable access checks for SQL requests over iproto:
+
+    -   ``new``: check the user's access permissions
+    -   ``old``: allow any user to execute SQL over iproto
 
     |
     | Type: string
@@ -639,8 +646,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.sql_seq_scan_default
 
-    Whether seq_seq_scan session setting should be set to true ('old') or false ('new')
-    during initialization or new session creation.
+    Controls the default value of the ``sql_seq_scan`` session setting:
+
+    -   ``new``: false
+    -   ``old``: true
 
     See also: :ref:`compat-option-sql-scan`
 
@@ -654,7 +663,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.yaml_pretty_multiline
 
-    Whether to encode in block scalar style all multiline strings or ones containing "\n\n" substring.
+    Whether to encode in block scalar style all multiline strings or ones containing the ``\n\n`` substring:
+
+    -   ``new``: encode all multiline strings in the block scalar style
+    -   ``old``: encode only strings containing the ``\n\n`` substring: in the block scalar style
 
     See also: :ref:`compat-option-lyaml`
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -426,8 +426,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.binary_data_decoding
 
-    Whether a binary data field should be stored in a varbinary object (`new`) or a plain
-    string (`old`) when decoded in Lua.
+    Defines how to store binary data fields in Lua after decoding:
+
+    -   ``new``: as varbinary objects
+    -   ``old``: as plain strings
 
     |
     | Type: string

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -441,7 +441,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_cfg_replication_sync_timeout
 
-    Set a default replication sync timeout: 0 (`new`) or 300 seconds (`old`).
+    Set a default replication sync timeout:
+
+    -   ``new``: 0
+    -   ``old``: 300 seconds
 
     .. important::
 
@@ -494,8 +497,10 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_info_cluster_meaning
 
-    Whether ``box.info.cluster`` should show the current replica set (`old`) or
-    the whole cluster with all its replica sets (`new`).
+    Define the behavior of ``box.info.cluster``:
+
+    -   ``new``: show the entire cluster
+    -   ``old:``: show the current replica set
 
     |
     | Type: string

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -459,6 +459,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_error_serialize_verbose
 
+    **Since:** :doc:`3.1.0 </release/3.1.0>`
+
     Set the verbosity of :ref:`error objects <box_error-error_object>` serialization:
 
     -   ``new``: serialize the error message together with other potentially useful fields
@@ -473,6 +475,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 .. _configuration_reference_compat_error_unpack:
 
 .. confval:: compat.box_error_unpack_type_and_code
+
+    **Since:** :doc:`3.1.0 </release/3.1.0>`
 
     Whether to show error fields in ``box.error.unpack()``:
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -426,7 +426,7 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.binary_data_decoding
 
-    Defines how to store binary data fields in Lua after decoding:
+    Define how to store binary data fields in Lua after decoding:
 
     -   ``new``: as varbinary objects
     -   ``old``: as plain strings
@@ -441,7 +441,7 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_cfg_replication_sync_timeout
 
-    Sets a default replication sync timeout: 0 (`new`) or 300 seconds (`old`)
+    Set a default replication sync timeout: 0 (`new`) or 300 seconds (`old`).
 
     .. important::
 
@@ -459,7 +459,7 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_error_serialize_verbose
 
-    Controls the verbosity of :ref:`error objects <box_error-error_object>` serialization:
+    Set the verbosity of :ref:`error objects <box_error-error_object>` serialization:
 
     -   ``new``: serialize the error message together with other potentially useful fields
     -   ``old``: serialize only the error message
@@ -477,7 +477,7 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
     Whether to show error fields in ``box.error.unpack()``:
 
     -   ``new``: do not show ``base_type`` and ``custom_type`` fields; do not show
-        the ``code`` field if it is 0. Note that ``base_type`` is still accessible for error object.
+        the ``code`` field if it is 0. Note that ``base_type`` is still accessible for an error object.
     -   ``old``: show all fields
 
     |
@@ -535,7 +535,7 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.box_space_max
 
-    Controls the max space id (``box.schema.SPACE_MAX``):
+    Set the maximum space identifier (``box.schema.SPACE_MAX``):
 
     -   ``new``: 2147483646
     -   ``old``: 2147483647
@@ -600,7 +600,7 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
 
 .. confval:: compat.fiber_channel_close_mode
 
-    Defines the behavior of filber channels after closing:
+    Define the behavior of fiber channels after closing:
 
     -   ``new``: mark the channel read-only
     -   ``old``: destroy the channel object

--- a/doc/reference/reference_lua/compat.rst
+++ b/doc/reference/reference_lua/compat.rst
@@ -3,9 +3,6 @@
 Module compat
 =============
 
-Module ``compat`` is introduced since version 2.11.0-rc.
-
-
 The usual way to handle compatibility problems is to introduce an option for a new behavior and leave the old one by default.
 It is not always the perfect way.
 
@@ -43,6 +40,26 @@ Basic usage
 If you want to explicitly secure every behavior in ``compat``, you can do it manually, and then call ``compat.dump()`` to get a Lua command that sets up the ``compat`` with all the options selected.
 You should place this commands at the beginning of code in your ``init.lua`` file. In this way, you are guaranteed to get the same behavior on any other Tarantool version.
 See a :doc:`tutorial on using compat <./compat/compat_tutorial>` for more examples.
+
+Configuration options
+---------------------
+
+Another way to handle compatibility issues is setting the ``compat.*`` :ref:`configuration options <configuration_reference_compat>`.
+Similarly to the ``compat`` Lua module options, the configuration options can have
+values ``new`` and ``old``. The set of configuration options matches the set of
+options available in the ``compat`` module.
+
+Below is an example fragment of a YAML configuration file:
+
+.. code-block:: yaml
+
+    compat:
+      box_space_max: 'new'
+      sql_seq_scan_default: 'old'
+      fiber_slice_default: 'old'
+      binary_data_decoding: 'new'
+
+Learn more in the :ref:`configuration_reference`.
 
 Options
 -------

--- a/doc/reference/reference_lua/compat/box_cfg_replication_sync_timeout.rst
+++ b/doc/reference/reference_lua/compat/box_cfg_replication_sync_timeout.rst
@@ -3,6 +3,8 @@
 Default value for replication_sync_timeout
 ==========================================
 
+Option: ``box_cfg_replication_sync_timeout``
+
 Having a non-zero :ref:`replication_sync_timeout <cfg_replication-replication_sync_timeout>` gives a user the false assumption that the ``box.cfg{replication = ...}`` call returns only when the configured node is synced with all the other nodes.
 This is mostly true for the big ``replication_sync_timeout`` values, but it is not 100% guaranteed.
 In other words, a user still has to check if the node is synced, or the sync just timed out.

--- a/doc/reference/reference_lua/compat/fiber_channel_close_mode.rst
+++ b/doc/reference/reference_lua/compat/fiber_channel_close_mode.rst
@@ -3,6 +3,8 @@
 Fiber channel close mode
 ========================
 
+Option: ``fiber_channel_close_mode``
+
 Before the change, there was an unexpected behavior when using ``channel:close()`` because it closed the channel entirely and discarded all unread events.
 
 Old and new behavior

--- a/doc/reference/reference_lua/compat/fiber_slice_default.rst
+++ b/doc/reference/reference_lua/compat/fiber_slice_default.rst
@@ -3,6 +3,8 @@
 Default value for max fiber slice
 =================================
 
+Option: ``fiber_slice_default``
+
 The max fiber slice specifies the max fiber execution time without yield before a warning is logged or an error is raised.
 It is set with the :ref:`fiber.set_max_slice() <fiber-set_max_slice>` function.
 The new ``compat`` option – ``fiber_slice_default`` – controls the default value of the max fiber slice.

--- a/doc/reference/reference_lua/compat/json_escape_forward_slash.rst
+++ b/doc/reference/reference_lua/compat/json_escape_forward_slash.rst
@@ -3,6 +3,8 @@
 JSON encode escape forward slash
 ================================
 
+Option: ``json_escape_forward_slash``
+
 For some reason, in the upstream ``lua_cjson``, the '/' sign is escaped.
 But according to the ``rfc4627`` standard, it is unnecessary and questionably compatible with other implementations.
 

--- a/doc/reference/reference_lua/compat/sql_seq_scan_default.rst
+++ b/doc/reference/reference_lua/compat/sql_seq_scan_default.rst
@@ -3,6 +3,8 @@
 Default value for sql_seq_scan session setting
 ==============================================
 
+Option: ``sql_seq_scan_default``
+
 The default value for the ``sql_seq_scan`` session setting will be set to false starting with Tarantool 3.0.
 To be able to return the behavior to the old default, a new ``compat`` option is introduced.
 

--- a/doc/reference/reference_lua/compat/yaml_pretty_multiline.rst
+++ b/doc/reference/reference_lua/compat/yaml_pretty_multiline.rst
@@ -3,6 +3,8 @@
 Lua-YAML prettier multiline output
 ==================================
 
+Option: ``yaml_pretty_multiline``
+
 The ``lua-yaml`` encoder selects the string style automatically, but in Tarantool context, it can be beneficial to enforce them, for example, for better readability.
 The ``yaml_pretty_multiline`` compat option allows to encode multiline strings in a block style.
 


### PR DESCRIPTION
Resolves #3937 

Add documentation on the `compat` part of the configuration scheme:

- Add the new [compat](https://docs.d.tarantool.io/en/doc/gh-3937-config-compat/reference/configuration/configuration_reference/#compat) section to the config reference
- Add info about `compat` configuration options to the [compat module reference](https://docs.d.tarantool.io/en/doc/gh-3937-config-compat/reference/reference_lua/compat/)

Deployment: https://docs.d.tarantool.io/en/doc/gh-3937-config-compat/reference/configuration/configuration_reference/#compat

> [!NOTE]  
> Some compat options available in the config are not documented yet in the `compat` module reference. Need to cross-link their doc pages (when ready) with descriptions in the config reference.