### PR TITLE
datetime: describe tarantool.build.tzdata_version

### DIFF
--- a/doc/reference/reference_lua/datetime.rst
+++ b/doc/reference/reference_lua/datetime.rst
@@ -1049,7 +1049,9 @@ the Earth's rotation speed varies in response to climatic and geological events,
 and due to this, UTC leap seconds are irregularly spaced and unpredictable.
 
 Tarantool includes the `Time Zone Database <https://www.iana.org/time-zones>`__
-that beside the time zone description files also contains a leapseconds file.
+that besides the time zone description files also contains a leapseconds file.
+You can use the Lua module :ref:`tarantool <tarantool-module>` to get a used
+version of ``tzdata``.
 
 This section describes how the ``datetime`` module supports leap seconds:
 

--- a/doc/reference/reference_lua/tarantool.rst
+++ b/doc/reference/reference_lua/tarantool.rst
@@ -49,3 +49,14 @@ the tarantool module is recommended.
     ---
     - 108.64641499519
     ...
+
+Tarantool includes parts of `tzdata <https://www.iana.org/time-zones>`__ package
+and uses its database for a correct time zone support. Since :doc:`3.2.0 </release/3.2.0>`,
+you can get a used version of ``tzdata``:
+
+..  code-block:: tarantoolsession
+
+    tarantool> tarantool.build.tzdata_version
+    ---
+    - 2022a
+    ...


### PR DESCRIPTION
Stage:

- https://docs.d.tarantool.io/en/doc/gh-4434-tzdata_version/reference/reference_lua/tarantool/
- https://docs.d.tarantool.io/en/doc/gh-4434-tzdata_version/reference/reference_lua/datetime/

The patch describes `tarantool.build.tzdata_version`.

Closes #4424