### PR TITLE
Add default values docs

### DIFF
--- a/doc/code_snippets/test/default_values/default_functions_test.lua
+++ b/doc/code_snippets/test/default_values/default_functions_test.lua
@@ -1,0 +1,66 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:drop()
+    fio.rmtree(cg.server.workdir)
+end)
+
+g.test_constraints = function(cg)
+    cg.server:exec(function()
+
+        -- Define a tuple constraint function --
+        box.schema.func.create('check_person', {
+            language = 'LUA',
+            is_deterministic = true,
+            body = 'function(t, c) return (t.age >= 0 and #(t.name) > 3) end'
+        })
+
+        -- Create a space with a tuple constraint --
+        customers = box.schema.space.create('customers', {constraint = 'check_person'})
+
+        -- Define a field constraint function --
+        box.schema.func.create('check_age', {
+            language = 'LUA',
+            is_deterministic = true,
+            body = 'function(f, c) return (f >= 0 and f < 150) end'
+        })
+
+        -- Specify format with a field constraint --
+        box.space.customers:format({
+            {name = 'id', type = 'number'},
+            {name = 'name', type = 'string'},
+            {name = 'age',  type = 'number', constraint = 'check_age'},
+        })
+
+        box.space.customers:create_index('primary', { parts = { 1 } })
+
+        box.space.customers:insert{1, "Alice", 30}
+
+        -- Tests --
+        t.assert_equals(customers:count(), 1)
+        t.assert_equals(customers:get(1), {1, "Alice", 30})
+
+        -- Failed contstraint --
+        t.assert_error_msg_contains("Check constraint 'check_person' failed for a tuple",
+                function() customers:insert{2, "Bob", 230} end)
+
+        -- Create one more tuple constraint --
+        box.schema.func.create('another_constraint',
+            {language = 'LUA', is_deterministic = true, body = 'function(t, c) return true end'})
+
+        -- Set two constraints with optional names --
+        box.space.customers:alter{
+            constraint = { check1 = 'check_person', check2 = 'another_constraint'}
+        }
+    end)
+end

--- a/doc/code_snippets/test/default_values/default_functions_test.lua
+++ b/doc/code_snippets/test/default_values/default_functions_test.lua
@@ -15,52 +15,51 @@ g.after_each(function(cg)
     fio.rmtree(cg.server.workdir)
 end)
 
