### PR TITLE
Add TCM 1.2 Whats new

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -18,3 +18,4 @@ This section will get you acquainted with Tarantool.
     vshard_quick
     getting_started_tcm
 
+†

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -17,5 +17,3 @@ This section will get you acquainted with Tarantool.
     getting_started_db
     vshard_quick
     getting_started_tcm
-
-†

--- a/doc/tooling/tcm/tcm_access_control.rst
+++ b/doc/tooling/tcm/tcm_access_control.rst
@@ -357,6 +357,11 @@ jobs that retrieve metrics of connected Tarantool clusters.
 The API tokens functionality is disabled by default. To enable it, set the
 :ref:`feature.api-token <tcm_configuration_reference_feature_api-token>` configuration option to ``true``.
 
+.. code-block:: yaml
+
+    feature:
+      api-token: true
+
 Each |tcm| API token belongs to the user that created it and has the same :ref:`access permissions <tcm_access_control_permissions>`.
 Thus, if a user has a permission to view a cluster's metrics in |tcm|, this user's
 API tokens can be used to read this cluster's metrics with Prometheus.

--- a/doc/tooling/tcm/tcm_access_control.rst
+++ b/doc/tooling/tcm/tcm_access_control.rst
@@ -354,6 +354,9 @@ API tokens
 external applications' requests to |tcm|. For example, these can be Prometheus
 jobs that retrieve metrics of connected Tarantool clusters.
 
+The API tokens functionality is disabled by default. To enable it, set the
+:ref:`feature.api-token <tcm_configuration_reference_feature_api-token>` configuration option to ``true``.
+
 Each |tcm| API token belongs to the user that created it and has the same :ref:`access permissions <tcm_access_control_permissions>`.
 Thus, if a user has a permission to view a cluster's metrics in |tcm|, this user's
 API tokens can be used to read this cluster's metrics with Prometheus.

--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -2231,6 +2231,8 @@ The ``feature`` section defines the security parameters of |tcm|.
 
 -   :ref:`feature.ttgraph <tcm_configuration_reference_feature_ttgraph>`
 -   :ref:`feature.column-store <tcm_configuration_reference_feature_column-store>`
+-   :ref:`feature.tqe <tcm_configuration_reference_feature_tqe>`
+-   :ref:`feature.api-token <tcm_configuration_reference_feature_api-token>`
 
 
 .. _tcm_configuration_reference_feature_ttgraph:
@@ -2256,3 +2258,27 @@ The ``feature`` section defines the security parameters of |tcm|.
     | Default: false
     | Environment variable: TCM_FEATURE_COLUMN_STORE
     | Command-line option: ``--feature.column-store``
+
+.. _tcm_configuration_reference_feature_tqe:
+
+.. confval:: feature.tqe
+
+    Whether Tarantool Queue Enterprise integration is enabled.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_FEATURE_TQE
+    | Command-line option: ``--feature.tqe``
+
+.. _tcm_configuration_reference_feature_api-token:
+
+.. confval:: feature.api-token
+
+    Whether the use of :ref:`API tokens <tcm_access_control_api_tokens>` is enabled.
+
+    |
+    | Type: bool
+    | Default: false
+    | Environment variable: TCM_FEATURE_API_TOKEN
+    | Command-line option: ``--feature.api-token``

--- a/doc/tooling/tcm/tcm_releases/index.rst
+++ b/doc/tooling/tcm/tcm_releases/index.rst
@@ -45,5 +45,6 @@ Supported versions
 ..  toctree::
     :maxdepth: 1
 
+    tcm_1.2
     tcm_1.1
     tcm_1.0

--- a/doc/tooling/tcm/tcm_releases/index.rst
+++ b/doc/tooling/tcm/tcm_releases/index.rst
@@ -26,6 +26,10 @@ Supported versions
             -   First release date
             -   Versions
 
+        *   -   :ref:`1.2 <tcm_releases_1_2>`
+            -   July 30, 2024
+            -   1.2.0
+
         *   -   :ref:`1.1 <tcm_releases_1_1>`
             -   May 16, 2024
             -   1.1.0

--- a/doc/tooling/tcm/tcm_releases/tcm_1.2.rst
+++ b/doc/tooling/tcm/tcm_releases/tcm_1.2.rst
@@ -18,7 +18,7 @@ Managing Tarantool users
 |tcm| 1.2 introduces the ability to manage Tarantool users on connected clusters.
 Previously, you could manage Tarantool users only though the Lua API (:ref:`box.schema <box_schema>` submodule)
 or cluster :ref:`configuration <configuration_credentials_managing_users_roles>`.
