### PR TITLE
Add varbinary docs

### DIFF
--- a/doc/code_snippets/test/varbinary/varbinary_test.lua
+++ b/doc/code_snippets/test/varbinary/varbinary_test.lua
@@ -1,18 +1,24 @@
 local varbinary = require('varbinary')
 
+-- Create a varbinary object
 local bin = varbinary.new('data')
+
+-- Check whether a value is a varbinary object
 varbinary.is(bin) -- true
 varbinary.is(100) -- false
 varbinary.is('data') -- false
 
-print(bin == 'data') -- true
+-- Check varbinary objects equality
 print(bin == varbinary.new('data')) -- true
+print(bin == 'data') -- true
 print(bin == 'data1') -- false
 print(bin ~= 'data1') -- true
 
+-- Check varbinary objects length
 print(#bin) -- 4
 print(#varbinary.new('\xFF\xFE')) -- 2
 
+-- Print string representation
 print(tostring(bin)) -- data
 
 local bin2 = varbinary.new(ffi.cast('const char *', 'data'), 4)

--- a/doc/code_snippets/test/varbinary/varbinary_test.lua
+++ b/doc/code_snippets/test/varbinary/varbinary_test.lua
@@ -1,6 +1,6 @@
 local varbinary = require('varbinary')
 
-bin = varbinary.new('data')
+local bin = varbinary.new('data')
 varbinary.is(bin) -- true
 varbinary.is(100) -- false
 varbinary.is('data') -- false

--- a/doc/code_snippets/test/varbinary/varbinary_test.lua
+++ b/doc/code_snippets/test/varbinary/varbinary_test.lua
@@ -1,0 +1,25 @@
+local varbinary = require('varbinary')
+
+bin = varbinary.new('data')
+varbinary.is(bin) -- true
+varbinary.is(100) -- false
+varbinary.is('data') -- false
+
+
+print(bin == 'data') -- true
+print(bin == varbinary.new('data')) -- true
+print(bin == 'data1') -- false
+
+print(#bin) -- 4
+print(#varbinary.new('\xFF\xFE')) -- 2
+
+print(tostring(bin)) -- data
+
+local luatest = require('luatest')
+local test_group = luatest.group()
+test_group.test_varbinary = function()
+    luatest.assert_equals(varbinary.is(bin), true)
+    luatest.assert_equals(bin, 'data')
+    luatest.assert_equals(#bin, 4)
+    luatest.assert_equals(#varbinary.new('\xFF\xFE'), 2)
+end

--- a/doc/code_snippets/test/varbinary/varbinary_test.lua
+++ b/doc/code_snippets/test/varbinary/varbinary_test.lua
@@ -2,21 +2,23 @@ local varbinary = require('varbinary')
 
 -- Create a varbinary object
 local bin = varbinary.new('data')
+local bin_hex = varbinary.new('\xFF\xFE')
 
 -- Check whether a value is a varbinary object
 varbinary.is(bin) -- true
+varbinary.is(bin_hex) -- true
 varbinary.is(100) -- false
 varbinary.is('data') -- false
 
 -- Check varbinary objects equality
 print(bin == varbinary.new('data')) -- true
 print(bin == 'data') -- true
-print(bin == 'data1') -- false
 print(bin ~= 'data1') -- true
+print(bin_hex ~= '\xFF\xFE') -- false
 
 -- Check varbinary objects length
 print(#bin) -- 4
-print(#varbinary.new('\xFF\xFE')) -- 2
+print(#bin_hex) -- 2
 
 -- Print string representation
 print(tostring(bin)) -- data

--- a/doc/code_snippets/test/varbinary/varbinary_test.lua
+++ b/doc/code_snippets/test/varbinary/varbinary_test.lua
@@ -15,6 +15,10 @@ print(#varbinary.new('\xFF\xFE')) -- 2
 
 print(tostring(bin)) -- data
 
+local bin2 = varbinary.new(ffi.cast('const char *', 'data'), 4)
+varbinary.is(bin2) -- true
+print(bin2) -- data
+
 local luatest = require('luatest')
 local test_group = luatest.group()
 test_group.test_varbinary = function()

--- a/doc/code_snippets/test/varbinary/varbinary_test.lua
+++ b/doc/code_snippets/test/varbinary/varbinary_test.lua
@@ -9,6 +9,7 @@ varbinary.is('data') -- false
 print(bin == 'data') -- true
 print(bin == varbinary.new('data')) -- true
 print(bin == 'data1') -- false
+print(bin ~= 'data1') -- false
 
 print(#bin) -- 4
 print(#varbinary.new('\xFF\xFE')) -- 2

--- a/doc/code_snippets/test/varbinary/varbinary_test.lua
+++ b/doc/code_snippets/test/varbinary/varbinary_test.lua
@@ -5,11 +5,10 @@ varbinary.is(bin) -- true
 varbinary.is(100) -- false
 varbinary.is('data') -- false
 
-
 print(bin == 'data') -- true
 print(bin == varbinary.new('data')) -- true
 print(bin == 'data1') -- false
-print(bin ~= 'data1') -- false
+print(bin ~= 'data1') -- true
 
 print(#bin) -- 4
 print(#varbinary.new('\xFF\xFE')) -- 2

--- a/doc/platform/ddl_dml/value_store.rst
+++ b/doc/platform/ddl_dml/value_store.rst
@@ -345,9 +345,8 @@ bin
 ***
 
 A bin (binary) value is not directly supported by Lua but there is
-a Tarantool type ``varbinary`` which is encoded as MsgPack binary.
-For an (advanced) example showing how to insert varbinary into a database,
-see the Cookbook Recipe for :ref:`ffi_varbinary_insert <cookbook-ffi_varbinary_insert>`.
+a Tarantool type ``varbinary``. See the :ref:`varbinary module reference <varbinary-module>`
+for details.
 
 **Example:** ``"\65 \66 \67"``.
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -431,6 +431,8 @@ The ``compat`` section defines values of the :ref:`compat <compat-module>` modul
     -   ``new``: as varbinary objects
     -   ``old``: as plain strings
 
+    See also: :ref:`compat-option-binary-decoding`
+
     |
     | Type: string
     | Possible values: 'new', 'old'

--- a/doc/reference/reference_lua/compat.rst
+++ b/doc/reference/reference_lua/compat.rst
@@ -83,5 +83,5 @@ Below are the available ``compat`` options:
     compat/box_cfg_replication_sync_timeout
     compat/sql_seq_scan_default
     compat/fiber_slice_default
-    compat/binary_data_decoding>
+    compat/binary_data_decoding
     compat/compat_tutorial

--- a/doc/reference/reference_lua/compat.rst
+++ b/doc/reference/reference_lua/compat.rst
@@ -72,6 +72,7 @@ Below are the available ``compat`` options:
 * :doc:`box_cfg_replication_sync_timeout <./compat/box_cfg_replication_sync_timeout>`
 * :doc:`sql_seq_scan_default <./compat/sql_seq_scan_default>`
 * :doc:`fiber_slice_default <./compat/fiber_slice_default>`
+* :doc:`binary_data_decoding <./compat/binary_data_decoding>`
 
 ..  toctree::
     :hidden:
@@ -82,4 +83,5 @@ Below are the available ``compat`` options:
     compat/box_cfg_replication_sync_timeout
     compat/sql_seq_scan_default
     compat/fiber_slice_default
+    compat/binary_data_decoding>
     compat/compat_tutorial

--- a/doc/reference/reference_lua/compat/binary_data_decoding.rst
+++ b/doc/reference/reference_lua/compat/binary_data_decoding.rst
@@ -8,7 +8,8 @@ Option: ``binary_data_decoding``
 Starting from version 3.0, Tarantool has the :ref:`varbinary <varbinary_module>` module
 for handling binary objects of arbitrary lengths.
 The ``binary_data_decoding`` compat option allows to define the format in which
-varbinary field values are returned for handling in Lua.
+varbinary field values are returned for handling in Lua: plain strings or ``varbinary``
+objects.
 
 Old and new behavior
 --------------------
@@ -52,8 +53,4 @@ At this point, no incompatible modules are known.
 Detecting issues in your codebase
 ---------------------------------
 
-Both encoding styles are correct from the YAML standard standpoint, but if your module relies on encodings results bytewise, it may break with this change.
-Be cautious if you do the following:
-
-*   Compare results of YAML encoding as strings.
-*   Hash results of yaml encoding.
+TBD

--- a/doc/reference/reference_lua/compat/binary_data_decoding.rst
+++ b/doc/reference/reference_lua/compat/binary_data_decoding.rst
@@ -5,7 +5,7 @@ Decoding binary objects
 
 Option: ``binary_data_decoding``
 
-Starting from version 3.0, Tarantool has the :ref:`varbinary <varbinary_module>` module
+Starting from version 3.0, Tarantool has the :ref:`varbinary <varbinary-module>` module
 for handling binary objects of arbitrary lengths.
 The ``binary_data_decoding`` compat option allows to define the format in which
 varbinary field values are returned for handling in Lua: plain strings or ``varbinary``

--- a/doc/reference/reference_lua/compat/binary_data_decoding.rst
+++ b/doc/reference/reference_lua/compat/binary_data_decoding.rst
@@ -53,4 +53,7 @@ At this point, no incompatible modules are known.
 Detecting issues in your codebase
 ---------------------------------
 
-TBD
+String manipulation methods, such as ``string.sub()`` or ``string.match()`` are not
+defined for ``varbinary`` objects. Thus, if you use such methods on results of
+binary data decoding from MsgPack or YAML, convert them to strings
+explicitly using the ``tostring()`` method.

--- a/doc/reference/reference_lua/compat/binary_data_decoding.rst
+++ b/doc/reference/reference_lua/compat/binary_data_decoding.rst
@@ -1,0 +1,59 @@
+.. _compat-option-binary-decoding:
+
+Decoding binary objects
+=======================
+
+Option: ``binary_data_decoding``
+
+Starting from version 3.0, Tarantool has the :ref:`varbinary <varbinary_module>` module
+for handling binary objects of arbitrary lengths.
+The ``binary_data_decoding`` compat option allows to define the format in which
+varbinary field values are returned for handling in Lua.
+
+Old and new behavior
+--------------------
+
+New behavior: ``varbinary`` field values are returned as ``varbinary`` objects.
+
+..  code-block:: tarantoolsession
+
+    tarantool> compat.binary_data_decoding = 'new'
+    ---
+    ...
+
+    tarantool> varbinary.is(msgpack.decode('\xC4\x02\xFF\xFE'))
+    ---
+    - true
+    ...
+
+Old behavior: ``varbinary`` field values are returned as plain strings.
+
+..  code-block:: tarantoolsession
+
+    tarantool> compat.binary_data_decoding = 'old'
+    ---
+    ...
+
+    tarantool> varbinary.is(msgpack.decode('\xC4\x02\xFF\xFE'))
+    ---
+    - false
+    ...
+
+    tarantool> varbinary.is(yaml.decode('!!binary //4='))
+    ---
+    - false
+    ...
+
+Known compatibility issues
+--------------------------
+
+At this point, no incompatible modules are known.
+
+Detecting issues in your codebase
+---------------------------------
+
+Both encoding styles are correct from the YAML standard standpoint, but if your module relies on encodings results bytewise, it may break with this change.
+Be cautious if you do the following:
+
+*   Compare results of YAML encoding as strings.
+*   Hash results of yaml encoding.

--- a/doc/reference/reference_lua/index.rst
+++ b/doc/reference/reference_lua/index.rst
@@ -58,9 +58,10 @@ This reference covers Tarantool's built-in Lua modules.
     table
     tap
     tarantool
-    uuid
-    utf8
     uri
+    utf8
+    uuid
+    varbinary
     xlog
     yaml
     other

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -169,8 +169,8 @@ Functions
 
     ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
         :language: lua
-        :start-at: bin = varbinary.new('data')
-        :end-at: varbinary.is('data') -- false
+        :start-at: local bin = varbinary.new('data')
+        :end-at: print(bin_hex ~= '\xFF\xFE') -- false
         :dedent:
 
 .. _varbinary_new_string:
@@ -188,8 +188,9 @@ Functions
 
     ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
         :language: lua
-        :start-at: bin = varbinary.new('data')
-        :end-before: varbinary.is(100) -- false
+        :start-at: local bin = varbinary.new('data')
+        :end-at: local bin_hex = varbinary.new('\xFF\xFE')
+
         :dedent:
 
 .. _varbinary_new_ptr:
@@ -235,8 +236,8 @@ Metamethods
 
         ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
             :language: lua
-            :start-at: print(bin == 'data') -- true
-            :end-at: print(bin ~= 'data1') -- true
+            :start-at: print(bin == varbinary.new('data')) -- true
+            :end-at: print(bin_hex ~= '\xFF\xFE') -- false
             :dedent:
 
     .. _varbinary_len:
@@ -254,7 +255,7 @@ Metamethods
         ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
             :language: lua
             :start-at: print(#bin) -- 4
-            :end-at: print(#varbinary.new('\xFF\xFE')) -- 2
+            :end-at: print(#bin_hex) -- 2
             :dedent:
 
     .. _varbinary_tostring:

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -1,0 +1,294 @@
+..  _varbinary-module:
+
+Module varbinary
+================
+
+.. _varbinary-module-overview:
+
+Overview
+--------
+
+The ``varbinary`` module provides functions that convert `URI <https://en.wikipedia.org/wiki/Uniform_Resource_Identifier>`_ strings into their
+components, or turn components into URI strings, for example:
+
+..  literalinclude:: /code_snippets/test/uri/uri_parse_test.lua
+    :language: lua
+    :lines: 1-21
+
+You can also use this module to encode and decode arbitrary strings using the specified encoding options.
+
+
+.. _varbinary-module-api-reference:
+
+API Reference
+-------------
+
+Below is a list of ``uri`` functions, properties, and related objects.
+
+..  container:: table
+
+    ..  rst-class:: left-align-column-1
+    ..  rst-class:: left-align-column-2
+
+    ..  list-table::
+        :widths: 35 65
+
+        *   -   **Functions**
+            -
+        *   -   :ref:`varbinary.is() <varbinary_is>`
+            -   Check that the argument is a varbinary object
+
+        *   -   :ref:`varbinary.new() <varbinary_new>`
+            -   Create a varbinary object
+
+        *   -   **Metamethods**
+            -
+
+        *   -   :ref:`varbinary_object.__eq <varbinary_eq>`
+            -   Encoding options that use unreserved symbols defined in RFC 3986
+
+        *   -   :ref:`varbinary_object.__len <varbinary_len>`
+            -   Encoding options that use unreserved symbols defined in RFC 3986
+
+        *   -   :ref:`varbinary_object.__tostring <varbinary_tostring>`
+            -   Encoding options that use unreserved symbols defined in RFC 3986
+
+
+.. module:: varbinary
+
+..  _varbinary-module-api-reference-functions:
+
+Functions
+~~~~~~~~~
+
+.. _varbinary-new:
+
+.. function:: parse(uri-string)
+
+    Parse a URI string into components.
+
+    **See also:** :ref:`uri.format() <uri-format>`
+
+    :param string uri-string: a URI string
+    :return: a URI components table (see :ref:`uri_components <uri_components>`)
+
+    :rtype: table
+
+    **Example:**
+
+    ..  literalinclude:: /code_snippets/test/uri/uri_parse_test.lua
+        :language: lua
+        :lines: 1-11
+
+
+.. _varbinary_is:
+
+.. function:: format(uri_components[, include_password])
+
+    Construct a URI from the specified components.
+
+    **See also:** :ref:`uri.parse() <uri-parse>`
+
+    :param table uri_components: a series of ``name=value`` pairs, one for each
+                                 component (see :ref:`uri_components <uri_components>`)
+    :param boolean include_password: specify whether the password component is rendered in clear text;
+                                     otherwise, it is omitted
+    :return: URI string
+    :rtype: string
+
+    **Example:**
+
+    ..  literalinclude:: /code_snippets/test/uri/uri_parse_test.lua
+        :language: lua
+        :lines: 1-2,13-21
+
+
+..  _varbinary-module-api-reference-metamethods:
+
+Metamethods
+~~~~~~~~~~~
+
+.. _varbinary_eq:
+
+.. function:: __eq
+
+    Encoding options that use unreserved symbols defined in RFC 3986.
+    These are default options used to encode and decode using the :ref:`uri.escape() <uri-escape>`
+    and :ref:`uri.unescape() <uri-unescape>` functions, respectively.
+
+    **See also:** :ref:`uri_encoding_opts <uri_encoding_opts>`
+
+    :rtype: table
+
+.. _varbinary_len:
+
+.. function:: __len
+
+    Options used to encode the ``path`` URI component.
+
+    **See also:** :ref:`uri_encoding_opts <uri_encoding_opts>`
+
+    :rtype: table
+
+.. _varbinary_tostring:
+
+.. function:: __tostring
+
+    Options used to encode specific ``path`` parts.
+
+    **See also:** :ref:`uri_encoding_opts <uri_encoding_opts>`
+
+    :rtype: table
+
+..  _uri-module-api-reference-objects:
+
+Related objects
+~~~~~~~~~~~~~~~
+
+.. _uri_components:
+
+uri_components
+**************
+
+
+..  class:: uri_components
+
+    URI components.
+    The ``uri_components`` object is used in the following functions:
+
+    *   The :ref:`uri.parse() <uri-parse>` function returns the ``uri_components`` object.
+    *   The :ref:`uri.format() <uri-format>` function accepts the ``uri_components`` object as an argument.
+
+
+    ..  _uri_components-scheme:
+
+    .. data:: scheme
+
+        A URI scheme.
+
+        **Examples:** ``https``, ``http``
+
+    ..  _uri_components-login:
+
+    .. data:: login
+
+        A user name, which is a part of the ``userinfo`` subcomponent.
+
+    ..  _uri_components-password:
+
+    .. data:: password
+
+        A password, which is a part of the ``userinfo`` subcomponent.
+
+    ..  _uri_components-host:
+
+    .. data:: host
+
+        A host subcomponent.
+
+        **Example:** ``www.tarantool.io``
+
+    ..  _uri_components-service:
+
+    .. data:: service
+
+        A service subcomponent.
+        This property might return different values depending on the used URI scheme, for example:
+
+        *   If the ``https`` or ``http`` scheme is used, ``service`` returns the port value.
+        *   If the Unix domain socket is used, ``service`` returns the socket path.
+
+        **Examples:** ``3301``, ``/tmp/unix.sock``
+
+    ..  _uri_components-path:
+
+    .. data:: path
+
+        A path component.
+
+        **Example:** ``/doc/latest/reference/reference_lua/http/``
+
+    ..  _uri_components-query:
+
+    .. data:: query
+
+        A query component.
+
+        **Example:** ``key1=value1&key2=value2``
+
+    ..  _uri_components-fragment:
+
+    .. data:: fragment
+
+        A fragment component.
+
+        **Example:** ``api-reference``
+
+    ..  _uri_components-ipv4:
+
+    .. data:: ipv4
+
+        An IPv4 address.
+
+        **Example:** ``127.0.0.1``
+
+    ..  _uri_components-ipv6:
+
+    .. data:: ipv6
+
+        An IPv6 address.
+
+        **Example:** ``2a00:1148:b0ba:2016:12bf:48ff:fe78:fd10``
+
+    ..  _uri_components-unix:
+
+    .. data:: unix
+
+        A Unix domain socket.
+
+        **Example:** ``/tmp/unix.sock``
+
+
+.. _uri_encoding_opts:
+
+uri_encoding_opts
+*****************
+
+
+..  class:: uri_encoding_opts
+
+    **Since:** :doc:`2.11.0 </release/2.11.0>`
+
+    URI encoding options.
+    These options can be passed to the :ref:`uri.escape() <uri-escape>` and :ref:`uri.unescape() <uri-unescape>` functions.
+
+    **Example:**
+
+    The example below shows how to encode a string using custom encoding options.
+
+    ..  literalinclude:: /code_snippets/test/uri/uri_escape_test.lua
+        :language: lua
+        :lines: 1-2,29-38
+
+    .. NOTE::
+
+        The ``uri`` module also provides several sets of predefined options targeted for encoding a specific URI part (for example, :ref:`uri.PATH <uri-path>` or :ref:`uri.QUERY <uri-query>`).
+
+    ..  _uri_encoding_opts-plus:
+
+    .. data:: plus
+
+        Enable encoding of ``+`` as the space character.
+        By default, this property is set to ``false``.
+
+        :rtype: boolean
+
+    ..  _uri_components-unreserved:
+
+    .. data:: unreserved
+
+        Specify a Lua pattern defining unreserved symbols that are not encoded.
+
+        :rtype: table
+
+        **Example:** ``'a-zA-Z0-9%-._~'``

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -243,7 +243,7 @@ Metamethods
 
     .. method:: __len()
 
-        Returns the length of a ``varbinary`` object in bytes.
+        Returns the length of the binary data in bytes.
 
         Defines the ``#`` operator for ``varbinary`` objects.
 
@@ -261,7 +261,7 @@ Metamethods
 
     .. method:: __tostring()
 
-        Returns a ``varbinary`` object data in a plain string.
+        Returns the binary data in a plain string.
         
         Defines the ``tostring()`` function for ``varbinary`` objects.
 

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -89,7 +89,7 @@ Decoding binary data to varbinary objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The built-in decoders also decode binary data fields (fields with the
-``binary`` tag in YAML; the ``MP_BIN`` type in MsgPack) to varbinary
+``binary`` tag in YAML and the ``MP_BIN`` type in MsgPack) to varbinary
 objects by default:
 
 .. code-block:: tarantoolsession
@@ -197,53 +197,53 @@ Functions
 
 ..  _varbinary-module-api-reference-metamethods:
 
-.. class:: varbinary_object
-
 Metamethods
 ~~~~~~~~~~~
 
-.. _varbinary_eq:
+.. class:: varbinary_object
 
-.. method:: __eq
+    .. _varbinary_eq:
 
-    Checks the equality of two ``varbinary`` objects or a ``varbinary`` object and a string.
-    A ``varbinary`` object equals to a another ``varbinary`` object of a string if it
-    contains the same data.
+    .. method:: __eq
 
-    Defines the ``==`` and ``~=`` operators for ``varbinary`` objects.
+        Checks the equality of two ``varbinary`` objects or a ``varbinary`` object and a string.
+        A ``varbinary`` object equals to a another ``varbinary`` object of a string if it
+        contains the same data.
 
-    :rtype: boolean
+        Defines the ``==`` and ``~=`` operators for ``varbinary`` objects.
 
-    **Example:**
+        :rtype: boolean
 
-    ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
-        :language: lua
-        :start-at: print(bin == 'data') -- true
-        :end-at: print(bin ~= 'data1') -- true
-        :dedent:
+        **Example:**
 
-.. _varbinary_len:
+        ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
+            :language: lua
+            :start-at: print(bin == 'data') -- true
+            :end-at: print(bin ~= 'data1') -- true
+            :dedent:
 
-.. method:: __len
+    .. _varbinary_len:
 
-    Returns the length of a ``varbinary`` object in bytes.
+    .. method:: __len
 
-    Defines the ``#`` operator for ``varbinary`` objects.
+        Returns the length of a ``varbinary`` object in bytes.
 
-    :rtype: number
+        Defines the ``#`` operator for ``varbinary`` objects.
 
-    **Example:**
+        :rtype: number
 
-    ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
-        :language: lua
-        :start-at: print(#bin) -- 4
-        :end-at: print(#varbinary.new('\xFF\xFE')) -- 2
-        :dedent:
+        **Example:**
 
-.. _varbinary_tostring:
+        ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
+            :language: lua
+            :start-at: print(#bin) -- 4
+            :end-at: print(#varbinary.new('\xFF\xFE')) -- 2
+            :dedent:
 
-.. method:: __tostring
+    .. _varbinary_tostring:
 
-    Returns a ``varbinary`` object data in a plain string.
+    .. method:: __tostring
 
-    :rtype: string
+        Returns a ``varbinary`` object data in a plain string.
+
+        :rtype: string

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -8,14 +8,9 @@ Module varbinary
 Overview
 --------
 
-The ``varbinary`` module provides functions that convert `URI <https://en.wikipedia.org/wiki/Uniform_Resource_Identifier>`_ strings into their
-components, or turn components into URI strings, for example:
+The ``varbinary`` module provides functions for operating binary objects in Lua.
 
-..  literalinclude:: /code_snippets/test/uri/uri_parse_test.lua
-    :language: lua
-    :lines: 1-21
-
-You can also use this module to encode and decode arbitrary strings using the specified encoding options.
+This module provides functions for creating varbinary objects
 
 
 .. _varbinary-module-api-reference:
@@ -23,7 +18,7 @@ You can also use this module to encode and decode arbitrary strings using the sp
 API Reference
 -------------
 
-Below is a list of ``uri`` functions, properties, and related objects.
+Below is a list of ``varbinary`` functions, properties, and related objects.
 
 ..  container:: table
 
@@ -45,13 +40,13 @@ Below is a list of ``uri`` functions, properties, and related objects.
             -
 
         *   -   :ref:`varbinary_object.__eq <varbinary_eq>`
-            -   Encoding options that use unreserved symbols defined in RFC 3986
+            -   Checks the equality of two varbinary ojbects
 
         *   -   :ref:`varbinary_object.__len <varbinary_len>`
-            -   Encoding options that use unreserved symbols defined in RFC 3986
+            -   Returns the length of the binary data in bytes
 
         *   -   :ref:`varbinary_object.__tostring <varbinary_tostring>`
-            -   Encoding options that use unreserved symbols defined in RFC 3986
+            -   Returns the binary data in a plain string
 
 
 .. module:: varbinary
@@ -63,45 +58,45 @@ Functions
 
 .. _varbinary-new:
 
-.. function:: parse(uri-string)
+.. function:: new(data[, size])
 
-    Parse a URI string into components.
+    Create a new varbinary object from a given string or a cdata pointer and size.
 
     **See also:** :ref:`uri.format() <uri-format>`
 
-    :param string uri-string: a URI string
-    :return: a URI components table (see :ref:`uri_components <uri_components>`)
+    :param string data: a string or a cdata pointer
+    :param number size: (optional) object size if ``data`` is a cdata pointer
+    :return: a varbinary object containing the data
 
-    :rtype: table
+    :rtype: varbinary
 
     **Example:**
 
-    ..  literalinclude:: /code_snippets/test/uri/uri_parse_test.lua
+    ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
         :language: lua
-        :lines: 1-11
+        :start-at: bin = varbinary.new('data')
+        :end-before: print(bin)
+        :dedent:
 
 
 .. _varbinary_is:
 
-.. function:: format(uri_components[, include_password])
+.. function:: is(object)
 
-    Construct a URI from the specified components.
+    Check that the given object is a varbinary object.
 
-    **See also:** :ref:`uri.parse() <uri-parse>`
+    :param object object: an object to check
 
-    :param table uri_components: a series of ``name=value`` pairs, one for each
-                                 component (see :ref:`uri_components <uri_components>`)
-    :param boolean include_password: specify whether the password component is rendered in clear text;
-                                     otherwise, it is omitted
-    :return: URI string
-    :rtype: string
+    :return: Whether the given object is a varbinary object
+    :rtype: boolean
 
     **Example:**
 
-    ..  literalinclude:: /code_snippets/test/uri/uri_parse_test.lua
+    ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
         :language: lua
-        :lines: 1-2,13-21
-
+        :start-at: bin = varbinary.new('data')
+        :end-at: varbinary.is('data') -- false
+        :dedent:
 
 ..  _varbinary-module-api-reference-metamethods:
 
@@ -110,185 +105,46 @@ Metamethods
 
 .. _varbinary_eq:
 
-.. function:: __eq
+.. function:: __eq (== and ~= operators)
 
-    Encoding options that use unreserved symbols defined in RFC 3986.
-    These are default options used to encode and decode using the :ref:`uri.escape() <uri-escape>`
-    and :ref:`uri.unescape() <uri-unescape>` functions, respectively.
+    Checks the equality of two varbinary objects or a varbinary object and a string.
+    A varbinary object equals to a another varbinary object of a string if it
+    contains the same data.
 
-    **See also:** :ref:`uri_encoding_opts <uri_encoding_opts>`
+    Defines the ``==`` and ``~=`` operators for varbinary objects.
 
-    :rtype: table
+    :rtype: boolean
+
+    **Example:**
+
+    ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
+        :language: lua
+        :start-at: bin = varbinary.new('data')
+        :end-at: varbinary.is('data') -- false
+        :dedent:
 
 .. _varbinary_len:
 
-.. function:: __len
+.. function:: __len (# operator)
 
-    Options used to encode the ``path`` URI component.
+    Returns the length of a varbinary object in bytes.
 
-    **See also:** :ref:`uri_encoding_opts <uri_encoding_opts>`
+    Defines the ``#`` operator for varbinary objects.
 
-    :rtype: table
+    :rtype: number
+
+    **Example:**
+
+    ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
+        :language: lua
+        :start-at: print(#bin) -- 4
+        :end-at: print(#varbinary.new('\xFF\xFE')) -- 2
+        :dedent:
 
 .. _varbinary_tostring:
 
 .. function:: __tostring
 
-    Options used to encode specific ``path`` parts.
+    Returns a varbinary object data in a plain string
 
-    **See also:** :ref:`uri_encoding_opts <uri_encoding_opts>`
-
-    :rtype: table
-
-..  _uri-module-api-reference-objects:
-
-Related objects
-~~~~~~~~~~~~~~~
-
-.. _uri_components:
-
-uri_components
-**************
-
-
-..  class:: uri_components
-
-    URI components.
-    The ``uri_components`` object is used in the following functions:
-
-    *   The :ref:`uri.parse() <uri-parse>` function returns the ``uri_components`` object.
-    *   The :ref:`uri.format() <uri-format>` function accepts the ``uri_components`` object as an argument.
-
-
-    ..  _uri_components-scheme:
-
-    .. data:: scheme
-
-        A URI scheme.
-
-        **Examples:** ``https``, ``http``
-
-    ..  _uri_components-login:
-
-    .. data:: login
-
-        A user name, which is a part of the ``userinfo`` subcomponent.
-
-    ..  _uri_components-password:
-
-    .. data:: password
-
-        A password, which is a part of the ``userinfo`` subcomponent.
-
-    ..  _uri_components-host:
-
-    .. data:: host
-
-        A host subcomponent.
-
-        **Example:** ``www.tarantool.io``
-
-    ..  _uri_components-service:
-
-    .. data:: service
-
-        A service subcomponent.
-        This property might return different values depending on the used URI scheme, for example:
-
-        *   If the ``https`` or ``http`` scheme is used, ``service`` returns the port value.
-        *   If the Unix domain socket is used, ``service`` returns the socket path.
-
-        **Examples:** ``3301``, ``/tmp/unix.sock``
-
-    ..  _uri_components-path:
-
-    .. data:: path
-
-        A path component.
-
-        **Example:** ``/doc/latest/reference/reference_lua/http/``
-
-    ..  _uri_components-query:
-
-    .. data:: query
-
-        A query component.
-
-        **Example:** ``key1=value1&key2=value2``
-
-    ..  _uri_components-fragment:
-
-    .. data:: fragment
-
-        A fragment component.
-
-        **Example:** ``api-reference``
-
-    ..  _uri_components-ipv4:
-
-    .. data:: ipv4
-
-        An IPv4 address.
-
-        **Example:** ``127.0.0.1``
-
-    ..  _uri_components-ipv6:
-
-    .. data:: ipv6
-
-        An IPv6 address.
-
-        **Example:** ``2a00:1148:b0ba:2016:12bf:48ff:fe78:fd10``
-
-    ..  _uri_components-unix:
-
-    .. data:: unix
-
-        A Unix domain socket.
-
-        **Example:** ``/tmp/unix.sock``
-
-
-.. _uri_encoding_opts:
-
-uri_encoding_opts
-*****************
-
-
-..  class:: uri_encoding_opts
-
-    **Since:** :doc:`2.11.0 </release/2.11.0>`
-
-    URI encoding options.
-    These options can be passed to the :ref:`uri.escape() <uri-escape>` and :ref:`uri.unescape() <uri-unescape>` functions.
-
-    **Example:**
-
-    The example below shows how to encode a string using custom encoding options.
-
-    ..  literalinclude:: /code_snippets/test/uri/uri_escape_test.lua
-        :language: lua
-        :lines: 1-2,29-38
-
-    .. NOTE::
-
-        The ``uri`` module also provides several sets of predefined options targeted for encoding a specific URI part (for example, :ref:`uri.PATH <uri-path>` or :ref:`uri.QUERY <uri-query>`).
-
-    ..  _uri_encoding_opts-plus:
-
-    .. data:: plus
-
-        Enable encoding of ``+`` as the space character.
-        By default, this property is set to ``false``.
-
-        :rtype: boolean
-
-    ..  _uri_components-unreserved:
-
-    .. data:: unreserved
-
-        Specify a Lua pattern defining unreserved symbols that are not encoded.
-
-        :rtype: table
-
-        **Example:** ``'a-zA-Z0-9%-._~'``
+    :rtype: string

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -27,8 +27,8 @@ For example:
 Encoding varbinary objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``varbinary`` objects preserve their binary type when encoded by the built-in MsgPack
-and YAML encoders.
+``varbinary`` objects preserve their binary type when encoded by the built-in :ref:`MsgPack <msgpack-module>`
+and :ref:`YAML <yaml-module>` encoders.
 
 See the difference:
 
@@ -175,16 +175,14 @@ Functions
         :end-at: varbinary.is('data') -- false
         :dedent:
 
-.. _varbinary_new:
+.. _varbinary_new_string:
 
-.. function:: new(data[, size])
+.. function:: new(string)
 
-    Create a new ``varbinary`` object from a given string or a ``cdata`` pointer and size.
+    Create a new ``varbinary`` object from a given string.
 
-    :param string data: a string object
-    :param cdata data: a ``cdata`` pointer
-    :param number size: (optional) object size if ``data`` is a ``cdata`` pointer
-    :return: a ``varbinary`` object containing the data
+    :param string string: a string object
+    :return: a ``varbinary`` object containing the string data
 
     :rtype: cdata
 
@@ -196,6 +194,25 @@ Functions
         :end-before: varbinary.is(100) -- false
         :dedent:
 
+.. _varbinary_new_ptr:
+
+.. function:: new(ptr, size)
+
+    Create a new ``varbinary`` object from a ``cdata`` pointer and size.
+
+    :param cdata ptr: a ``cdata`` pointer
+    :param number size: object size in bytes
+    :return: a ``varbinary`` object containing the data
+
+    :rtype: cdata
+
+    **Example:**
+
+    ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
+        :language: lua
+        :start-at: local bin2
+        :end-at: print(bin2) -- data
+        :dedent:
 
 ..  _varbinary-module-api-reference-metamethods:
 

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -188,9 +188,8 @@ Functions
 
     ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
         :language: lua
-        :start-at: local bin = varbinary.new('data')
-        :end-before: -- Check whether a value is a varbinary object
-
+        :start-at: local bin
+        :end-at: local bin_hex
         :dedent:
 
 .. _varbinary_new_ptr:

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -19,7 +19,7 @@ For example:
 ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
     :language: lua
     :start-at: local
-    :end-before: local luatest
+    :end-before: local bin2
     :dedent:
 
 .. _varbinary-module-overview-encode:
@@ -28,9 +28,7 @@ Encoding varbinary objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``varbinary`` objects preserve their binary type when encoded by the built-in :ref:`MsgPack <msgpack-module>`
-and :ref:`YAML <yaml-module>` encoders.
-
-See the difference:
+and :ref:`YAML <yaml-module>` encoders. See the difference with strings:
 
 -   String to MsgPack:
 
@@ -133,7 +131,7 @@ Below is a list of ``varbinary`` functions, properties, and related objects.
         *   -   :ref:`varbinary.is() <varbinary_is>`
             -   Check that the argument is a ``varbinary`` object
 
-        *   -   :ref:`varbinary.new() <varbinary_new>`
+        *   -   :ref:`varbinary.new() <varbinary_new_string>`
             -   Create a ``varbinary`` object
 
         *   -   **Metamethods**
@@ -182,7 +180,7 @@ Functions
     Create a new ``varbinary`` object from a given string.
 
     :param string string: a string object
-    :return: a ``varbinary`` object containing the string data
+    :return: A ``varbinary`` object containing the string data
 
     :rtype: cdata
 
@@ -202,7 +200,7 @@ Functions
 
     :param cdata ptr: a ``cdata`` pointer
     :param number size: object size in bytes
-    :return: a ``varbinary`` object containing the data
+    :return: A ``varbinary`` object containing the data
 
     :rtype: cdata
 

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -3,6 +3,8 @@
 Module varbinary
 ================
 
+**Since:** :doc:`3.0.0 </release/3.0.0>`
+
 .. _varbinary-module-overview:
 
 Overview
@@ -106,7 +108,7 @@ objects by default:
 
 .. important::
 
-    This behavior is different from what is was before Tarantool 3.0.
+    This behavior is different from what it was before Tarantool 3.0.
     In earlier versions, such fields were decoded to plain strings.
     To return to this behavior, use the ``compat`` option
     :ref:`binary_data_decoding <compat-option-binary-decoding>`.
@@ -184,7 +186,7 @@ Functions
     :param number size: (optional) object size if ``data`` is a ``cdata`` pointer
     :return: a ``varbinary`` object containing the data
 
-    :rtype: varbinary
+    :rtype: cdata
 
     **Example:**
 
@@ -207,7 +209,7 @@ Metamethods
     .. method:: __eq(object)
 
         Checks the equality of two ``varbinary`` objects or a ``varbinary`` object and a string.
-        A ``varbinary`` object equals to a another ``varbinary`` object or a string if it
+        A ``varbinary`` object equals to another ``varbinary`` object or a string if it
         contains the same data.
 
         Defines the ``==`` and ``~=`` operators for ``varbinary`` objects.
@@ -245,5 +247,7 @@ Metamethods
     .. method:: __tostring()
 
         Returns a ``varbinary`` object data in a plain string.
+        
+        Defines the ``tostring()`` function for ``varbinary`` objects.
 
         :rtype: string

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -9,9 +9,7 @@ Overview
 --------
 
 The ``varbinary`` module provides functions for operating variable-length binary
-objects in Lua.
-
-This module provides functions for creating ``varbinary`` objects, checking their type,
+objects in Lua. It provides functions for creating ``varbinary`` objects, checking their type,
 and also defines basic operators on such objects.
 
 For example:
@@ -54,10 +52,10 @@ See the difference:
 
     .. code-block:: tarantoolsession
 
-    tarantool> '\xFF\xFE'
-    ---
-    - "\xFF\xFE"
-    ...
+        tarantool> '\xFF\xFE'
+        ---
+        - "\xFF\xFE"
+        ...
 
 -   ``varbinary`` to YAML:
 
@@ -108,8 +106,9 @@ objects by default:
 
 .. important::
 
-    This changes the decoder behavior: before Tarantool 3.0, such fields were decoded
-    to plain strings. To return to this behavior, use the ``compat`` option
+    This behavior is different from what is was before Tarantool 3.0.
+    In earlier versions, such fields were decoded to plain strings.
+    To return to this behavior, use the ``compat`` option
     :ref:`binary_data_decoding <compat-option-binary-decoding>`.
 
 .. _varbinary-module-api-reference:
@@ -130,16 +129,16 @@ Below is a list of ``varbinary`` functions, properties, and related objects.
         *   -   **Functions**
             -
         *   -   :ref:`varbinary.is() <varbinary_is>`
-            -   Check that the argument is a varbinary object
+            -   Check that the argument is a ``varbinary`` object
 
         *   -   :ref:`varbinary.new() <varbinary_new>`
-            -   Create a varbinary object
+            -   Create a ``varbinary`` object
 
         *   -   **Metamethods**
             -
 
         *   -   :ref:`varbinary_object.__eq <varbinary_eq>`
-            -   Checks the equality of two varbinary ojbects
+            -   Checks the equality of two ``varbinary`` objects
 
         *   -   :ref:`varbinary_object.__len <varbinary_len>`
             -   Returns the length of the binary data in bytes
@@ -159,11 +158,11 @@ Functions
 
 .. function:: is(object)
 
-    Check that the given object is a varbinary object.
+    Check that the given object is a ``varbinary`` object.
 
     :param object object: an object to check
 
-    :return: Whether the given object is a varbinary object
+    :return: Whether the given object is of ``varbinary`` type
     :rtype: boolean
 
     **Example:**
@@ -178,12 +177,12 @@ Functions
 
 .. function:: new(data[, size])
 
-    Create a new varbinary object from a given string or a ``cdata`` pointer and size.
+    Create a new ``varbinary`` object from a given string or a ``cdata`` pointer and size.
 
     :param string data: a string object
     :param cdata data: a ``cdata`` pointer
     :param number size: (optional) object size if ``data`` is a ``cdata`` pointer
-    :return: a varbinary object containing the data
+    :return: a ``varbinary`` object containing the data
 
     :rtype: varbinary
 
@@ -198,18 +197,20 @@ Functions
 
 ..  _varbinary-module-api-reference-metamethods:
 
+.. class:: varbinary_object
+
 Metamethods
 ~~~~~~~~~~~
 
 .. _varbinary_eq:
 
-.. function:: __eq
+.. method:: __eq
 
-    Checks the equality of two varbinary objects or a varbinary object and a string.
-    A varbinary object equals to a another varbinary object of a string if it
+    Checks the equality of two ``varbinary`` objects or a ``varbinary`` object and a string.
+    A ``varbinary`` object equals to a another ``varbinary`` object of a string if it
     contains the same data.
 
-    Defines the ``==`` and ``~=`` operators for varbinary objects.
+    Defines the ``==`` and ``~=`` operators for ``varbinary`` objects.
 
     :rtype: boolean
 
@@ -218,16 +219,16 @@ Metamethods
     ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
         :language: lua
         :start-at: print(bin == 'data') -- true
-        :end-at: print(bin ~= 'data1') -- false
+        :end-at: print(bin ~= 'data1') -- true
         :dedent:
 
 .. _varbinary_len:
 
-.. function:: __len
+.. method:: __len
 
-    Returns the length of a varbinary object in bytes.
+    Returns the length of a ``varbinary`` object in bytes.
 
-    Defines the ``#`` operator for varbinary objects.
+    Defines the ``#`` operator for ``varbinary`` objects.
 
     :rtype: number
 
@@ -241,8 +242,8 @@ Metamethods
 
 .. _varbinary_tostring:
 
-.. function:: __tostring
+.. method:: __tostring
 
-    Returns a varbinary object data in a plain string
+    Returns a ``varbinary`` object data in a plain string.
 
     :rtype: string

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -8,10 +8,19 @@ Module varbinary
 Overview
 --------
 
-The ``varbinary`` module provides functions for operating binary objects in Lua.
+The ``varbinary`` module provides functions for operating variable-length binary
+objects in Lua.
 
-This module provides functions for creating varbinary objects
+This module provides functions for creating varbinary objects, checking their type,
+and also defines basic operators on such objects.
 
+For example:
+
+..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
+    :language: lua
+    :start-at: local
+    :end-before: local luatest
+    :dedent:
 
 .. _varbinary-module-api-reference:
 
@@ -56,29 +65,6 @@ Below is a list of ``varbinary`` functions, properties, and related objects.
 Functions
 ~~~~~~~~~
 
-.. _varbinary-new:
-
-.. function:: new(data[, size])
-
-    Create a new varbinary object from a given string or a cdata pointer and size.
-
-    **See also:** :ref:`uri.format() <uri-format>`
-
-    :param string data: a string or a cdata pointer
-    :param number size: (optional) object size if ``data`` is a cdata pointer
-    :return: a varbinary object containing the data
-
-    :rtype: varbinary
-
-    **Example:**
-
-    ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
-        :language: lua
-        :start-at: bin = varbinary.new('data')
-        :end-before: print(bin)
-        :dedent:
-
-
 .. _varbinary_is:
 
 .. function:: is(object)
@@ -98,6 +84,27 @@ Functions
         :end-at: varbinary.is('data') -- false
         :dedent:
 
+.. _varbinary_new:
+
+.. function:: new(data[, size])
+
+    Create a new varbinary object from a given string or a cdata pointer and size.
+
+    :param string data: a string or a cdata pointer
+    :param number size: (optional) object size if ``data`` is a cdata pointer
+    :return: a varbinary object containing the data
+
+    :rtype: varbinary
+
+    **Example:**
+
+    ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
+        :language: lua
+        :start-at: bin = varbinary.new('data')
+        :end-before: varbinary.is(100) -- false
+        :dedent:
+
+
 ..  _varbinary-module-api-reference-metamethods:
 
 Metamethods
@@ -105,7 +112,7 @@ Metamethods
 
 .. _varbinary_eq:
 
-.. function:: __eq (== and ~= operators)
+.. function:: __eq
 
     Checks the equality of two varbinary objects or a varbinary object and a string.
     A varbinary object equals to a another varbinary object of a string if it
@@ -119,13 +126,13 @@ Metamethods
 
     ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
         :language: lua
-        :start-at: bin = varbinary.new('data')
-        :end-at: varbinary.is('data') -- false
+        :start-at: print(bin == 'data') -- true
+        :end-at: print(bin ~= 'data1') -- false
         :dedent:
 
 .. _varbinary_len:
 
-.. function:: __len (# operator)
+.. function:: __len
 
     Returns the length of a varbinary object in bytes.
 

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -204,10 +204,10 @@ Metamethods
 
     .. _varbinary_eq:
 
-    .. method:: __eq(varbinary)
+    .. method:: __eq(object)
 
         Checks the equality of two ``varbinary`` objects or a ``varbinary`` object and a string.
-        A ``varbinary`` object equals to a another ``varbinary`` object of a string if it
+        A ``varbinary`` object equals to a another ``varbinary`` object or a string if it
         contains the same data.
 
         Defines the ``==`` and ``~=`` operators for ``varbinary`` objects.

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -204,7 +204,7 @@ Metamethods
 
     .. _varbinary_eq:
 
-    .. method:: __eq
+    .. method:: __eq(varbinary)
 
         Checks the equality of two ``varbinary`` objects or a ``varbinary`` object and a string.
         A ``varbinary`` object equals to a another ``varbinary`` object of a string if it
@@ -224,7 +224,7 @@ Metamethods
 
     .. _varbinary_len:
 
-    .. method:: __len
+    .. method:: __len()
 
         Returns the length of a ``varbinary`` object in bytes.
 
@@ -242,7 +242,7 @@ Metamethods
 
     .. _varbinary_tostring:
 
-    .. method:: __tostring
+    .. method:: __tostring()
 
         Returns a ``varbinary`` object data in a plain string.
 

--- a/doc/reference/reference_lua/varbinary.rst
+++ b/doc/reference/reference_lua/varbinary.rst
@@ -170,7 +170,7 @@ Functions
     ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
         :language: lua
         :start-at: local bin = varbinary.new('data')
-        :end-at: print(bin_hex ~= '\xFF\xFE') -- false
+        :end-at: varbinary.is('data') -- false
         :dedent:
 
 .. _varbinary_new_string:
@@ -189,7 +189,7 @@ Functions
     ..  literalinclude:: /code_snippets/test/varbinary/varbinary_test.lua
         :language: lua
         :start-at: local bin = varbinary.new('data')
-        :end-at: local bin_hex = varbinary.new('\xFF\xFE')
+        :end-before: -- Check whether a value is a varbinary object
 
         :dedent:
 


### PR DESCRIPTION
Resolves #3551 

- Add new [Module varbinary](https://docs.d.tarantool.io/en/doc/gh-3551-varbinary/reference/reference_lua/varbinary/) page to Lua reference
- Add new compat page about [binary data decoding](https://docs.d.tarantool.io/en/doc/gh-3551-varbinary/reference/reference_lua/compat/binary_data_decoding/#compat-option-binary-decoding)
- Cross-link [config option compat.binary_data_decoding](https://docs.d.tarantool.io/en/doc/gh-3551-varbinary/reference/configuration/configuration_reference/#configuration-reference-compat-binary-decoding) to the compat option reference
- Delete the outdated Lua cookbook recipe [ffi_varbinary_insert](https://www.tarantool.io/en/doc/latest/platform/app/cookbook/#cookbook-ffi-varbinary-insert)
 and a link to it from the [bin type description](https://docs.d.tarantool.io/en/doc/gh-3551-varbinary/platform/ddl_dml/value_store/#bin)

Deployment: https://docs.d.tarantool.io/en/doc/gh-3551-varbinary/reference/reference_lua/varbinary/