-g.test_constraints = function(cg)
+g.test_default_func = function(cg)
     cg.server:exec(function()
 
-        -- Define a tuple constraint function --
-        box.schema.func.create('check_person', {
-            language = 'LUA',
-            is_deterministic = true,
-            body = 'function(t, c) return (t.age >= 0 and #(t.name) > 3) end'
+        -- create_no_arg_function_start
+        box.schema.func.create('current_year', {
+            language = 'Lua',
+            body = "function() return require('datetime').now().year end"
         })
+        -- create_no_arg_function_end
 
-        -- Create a space with a tuple constraint --
-        customers = box.schema.space.create('customers', {constraint = 'check_person'})
-
-        -- Define a field constraint function --
-        box.schema.func.create('check_age', {
-            language = 'LUA',
-            is_deterministic = true,
-            body = 'function(f, c) return (f >= 0 and f < 150) end'
+        -- format_space_default_func_start
+        local books = box.schema.space.create('books')
+        books:format({
+            { name = 'id', type = 'unsigned' },
+            { name = 'isbn', type = 'string' },
+            { name = 'title', type = 'string', default = 'No title specified' },
+            { name = 'year', type = 'unsigned', default_func = 'current_year' }
         })
+        books:create_index('primary', { parts = { 1 } })
+        -- format_space_default_func_end
 
-        -- Specify format with a field constraint --
-        box.space.customers:format({
-            {name = 'id', type = 'number'},
-            {name = 'name', type = 'string'},
-            {name = 'age',  type = 'number', constraint = 'check_age'},
+        -- insert_ok_start
+        books:insert { 1, '978000', 'Thinking in Java' }
+        -- insert_ok_end
+
+        -- create_arg_function_start
+        box.schema.func.create('randomize', {
+            language = 'Lua',
+            body = "function(limit) return math.random(limit.min, limit.max) end"
         })
+        -- create_arg_function_end
 
-        box.space.customers:create_index('primary', { parts = { 1 } })
+        -- reformat_space_start
+        books:format({
+            { name = 'id', type = 'unsigned', default_func= 'randomize', default = {min = 0, max = 1000} },
+            { name = 'isbn', type = 'string' },
+            { name = 'title', type = 'string', default = 'No title specified' },
+            { name = 'year', type = 'unsigned', default_func = 'current_year' }
+        })
+        -- reformat_space_end
 
-        box.space.customers:insert{1, "Alice", 30}
+        books:insert { nil, '978001', 'How to code in Go' }
 
         -- Tests --
-        t.assert_equals(customers:count(), 1)
-        t.assert_equals(customers:get(1), {1, "Alice", 30})
-
-        -- Failed contstraint --
-        t.assert_error_msg_contains("Check constraint 'check_person' failed for a tuple",
-                function() customers:insert{2, "Bob", 230} end)
-
-        -- Create one more tuple constraint --
-        box.schema.func.create('another_constraint',
-            {language = 'LUA', is_deterministic = true, body = 'function(t, c) return true end'})
-
-        -- Set two constraints with optional names --
-        box.space.customers:alter{
-            constraint = { check1 = 'check_person', check2 = 'another_constraint'}
-        }
+        t.assert_equals(books:count(), 2)
+        t.assert_equals(books:get(1), { 1, '978000','Thinking in Java', 2024 })
     end)
 end

--- a/doc/code_snippets/test/default_values/default_functions_test.lua
+++ b/doc/code_snippets/test/default_values/default_functions_test.lua
@@ -30,7 +30,7 @@ g.test_default_func = function(cg)
         books:format({
             { name = 'id', type = 'unsigned' },
             { name = 'isbn', type = 'string' },
-            { name = 'title', type = 'string', default = 'No title specified' },
+            { name = 'title', type = 'string' },
             { name = 'year', type = 'unsigned', default_func = 'current_year' }
         })
         books:create_index('primary', { parts = { 1 } })
@@ -51,7 +51,7 @@ g.test_default_func = function(cg)
         books:format({
             { name = 'id', type = 'unsigned', default_func= 'randomize', default = {min = 0, max = 1000} },
             { name = 'isbn', type = 'string' },
-            { name = 'title', type = 'string', default = 'No title specified' },
+            { name = 'title', type = 'string' },
             { name = 'year', type = 'unsigned', default_func = 'current_year' }
         })
         -- reformat_space_end

--- a/doc/code_snippets/test/default_values/explicit_default_test.lua
+++ b/doc/code_snippets/test/default_values/explicit_default_test.lua
@@ -1,0 +1,38 @@
+local fio = require('fio')
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+g.before_each(function(cg)
+    cg.server = server:new {
+        box_cfg = {},
+        workdir = fio.cwd() .. '/tmp'
+    }
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:drop()
+    fio.rmtree(cg.server.workdir)
+end)
+
+g.test_default_values = function(cg)
+    cg.server:exec(function()
+        -- configure_space_start
+        local books = box.schema.space.create('books')
+        books:format({
+            { name = 'id', type = 'number' },
+            { name = 'name', type = 'string' },
+            { name = 'year', type = 'number', default = 2024 },
+        })
+        books:create_index('primary', { parts = { 1 } })
+        -- configure_space_end
+
+        -- insert_ok_start
+        books:insert { 1, "Thinking in Java" }
+        -- insert_ok_end
+
+        -- Tests --
+        t.assert_equals(books:count(), 1)
+        t.assert_equals(books:get(1), { 1, "Thinking in Java", 2024 })
+    end)
+end

--- a/doc/code_snippets/test/default_values/explicit_default_test.lua
+++ b/doc/code_snippets/test/default_values/explicit_default_test.lua
@@ -28,11 +28,12 @@ g.test_default_values = function(cg)
         -- configure_space_end
 
         -- insert_ok_start
-        books:insert { 1, "Thinking in Java" }
+        books:insert { 1, 'Thinking in Java' }
+        books:insert { 2, 'How to code in Go', nil }
         -- insert_ok_end
 
         -- Tests --
-        t.assert_equals(books:count(), 1)
-        t.assert_equals(books:get(1), { 1, "Thinking in Java", 2024 })
+        t.assert_equals(books:count(), 2)
+        t.assert_equals(books:get(1), { 1, 'Thinking in Java', 2024 })
     end)
 end

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -571,9 +571,9 @@ Default values
 *Default values* are assigned to tuple fields automatically if these fields are
 skipped during the tuple insert or update.
 
-You can specify a default value for a field in the :ref:`space_object.format () <box_space-format>`
+You can specify a default value for a field in the :ref:`space_object:format() <box_space-format>`
 call that defines the space format. Default values apply regardless of the field nullability:
-any tuple in which the field is skipped or set to `nil` receives the
+any tuple in which the field is skipped or set to `nil` receives
 the default value.
 
 Default values can be set in two ways: explicitly or using a function.
@@ -584,7 +584,7 @@ Explicit default values
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Explicit default values are defined in the ``default`` parameter of the field declaration
-in a :ref:`space_object.format () <box_space-format>` call.
+in a :ref:`space_object:format() <box_space-format>` call.
 
 ..  literalinclude:: /code_snippets/test/default_values/explicit_default_test.lua
     :language: lua
@@ -605,7 +605,7 @@ may be used as a default value, for example:
     Explicit default values are evaluated **only** when setting the space format.
     If you use a variable as a default value, its further assignments do not affect the default value.
 
-    To change the default values, call ``space_object.format()`` again.
+    To change the default values, call ``space_object:format()`` again.
 
 To use a default value for a field, skip it or assign `nil`:
 
@@ -615,7 +615,7 @@ To use a default value for a field, skip it or assign `nil`:
     :end-before: insert_ok_end
     :dedent:
 
-See also the :ref:`space_object.format() <box_space-format>` reference.
+See also the :ref:`space_object:format() <box_space-format>` reference.
 
 ..  _index-defaults-functions:
 
@@ -624,7 +624,7 @@ Default functions
 
 A default value can be defined as a return value of a stored Lua function. To be
 the default, a function must be created with :ref:`box.schema.func.create() <box_schema-func_create>`
-with function body and return one value of the field's type. It also must not yield.
+with the function body and return one value of the field's type. It also must not yield.
 
 ..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
     :language: lua
@@ -633,7 +633,7 @@ with function body and return one value of the field's type. It also must not yi
     :dedent:
 
 Default functions are set in the ``default_func`` parameter of the field declaration
-in a ``space_object.format()`` call. To make a function with no arguments the default
+in a ``space_object:format()`` call. To make a function with no arguments the default
 for a field, specify its name:
 
 ..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
@@ -651,7 +651,7 @@ A default function can also have one argument.
     :dedent:
 
 To pass the function argument when setting the default, specify it in the ``default`` parameter
-of the ``space_object.format()`` call:
+of the ``space_object:format()`` call:
 
 ..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
     :language: lua

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -569,11 +569,11 @@ Default values
 --------------
 
 *Default values* are assigned to tuple fields automatically if these fields are
-skipped during the tuple creation.
+skipped during the tuple insert or update.
 
-You can specify a default value for a field in the space_object.format call that
-defines the space format. Default values apply regardless of the field nullability:
-even if the value can be `nil`, any tuple in which the field is skipped receives the
+You can specify a default value for a field in the :ref:`space_object.format () <box_space-format>`
+call that defines the space format. Default values apply regardless of the field nullability:
+any tuple in which the field is skipped or set to `nil` receives the
 the default value.
 
 Default values can be set in two ways: explicitly or using a function.
@@ -592,23 +592,22 @@ in a :ref:`space_object.format () <box_space-format>` call.
     :end-before: configure_space_end
     :dedent:
 
-An explicit default value can be any Lua object that can be evaluated during the
-``space_object.format()`` call, for example:
+Any Lua object that can be evaluated during the ``space_object.format()`` call
+may be used as a default value, for example:
 
 -   a constant: ``default = 100``
 -   an initialized variable: ``default = default_size``
 -   an expression: ``default = 10 + default_size``
--   a function call: ``default = count_default()``
+-   a function return value: ``default = count_default()``
 
 .. important::
 
     Explicit default values are evaluated **only** when setting the space format.
-    If you use a variable as a default value when setting the space format,
-    its further assignments do not affect the default value.
+    If you use a variable as a default value, its further assignments do not affect the default value.
 
     To change the default values, call ``space_object.format()`` again.
 
-To use a default value for a field, skip or assign `nil`:
+To use a default value for a field, skip it or assign `nil`:
 
 ..  literalinclude:: /code_snippets/test/default_values/explicit_default_test.lua
     :language: lua
@@ -630,11 +629,11 @@ with function body and return one value of the field's type. It also must not yi
 ..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
     :language: lua
     :start-after: create_no_arg_function_start
-    :end-before: crate_no_arg_function_end
+    :end-before: create_no_arg_function_end
     :dedent:
 
 Default functions are set in the ``default_func`` parameter of the field declaration
-in a space_object.format call. To make a function with no arguments the default
+in a ``space_object.format()`` call. To make a function with no arguments the default
 for a field, specify its name:
 
 ..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
@@ -657,7 +656,7 @@ of the ``space_object.format()`` call:
 ..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
     :language: lua
     :start-after: reformat_space_start
-    :end-before: reformat_space_start
+    :end-before: reformat_space_end
     :dedent:
 
 See also the :ref:`space_object.format() <box_space-format>` reference.

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -569,7 +569,7 @@ Default values
 --------------
 
 *Default values* are assigned to tuple fields automatically if these fields are
-skipped during the tuple insert or update.
+skipped during the tuple :ref:`insert or update <index-box_data-operations>`.
 
 You can specify a default value for a field in the :ref:`space_object:format() <box_space-format>`
 call that defines the space format. Default values apply regardless of the field nullability:
@@ -592,6 +592,14 @@ in a :ref:`space_object:format() <box_space-format>` call.
     :end-before: configure_space_end
     :dedent:
 
+To use a default value for a field, skip it or assign `nil`:
+
+..  literalinclude:: /code_snippets/test/default_values/explicit_default_test.lua
+    :language: lua
+    :start-after: insert_ok_start
+    :end-before: insert_ok_end
+    :dedent:
+
 Any Lua object that can be evaluated during the ``space_object.format()`` call
 may be used as a default value, for example:
 
@@ -607,13 +615,6 @@ may be used as a default value, for example:
 
     To change the default values, call ``space_object:format()`` again.
 
-To use a default value for a field, skip it or assign `nil`:
-
-..  literalinclude:: /code_snippets/test/default_values/explicit_default_test.lua
-    :language: lua
-    :start-after: insert_ok_start
-    :end-before: insert_ok_end
-    :dedent:
 
 See also the :ref:`space_object:format() <box_space-format>` reference.
 
@@ -624,7 +625,7 @@ Default functions
 
 A default value can be defined as a return value of a stored Lua function. To be
 the default, a function must be created with :ref:`box.schema.func.create() <box_schema-func_create>`
-with the function body and return one value of the field's type. It also must not yield.
+with the function body and return one value of the field's type. It also must not :ref:`yield <app-yields>`.
 
 ..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
     :language: lua

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -659,6 +659,19 @@ of the ``space_object.format()`` call:
     :end-before: reformat_space_end
     :dedent:
 
+
+.. note::
+
+    A key difference between a default function (``default_func = 'count_default'``)
+    and a function return value used as a field default value (``default = count_default()``)
+    is the following:
+
+    -   A *default function* is called **every time a default value must be produced**,
+        that is, a tuple is inserted or updated without specifying the field.
+    -   A return value used a field *default value*: the function is called **once**
+        when setting the space format. Then, all tuples receive the result of
+        this exact call if the field is not specified.
+
 See also the :ref:`space_object.format() <box_space-format>` reference.
 
 

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -586,10 +586,10 @@ Explicit default values
 Explicit default values are defined in the ``default`` parameter of the field declaration
 in a :ref:`space_object.format () <box_space-format>` call.
 
-..  literalinclude:: /code_snippets/test/default_values/explicit_defaultlua
+..  literalinclude:: /code_snippets/test/default_values/explicit_default_test.lua
     :language: lua
     :start-after: configure_space_start
-    :end-before: configure_space_start
+    :end-before: configure_space_end
     :dedent:
 
 An explicit default value can be any Lua object that can be evaluated during the
@@ -602,13 +602,21 @@ An explicit default value can be any Lua object that can be evaluated during the
 
 .. important::
 
-    Explicit default values are evaluated once when setting the space format.
-    Further changes, such as assignments of variables used in default values,
-    do not affect the values. To change the default values, call ``space_object.format()``
-    again.
+    Explicit default values are evaluated **only** when setting the space format.
+    If you use a variable as a default value when setting the space format,
+    its further assignments do not affect the default value.
 
+    To change the default values, call ``space_object.format()`` again.
 
-Learn more in :ref:`space_object.format() <box_space-format>` reference.
+To use a default value for a field, skip or assign `nil`:
+
+..  literalinclude:: /code_snippets/test/default_values/explicit_default_test.lua
+    :language: lua
+    :start-after: insert_ok_start
+    :end-before: insert_ok_end
+    :dedent:
+
+See also the :ref:`space_object.format() <box_space-format>` reference.
 
 ..  _index-defaults-functions:
 
@@ -619,25 +627,40 @@ A default value can be defined as a return value of a stored Lua function. To be
 the default, a function must be created with :ref:`box.schema.func.create() <box_schema-func_create>`
 with function body and return one value of the field's type. It also must not yield.
 
+..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
+    :language: lua
+    :start-after: create_no_arg_function_start
+    :end-before: crate_no_arg_function_end
+    :dedent:
+
 Default functions are set in the ``default_func`` parameter of the field declaration
 in a space_object.format call. To make a function with no arguments the default
 for a field, specify its name:
 
-..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
+..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
     :language: lua
-    :lines: 21-26
+    :start-after: format_space_default_func_start
+    :end-before: format_space_default_func_end
     :dedent:
 
 A default function can also have one argument.
 
-// example
+..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
+    :language: lua
+    :start-after: create_arg_function_start
+    :end-before: create_arg_function_end
+    :dedent:
 
 To pass the function argument when setting the default, specify it in the ``default`` parameter
-of the space_object.format() call:
+of the ``space_object.format()`` call:
 
-// example
+..  literalinclude:: /code_snippets/test/default_values/default_functions_test.lua
+    :language: lua
+    :start-after: reformat_space_start
+    :end-before: reformat_space_start
+    :dedent:
 
-Learn more in :ref:`space_object.format() <box_space-format>` reference.
+See also the :ref:`space_object.format() <box_space-format>` reference.
 
 
 ..  _index-constraints:

--- a/doc/concepts/data_model/value_store.rst
+++ b/doc/concepts/data_model/value_store.rst
@@ -562,6 +562,84 @@ Charts explaining the precise differences from DUCET order are
 in the
 `Common Language Data Repository <https://unicode.org/cldr/charts/30/collation>`_.
 
+
+..  _index-defaults:
+
+Default values
+--------------
+
+*Default values* are assigned to tuple fields automatically if these fields are
+skipped during the tuple creation.
+
+You can specify a default value for a field in the space_object.format call that
+defines the space format. Default values apply regardless of the field nullability:
+even if the value can be `nil`, any tuple in which the field is skipped receives the
+the default value.
+
+Default values can be set in two ways: explicitly or using a function.
+
+..  _index-defaults-explicit:
+
+Explicit default values
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Explicit default values are defined in the ``default`` parameter of the field declaration
+in a :ref:`space_object.format () <box_space-format>` call.
+
+..  literalinclude:: /code_snippets/test/default_values/explicit_defaultlua
+    :language: lua
+    :start-after: configure_space_start
+    :end-before: configure_space_start
+    :dedent:
+
+An explicit default value can be any Lua object that can be evaluated during the
+``space_object.format()`` call, for example:
+
+-   a constant: ``default = 100``
+-   an initialized variable: ``default = default_size``
+-   an expression: ``default = 10 + default_size``
+-   a function call: ``default = count_default()``
+
+.. important::
+
+    Explicit default values are evaluated once when setting the space format.
+    Further changes, such as assignments of variables used in default values,
+    do not affect the values. To change the default values, call ``space_object.format()``
+    again.
+
+
+Learn more in :ref:`space_object.format() <box_space-format>` reference.
+
+..  _index-defaults-functions:
+
+Default functions
+~~~~~~~~~~~~~~~~~
+
+A default value can be defined as a return value of a stored Lua function. To be
+the default, a function must be created with :ref:`box.schema.func.create() <box_schema-func_create>`
+with function body and return one value of the field's type. It also must not yield.
+
+Default functions are set in the ``default_func`` parameter of the field declaration
+in a space_object.format call. To make a function with no arguments the default
+for a field, specify its name:
+
+..  literalinclude:: /code_snippets/test/constraints/constraint_test.lua
+    :language: lua
+    :lines: 21-26
+    :dedent:
+
+A default function can also have one argument.
+
+// example
+
+To pass the function argument when setting the default, specify it in the ``default`` parameter
+of the space_object.format() call:
+
+// example
+
+Learn more in :ref:`space_object.format() <box_space-format>` reference.
+
+
 ..  _index-constraints:
 
 Constraints

--- a/doc/enterprise/read_views.rst
+++ b/doc/enterprise/read_views.rst
@@ -21,10 +21,6 @@ Tarantool duplicates only blocks modified after a read view is created.
     Tarantool Enterprise Edition supports read views starting from v2.11.0 and enables the ability
     to work with them using both :ref:`Lua <read_views_lua_api>` and :ref:`C API <read_views_c_api>`.
 
-
-
-
-
 .. _read_views_limitations:
 
 Limitations
@@ -34,8 +30,7 @@ Read views have the following limitations:
 
 - Only the :ref:`memtx <engines-memtx>` engine is supported.
 - Only TREE and HASH :ref:`indexes <index-types>` are supported.
-- Pagination is not supported (the :ref:`after <box_index-select>` option).
-
+- Pagination (the :ref:`after <box_index-select>` option) is supported only for TREE indexes.
 
 
 .. _working_with_read_views:
@@ -72,8 +67,6 @@ After creating a read view, you can see the information about it by calling
     ...
 
 To list all the created read views, call the :ref:`box.read_view.list() <reference_lua-box_read_view_list>` function.
-
-
 
 .. _querying_data:
 
@@ -112,6 +105,7 @@ Similarly, you can retrieve data by the specific index.
     ...
 
 
+ADD example with fech_pos and after
 
 .. _closing_read_view:
 
@@ -133,7 +127,6 @@ Otherwise, a read view is closed implicitly when the read view object is collect
 After the read view is closed,
 its :ref:`status <read_view_object-status>` is set to ``closed``.
 On an attempt to use it, an error is raised.
-
 
 .. _read_views_example:
 
@@ -202,7 +195,7 @@ as described in :ref:`Using data operations <box_space-operations-detailed-examp
         ...
 
 
-
+??? ADD example with fetch_pos and after
 ..  toctree::
     :maxdepth: 2
     :hidden:

--- a/doc/reference/reference_lua/box_space/format.rst
+++ b/doc/reference/reference_lua/box_space/format.rst
@@ -47,6 +47,10 @@ space_object:format()
           See also: :ref:`key_part.collation <key_part_collation>`.
         * (Optional) The ``constraint`` table specifies the :ref:`constraints <index-constraints>` that the field value must satisfy.
         * (Optional) The ``foreign_key`` table specifies the :ref:`foreign keys <index-box_foreign_keys>` for the field.
+        * (Optional) The ``default`` value specifies the :ref:`explicit default value <index-defaults-explicit>` for the field
+          or the argument of the default function if ``default_func`` is specified.
+        * (Optional) The ``default_func`` string value specifies the name of the field's :ref:`default function <index-defaults-functions>`.
+          To pass the default function's argument, add the ``default`` parameter.
 
         It is not legal for tuples to contain values that have the wrong type.
         The example below will cause an error:

--- a/doc/release/3.0.0.rst
+++ b/doc/release/3.0.0.rst
@@ -447,7 +447,8 @@ It's possible to revert to the old behavior by toggling the new ``binary_data_de
 Default field values
 ~~~~~~~~~~~~~~~~~~~~
 
-You can now assign the default values for specific fields when defining a :ref:`space format <box_space-format>`.
+You can now assign the :ref:`default values <index-defaults>` for specific fields
+when defining a :ref:`space format <box_space-format>`.
 In this example, the ``isbn`` and ``title`` fields have the specified default values:
 
 ..  code-block:: lua
@@ -490,7 +491,7 @@ Then, assign the function name to ``default_func`` when defining a space format:
         { name = 'year_of_publication', type = 'unsigned', default_func = 'current_year' }
     })
 
-
+Learn more in :ref:`index-defaults`.
 
 .. _3-0-triggers:
 


### PR DESCRIPTION
Resolves #3520 #3617

Add default values documentation:
- Data storage page: new section [Default values](https://docs.d.tarantool.io/en/doc/gh-3520-default-values-funcs/concepts/data_model/value_store/#default-values) about explicit default values and default function
- [space_object.format](https://docs.d.tarantool.io/en/doc/gh-3520-default-values-funcs/reference/reference_lua/box_space/format/#box-space-format) reference: new parameters `default` and `default_func`
- Link from [What's new in 3.0 section about default values](https://docs.d.tarantool.io/en/doc/gh-3520-default-values-funcs/release/3.0.0/#default-field-values) to new documentation
- New code sample `default_values`

Deployment: https://docs.d.tarantool.io/en/doc/gh-3520-default-values-funcs/concepts/data_model/value_store/#default-values