-Now you can create, edit and delete users and roles on each instance of a Tarantool
+Now you can create, edit, and delete users and roles on each instance of a Tarantool
 cluster through the |tcm| web interface.
 
 The tools for managing Tarantool users on a cluster instance are located on the

--- a/doc/tooling/tcm/tcm_releases/tcm_1.2.rst
+++ b/doc/tooling/tcm/tcm_releases/tcm_1.2.rst
@@ -16,7 +16,7 @@ Managing Tarantool users
 ------------------------
 
 |tcm| 1.2 introduces the ability to manage Tarantool users on connected clusters.
-Previously, you could manage Tarantool users only though the Lua API (:`box.schema <box_schema>` submodule)
+Previously, you could manage Tarantool users only though the Lua API (:ref:`box.schema <box_schema>` submodule)
 or cluster :ref:`configuration <configuration_credentials_managing_users_roles>`.
 Now you can create, edit and delete users and roles on each instance of a Tarantool
 cluster through the |tcm| web interface.
@@ -37,7 +37,3 @@ provides a text editor where you can write migration scripts in Lua and apply th
 to the cluster.
 
 Learn more about migrations in Tarantool :ref:`migrations`.
-
-Console command Add/Delete cluster
-Added initial settings to tcm.yml config (ability to add clusters via tcm config file)
-Add configuration key for api token enabling

--- a/doc/tooling/tcm/tcm_releases/tcm_1.2.rst
+++ b/doc/tooling/tcm/tcm_releases/tcm_1.2.rst
@@ -7,7 +7,7 @@ Release date: July 30, 2024
 
 Latest release in series: 1.2.0
 
-|tcm_full_name| 1.2 introduces a number of new features that extend and improve its
+|tcm_full_name| 1.2 introduces new features that extend its
 cluster management capabilities. Below is an overview of its key updates.
 
 .. _tcm_releases_1_2_tarantool_users:

--- a/doc/tooling/tcm/tcm_releases/tcm_1.2.rst
+++ b/doc/tooling/tcm/tcm_releases/tcm_1.2.rst
@@ -1,0 +1,43 @@
+.. _tcm_releases_1_2:
+
+Tarantool Cluster Manager 1.2
+=============================
+
+Release date: July 30, 2024
+
+Latest release in series: 1.2.0
+
+|tcm_full_name| 1.2 introduces a number of new features that extend and improve its
+cluster management capabilities. Below is an overview of its key updates.
+
+.. _tcm_releases_1_2_tarantool_users:
+
+Managing Tarantool users
+------------------------
+
+|tcm| 1.2 introduces the ability to manage Tarantool users on connected clusters.
+Previously, you could manage Tarantool users only though the Lua API (:`box.schema <box_schema>` submodule)
+or cluster :ref:`configuration <configuration_credentials_managing_users_roles>`.
+Now you can create, edit and delete users and roles on each instance of a Tarantool
+cluster through the |tcm| web interface.
+
+The tools for managing Tarantool users on a cluster instance are located on the
+**Users** tab of the instance page.
+
+Learn more about Tarantool access model in :ref:`access_control`.
+
+.. _tcm_releases_1_2_migrations:
+
+Migrations
+----------
+
+Since version 1.2.0, |tcm| includes a page for editing and executing :ref:`migrations <migrations>`
+on connected clusters. The new page **Migrations** in the **Cluster** page group
+provides a text editor where you can write migration scripts in Lua and apply them
+to the cluster.
+
+Learn more about migrations in Tarantool :ref:`migrations`.
+
+Console command Add/Delete cluster
+Added initial settings to tcm.yml config (ability to add clusters via tcm config file)
+Add configuration key for api token enabling


### PR DESCRIPTION
Resolves #4411 

- Add a what's new page [TCM > Releases > 1.2](https://docs.d.tarantool.io/en/doc/gh-4411-whatsnew-tcm-12/tooling/tcm/tcm_releases/tcm_1.1/)
- Add TCM 1.2 to the [TCM releases table](https://docs.d.tarantool.io/en/doc/gh-4411-whatsnew-tcm-12/tooling/tcm/tcm_releases/)
- Add new TCM config options [feature.api-token and feature.tqe](https://docs.d.tarantool.io/en/doc/gh-4411-whatsnew-tcm-12/tooling/tcm/tcm_configuration_reference/#tcm-configuration-reference-feature-api-token)
- Add a note that [API tokens](https://docs.d.tarantool.io/en/doc/gh-4411-whatsnew-tcm-12/tooling/tcm/tcm_access_control/#api-tokens) are disabled by default

Deployment: https://docs.d.tarantool.io/en/doc/gh-4411-whatsnew-tcm-12/tooling/tcm/tcm_releases/tcm_1.2/