### PR TITLE
Add config labels documentation

### DIFF
--- a/doc/code_snippets/snippets/config/instances.enabled/labels/config.yaml
+++ b/doc/code_snippets/snippets/config/instances.enabled/labels/config.yaml
@@ -1,0 +1,12 @@
+groups:
+  group001:
+    replicasets:
+      replicaset001:
+        labels:
+          dc: 'east'
+          production: 'false'
+        instances:
+          instance001:
+            labels:
+              rack: '10'
+              production: 'true'

--- a/doc/code_snippets/snippets/config/instances.enabled/labels/instances.yml
+++ b/doc/code_snippets/snippets/config/instances.enabled/labels/instances.yml
@@ -1,0 +1,1 @@
+instance001:

--- a/doc/concepts/configuration.rst
+++ b/doc/concepts/configuration.rst
@@ -301,8 +301,8 @@ Given that the ``roles`` option has the ``array`` type and ``roles_cfg`` has the
 Adding custom labels
 ~~~~~~~~~~~~~~~~~~~~
 
-Labels allow adding custom attributes to your cluster configuration. A label is
-a ``key: value`` pair with a string key and value.
+*Labels* allow adding custom attributes to your cluster configuration. A label is
+an arbitrary ``key: value`` pair with a string key and value.
 
 ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/labels/config.yaml
     :language: yaml
@@ -313,7 +313,7 @@ a ``key: value`` pair with a string key and value.
 Labels can be defined in any configuration scope. An instance receives labels from
 all scopes in belongs to. A ``labels`` section in a group or a replica set scope
 applies to all instances of the group or a replica set. To override these labels on
-the instance level or add instance-specific labels define another ``labels`` section in the instance scope.
+the instance level or add instance-specific labels, define another ``labels`` section in the instance scope.
 
 ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/labels/config.yaml
     :language: yaml
@@ -321,15 +321,29 @@ the instance level or add instance-specific labels define another ``labels`` sec
 
 Example on GitHub: `labels <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/config/instances.enabled/labels>`_
 
-To access the labels from the application code, call the :ref:`config:get() <config_api_reference_get>` function:
+To access instance labels from the application code, call the :ref:`config:get() <config_api_reference_get>` function:
 
-.. code-block:: lua
+.. code-block:: tarantoolsession
 
-    require('config'):get('labels')
+    myapp:instance001> require('config'):get('labels')
+    ---
+    - production: 'true'
+      rack: '10'
+      dc: east
+    ...
 
-// how to use in connpool
+Labels can be used to direct function calls to instances that match certain criteria
+using the :ref:`connpool module <3-1-experimental_connpool>`. For example, call a
+function on any instance that has the ``dc`` label with the ``west`` value.
 
