### PR TITLE
datetime: describe relational operators

### DIFF
--- a/doc/reference/reference_lua/datetime.rst
+++ b/doc/reference/reference_lua/datetime.rst
@@ -964,3 +964,51 @@ The matrix of the ``subtraction`` operands eligibility and their result types:
             -   unsupported
             -   interval
             -   interval
+
+.. _interval_comp:
+
+Datetime and interval comparison
+--------------------------------
+
+If you need to compare the ``datetime`` and ``interval`` object values, you can use standard Lua relational operators: ``==``, ``~=``, ``>``, ``<``, ``>=``, and ``<=``. These operators use the overloaded ``__eq``, ``__lt``, and ``__le`` metamethods to compare values.
+
+Support for relational operators for ``interval`` objects has been added since :doc:`2.11.0 </release/2.11.0>`.
+
+**Example 1:**
+
+..  code-block:: tarantoolsession
+
+    tarantool> dt1 = datetime.new({ year = 2010 })
+    ---
+    ...
+
+    tarantool> dt2 = datetime.new({ year = 2024 })
+    ---
+    ...
+
+    tarantool> dt1 == dt2
+    ---
+    - false
+    ...
+
+    tarantool> dt1 < dt2
+    ---
+    - true
+    ...
+
+**Example 2:**
+
+..  code-block:: tarantoolsession
+
+    tarantool> iv1 = datetime.interval.new({month = 1})
+    ---
+    ...
+
+    tarantool> iv2 = datetime.interval.new({month = 2})
+    ---
+    ...
+
+    tarantool> iv1 < iv2
+    ---
+    - true
+    ...


### PR DESCRIPTION
Follows up commit de58780f7f33
("Add a new section for the datetime module with the description of its main functions and methods").

Datetime comparison has been added in [1] (since 2.10.0-beta2), interval comparison has been added in commit [2]
(since 2.11.0-rc1).

1. https://github.com/tarantool/tarantool/commit/43e10ed3494998b5f07af93b83307f27a9fb755a
2. https://github.com/tarantool/tarantool/commit/65a3c17f283acd89af252b4406ba9e93a034ccab

Follows up #2411
Fixes #3339