-ref:`connpool module <3-1-experimental_connpool>`
+.. code-block:: tarantoolsession
+
+    myapp:instance001> connpool = require('experimental.connpool')
+    ---
+    ...
+
+    myapp:instance001> connpool.call('box.stat', nil, { labels = { dc = 'east' })
+    ---
 
 .. _configuration_predefined_variables:
 

--- a/doc/concepts/configuration.rst
+++ b/doc/concepts/configuration.rst
@@ -296,8 +296,40 @@ Given that the ``roles`` option has the ``array`` type and ``roles_cfg`` has the
                       farewell: 'Bye'
 
 
+.. _configuration_labels:
 
+Adding custom labels
+~~~~~~~~~~~~~~~~~~~~
 
+Labels allow adding custom attributes to your cluster configuration. A label is
+a ``key: value`` pair with a string key and value.
+
+..  literalinclude:: /code_snippets/snippets/config/instances.enabled/labels/config.yaml
+    :language: yaml
+    :start-at: labels:
+    :end-at: 'false'
+    :dedent:
+
+Labels can be defined in any configuration scope. An instance receives labels from
+all scopes in belongs to. A ``labels`` section in a group or a replica set scope
+applies to all instances of the group or a replica set. To override these labels on
+the instance level or add instance-specific labels define another ``labels`` section in the instance scope.
+
+..  literalinclude:: /code_snippets/snippets/config/instances.enabled/labels/config.yaml
+    :language: yaml
+    :dedent:
+
+Example on GitHub: `labels <https://github.com/tarantool/doc/tree/latest/doc/code_snippets/snippets/config/instances.enabled/labels>`_
+
+To access the labels from the application code, call the :ref:`config:get() <config_api_reference_get>` function:
+
+.. code-block:: lua
+
+    require('config'):get('labels')
+
+// how to use in connpool
+
+ref:`connpool module <3-1-experimental_connpool>`
 
 .. _configuration_predefined_variables:
 

--- a/doc/concepts/configuration.rst
+++ b/doc/concepts/configuration.rst
@@ -298,8 +298,8 @@ Given that the ``roles`` option has the ``array`` type and ``roles_cfg`` has the
 
 .. _configuration_labels:
 
-Adding custom labels
-~~~~~~~~~~~~~~~~~~~~
+Adding labels
+~~~~~~~~~~~~~
 
 *Labels* allow adding custom attributes to your cluster configuration. A label is
 an arbitrary ``key: value`` pair with a string key and value.
@@ -311,7 +311,7 @@ an arbitrary ``key: value`` pair with a string key and value.
     :dedent:
 
 Labels can be defined in any configuration scope. An instance receives labels from
-all scopes in belongs to. The ``labels`` section in a group or a replica set scope
+all scopes it belongs to. The ``labels`` section in a group or a replica set scope
 applies to all instances of the group or a replica set. To override these labels on
 the instance level or add instance-specific labels, define another ``labels`` section in the instance scope.
 
@@ -333,17 +333,7 @@ To access instance labels from the application code, call the :ref:`config:get()
     ...
 
 Labels can be used to direct function calls to instances that match certain criteria
-using the :ref:`connpool module <connpool_module>`. For example, call a
-function on any instance that has the ``dc`` label with the ``east`` value.
-
-.. code-block:: tarantoolsession
-
-    myapp:instance001> connpool = require('experimental.connpool')
-    ---
-    ...
-
-    myapp:instance001> connpool.call('box.stat', nil, { labels = { dc = 'east' })
-    ---
+using the :ref:`connpool module <connpool_module>`.
 
 .. _configuration_predefined_variables:
 

--- a/doc/concepts/configuration.rst
+++ b/doc/concepts/configuration.rst
@@ -311,7 +311,7 @@ an arbitrary ``key: value`` pair with a string key and value.
     :dedent:
 
 Labels can be defined in any configuration scope. An instance receives labels from
-all scopes in belongs to. A ``labels`` section in a group or a replica set scope
+all scopes in belongs to. The ``labels`` section in a group or a replica set scope
 applies to all instances of the group or a replica set. To override these labels on
 the instance level or add instance-specific labels, define another ``labels`` section in the instance scope.
 
@@ -333,8 +333,8 @@ To access instance labels from the application code, call the :ref:`config:get()
     ...
 
 Labels can be used to direct function calls to instances that match certain criteria
-using the :ref:`connpool module <3-1-experimental_connpool>`. For example, call a
-function on any instance that has the ``dc`` label with the ``west`` value.
+using the :ref:`connpool module <connpool_module>`. For example, call a
+function on any instance that has the ``dc`` label with the ``east`` value.
 
 .. code-block:: tarantoolsession
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -2166,6 +2166,35 @@ instances
     Any configuration parameter that can be defined in the instance :ref:`scope <configuration_scopes>`.
     For example, :ref:`iproto <configuration_reference_iproto>` and :ref:`database <configuration_reference_database>` configuration parameters defined at the instance level are applied to this instance only.
 
+..  _configuration_reference_labels:
+
+labels
+------
+
+The ``labels`` section allows adding custom attributes to the configuration.
+Attributes must be ``key: value`` pairs with string keys and values.
+
+
+..  NOTE::
+
+    ``labels`` can be defined in any :ref:`scope <configuration_scopes>`.
+
+-   :ref:`labels.\<label_name\> <configuration_reference_labels_name>`
+
+..  _configuration_reference_labels_name:
+
+.. confval:: labels.<label_name>
+
+    A value of the label with the specified name.
+
+    **Example**
+
+    The example below shows how to define labels on the replica set and instance levels:
+
+    ..  literalinclude:: /code_snippets/snippets/config/instances.enabled/labels/config.yaml
+        :language: yaml
+        :dedent:
+
 ..  _configuration_reference_log:
 
 log

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -2195,6 +2195,8 @@ Attributes must be ``key: value`` pairs with string keys and values.
         :language: yaml
         :dedent:
 
+    See also: :ref:`configuration_labels`
+
 ..  _configuration_reference_log:
 
 log

--- a/doc/release/3.1.0.rst
+++ b/doc/release/3.1.0.rst
@@ -218,6 +218,7 @@ In the 3.1 version, this module provides the following API:
     .. code-block:: tarantoolsession
 
         sharded_cluster:router-a-001> connpool.call('vshard.storage.buckets_count', nil, { roles = { 'storage' }, labels = { dc = 'west' }, mode = 'rw' })
+        sharded_cluster:router-a-001> connpool.call('vshard.storage.buckets_count', nil, { roles = { 'storage' }, labels = { dc = 'west' }, mode = 'rw' })
         ---
         - 500
         ...

--- a/doc/release/3.1.0.rst
+++ b/doc/release/3.1.0.rst
@@ -223,6 +223,7 @@ In the 3.1 version, this module provides the following API:
         - 500
         ...
 
+Learn more in the ``experimental.connpool`` :ref:`module reference <connpool_module>`.
 
 
 .. _3-1-accessing_configuration:

--- a/doc/release/3.1.0.rst
+++ b/doc/release/3.1.0.rst
@@ -197,7 +197,8 @@ In the 3.1 version, this module provides the following API:
 
 
 *   The ``filter()`` function returns the names of instances that match the specified conditions.
-    In the example below, this function returns a list of instances with the ``storage`` role and specified label value:
+    In the example below, this function returns a list of instances with the ``storage`` role and specified
+    :ref:`label <configuration_labels>` value:
 
     .. code-block:: tarantoolsession
 


### PR DESCRIPTION
Resolves #4096

Add configuration labels documentation:
- Configuration reference: new [labels](https://docs.d.tarantool.io/en/doc/gh-4096-config-labels/reference/configuration/configuration_reference/#labels) subsection
- general Configuration page: new [Adding custom labels](https://docs.d.tarantool.io/en/doc/gh-4096-config-labels/concepts/configuration/#adding-custom-labels) subsection
- What's new in 3.1: link from [connpool module description](https://docs.d.tarantool.io/en/doc/gh-4096-config-labels/release/3.1.0/#experimental-connpool-module) to the labels feature docs
- new app sample `labels`

Deployment: https://docs.d.tarantool.io/en/doc/gh-4096-config-labels/concepts/configuration/#adding-custom-labels