### PR TITLE
Update docs for the 'box.info' module

### DIFF
--- a/doc/reference/configuration/cfg_replication.rst
+++ b/doc/reference/configuration/cfg_replication.rst
@@ -722,6 +722,21 @@
     Specify the instance name.
     This value must be unique in a replica set.
 
+    The following rules are applied to instance names:
+
+    -   The maximum number of symbols is 63.
+    -   Should start with a letter.
+    -   Can contain lowercase letters (a-z). If uppercase letters are used, they are converted to lowercase.
+    -   Can contain digits (0-9).
+    -   Can contain the following characters: ``-``, ``_``.
+
+    To change or remove the specified name, you should temporarily set the :ref:`box.cfg.force_recovery <cfg_binary_logging_snapshots-force_recovery>` configuration option to ``true``.
+    When all the names are updated and all the instances synced, ``box.cfg.force_recovery`` can be set back to ``false``.
+
+    ..  NOTE::
+
+        The instance name is persisted in the :ref:`box.space._cluster <box_space-cluster>` system space.
+
     See also: :ref:`box_info_name`
 
     |
@@ -739,6 +754,15 @@
     Specify the name of a replica set to which this instance belongs.
     This value must be the same for all instances of the replica set.
 
+    See the :ref:`instance_name <cfg_replication-instance_name>` description to learn:
+
+    -   which rules are applied to names
+    -   how to change or remove an already specified name
+
+    ..  NOTE::
+
+        The replica set name is persisted in the :ref:`box.space._schema <box_space-schema>` system space.
+
     See also: :ref:`box_info_replicaset`
 
     |
@@ -755,6 +779,15 @@
 
     Specify the name of a cluster to which this instance belongs.
     This value must be the same for all instances of the cluster.
+
+    See the :ref:`instance_name <cfg_replication-instance_name>` description to learn:
+
+    -   which rules are applied to names
+    -   how to change or remove an already specified name
+
+    ..  NOTE::
+
+        The cluster name is persisted in the :ref:`box.space._schema <box_space-schema>` system space.
 
     See also: :ref:`box_info_cluster`
 

--- a/doc/reference/configuration/cfg_replication.rst
+++ b/doc/reference/configuration/cfg_replication.rst
@@ -16,6 +16,10 @@
 * :ref:`election_mode <cfg_replication-election_mode>`
 * :ref:`election_timeout <cfg_replication-election_timeout>`
 * :ref:`election_fencing_mode <cfg_replication-election_fencing_mode>`
+* :ref:`instance_name <cfg_replication-instance_name>`
+* :ref:`replicaset_name <cfg_replication-replicaset_name>`
+* :ref:`cluster_name <cfg_replication-cluster_name>`
+
 
 .. _cfg_replication-replication:
 
@@ -708,3 +712,54 @@
     | Default: 'soft'
     | Environment variable: TT_ELECTION_FENCING_MODE
     | Dynamic: yes
+
+.. _cfg_replication-instance_name:
+
+.. confval:: instance_name
+
+    Since version :doc:`3.0.0 </release/3.0.0>`.
+
+    Specify the instance name.
+    This value must be unique in a replica set.
+
+    See also: :ref:`box_info_name`
+
+    |
+    | Type: string
+    | Default: null
+    | Environment variable: TT_INSTANCE_NAME
+    | Dynamic: no
+
+.. _cfg_replication-replicaset_name:
+
+.. confval:: replicaset_name
+
+    Since version :doc:`3.0.0 </release/3.0.0>`.
+
+    Specify the name of a replica set to which this instance belongs.
+    This value must be the same for all instances of the replica set.
+
+    See also: :ref:`box_info_replicaset`
+
+    |
+    | Type: string
+    | Default: null
+    | Environment variable: TT_REPLICASET_NAME
+    | Dynamic: no
+
+.. _cfg_replication-cluster_name:
+
+.. confval:: cluster_name
+
+    Since version :doc:`3.0.0 </release/3.0.0>`.
+
+    Specify the name of a cluster to which this instance belongs.
+    This value must be the same for all instances of the cluster.
+
+    See also: :ref:`box_info_cluster`
+
+    |
+    | Type: string
+    | Default: null
+    | Environment variable: TT_CLUSTER_NAME
+    | Dynamic: no

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -2548,6 +2548,14 @@ The ``groups`` section provides the ability to define the :ref:`full topology of
 
     A group name.
 
+    The following rules are applied to group names:
+
+    -   The maximum number of symbols is 63.
+    -   Should start with a letter.
+    -   Can contain lowercase letters (a-z).
+    -   Can contain digits (0-9).
+    -   Can contain the following characters: ``-``, ``_``.
+
 .. _configuration_reference_groups_name_replicasets:
 
 .. confval:: groups.<group_name>.replicasets
@@ -2581,6 +2589,9 @@ replicasets
 .. confval:: replicasets.<replicaset_name>
 
     A replica set name.
+
+    Note that the rules applied to a replica set name are the same as for groups.
+    Learn more in :ref:`groups.\<group_name\> <configuration_reference_groups_name>`.
 
 .. _configuration_reference_replicasets_name_leader:
 
@@ -2644,6 +2655,9 @@ instances
 .. confval:: instances.<instance_name>
 
     An instance name.
+
+    Note that the rules applied to an instance name are the same as for groups.
+    Learn more in :ref:`groups.\<group_name\> <configuration_reference_groups_name>`.
 
 .. _configuration_reference_instances_name_config_parameter:
 

--- a/doc/reference/reference_lua/box_info.rst
+++ b/doc/reference/reference_lua/box_info.rst
@@ -31,7 +31,7 @@ Below is a list of all ``box.info`` functions and members.
            - The instance's state in regard to configuration
 
         *  - :doc:`./box_info/election`
-           - The current state of this replica set node in regards to leader election
+           - The current state of this replica set node in regard to leader election
 
         *  - :doc:`./box_info/gc`
            - Get information about the Tarantool garbage collector

--- a/doc/reference/reference_lua/box_info.rst
+++ b/doc/reference/reference_lua/box_info.rst
@@ -6,60 +6,7 @@ Submodule box.info
 
 .. module:: box.info
 
-The ``box.info`` submodule provides access to information about server instance
-variables.
-
-* **cluster.uuid** is the UUID of the replica set.
-  Every instance in a replica set will have the same ``cluster.uuid`` value.
-  This value is also stored in :ref:`box.space._schema <box_space-schema>`
-  system space.
-* **gc()** returns the state of the
-  :ref:`Tarantool garbage collector <cfg_checkpoint_daemon-garbage-collector>`
-  including the checkpoints and their consumers (users); see details
-  :doc:`here </reference/reference_lua/box_info/gc>`.
-* **id** corresponds to :samp:`replication[{n}].id`
-  (see :doc:`here </reference/reference_lua/box_info/replication>`).
-* **lsn** corresponds to :samp:`replication[{n}].lsn`
-  (see :doc:`here </reference/reference_lua/box_info/replication>`).
-* **listen** returns a real address to which an instance was bound
-  (see :doc:`here </reference/reference_lua/box_info/listen>`).
-* **memory()** returns the statistics about memory
-  (see :doc:`here </reference/reference_lua/box_info/memory>`).
-* **pid** is the process ID. This value is also shown by
-  :ref:`tarantool <tarantool-build>` module
-  and by the Linux command ``ps -A``.
-* **ro** is ``true`` if the instance is in read-only mode
-  (same as :ref:`read_only <cfg_basic-read_only>` in ``box.cfg{}``),
-  or if status is 'orphan'.
-* **ro_reason** is ``nil`` if the instance is in writable mode.
-  When the field is not ``nil``, it contains the reason why the instance is read-only.
-  Possible error reasons: ``election``, ``synchro``, ``config``, and ``orphan``
-  (see :ref:`box.info.ro_reason <box_info_ro-reason>` for details).
-* **signature** is the sum of all ``lsn`` values from each :ref:`vector clock <replication-vector>`
-  (**vclock**) for all instances in the replica set.
-* **sql().cache.size** is the number of bytes in the SQL prepared statement cache.
-* **sql().cache.stmt_count** is the number of statements in the SQL prepared statement cache.
-* **status** is the current state of the instance. It can be:
-
-  * ``running`` -- the instance is loaded,
-  * ``loading`` -- the instance is either recovering xlogs/snapshots or bootstrapping,
-  * ``orphan`` --  the instance has not (yet) succeeded in joining the required
-    number of masters (see :ref:`orphan status <replication-orphan_status>`),
-  * ``hot_standby`` -- the instance is :ref:`standing by <index-hot_standby>` another instance.
-* **uptime** is the number of seconds since the instance started.
-  This value can also be retrieved with
-  :ref:`tarantool.uptime() <tarantool-build>`.
-* **uuid** corresponds to :samp:`replication[{n}].uuid`
-  (see :doc:`here </reference/reference_lua/box_info/replication>`).
-* **vclock** is a table with the vclock values of all instances in a replica set which have made data changes.
-* **version** is the Tarantool version. This value is also shown by
-  :ref:`tarantool -V <index-tarantool_version>`.
-* **vinyl()** returns runtime statistics for the vinyl storage engine.
-  This function is deprecated, use
-  :ref:`box.stat.vinyl() <box_introspection-box_stat_vinyl>` instead.
-* **election** shows the current state of a replica set node regarding leader
-  election (see :doc:`here </reference/reference_lua/box_info/election>`).
-
+The ``box.info`` submodule provides access to information about a running Tarantool instance.
 Below is a list of all ``box.info`` functions and members.
 
 ..  container:: table
@@ -68,53 +15,125 @@ Below is a list of all ``box.info`` functions and members.
     ..  rst-class:: left-align-column-2
 
     ..  list-table::
-        :widths: 25 75
+        :widths: 30 70
         :header-rows: 1
 
         *   - Name
             - Use
 
         *  - :doc:`./box_info/info`
-           - Return all keys and values provided in the submodule
+           - Get all keys and values provided by the ``box.info`` submodule
+
+        *  - :doc:`./box_info/cluster`
+           - Information about the cluster to which the current instance belongs
+
+        *  - :doc:`./box_info/config`
+           - The instance's state in regard to configuration
+
+        *  - :doc:`./box_info/election`
+           - The current state of this replica set node in regards to leader election
 
         *  - :doc:`./box_info/gc`
-           - Return info about garbage collector
+           - Get information about the Tarantool garbage collector
+
+        *  - :doc:`./box_info/hostname`
+           - The hostname that identifies a machine the current instance is running on
+
+        *  - :doc:`./box_info/id`
+           - A numeric identifier of the current instance within the replica set
+
+        *  - :doc:`./box_info/listen`
+           - A real address to which an instance is bound
+
+        *  - :doc:`./box_info/lsn`
+           - A log sequence number (LSN) for the latest entry in the instance's write-ahead log (WAL)
 
         *  - :doc:`./box_info/memory`
-           - Return info about memory usage
+           - Get information about memory usage for the current instance
+
+        *  - :doc:`./box_info/name`
+           - The name of the current instance
+
+        *  - :doc:`./box_info/package`
+           - The package name
+
+        *  - :doc:`./box_info/pid`
+           - Get a process ID of the current instance
+
+        *  - :doc:`./box_info/replicaset`
+           - Information about the replica set to which the current instance belongs
+
+        *  - :doc:`./box_info/replication`
+           - Statistics for all instances in the replica set
 
         *  - :doc:`./box_info/replication_anon`
            - List all the anonymous replicas following the instance
 
-        *  - :doc:`./box_info/replication`
-           - Return statistics for all instances in the replica set
-
-        *  - :doc:`./box_info/listen`
-           - Return a real address to which an instance was bound
-
-        *  - :doc:`./box_info/election`
-           - Show the current state of a replica set node
-             in regards to leader election
-
-        *  - :doc:`./box_info/synchro`
-           - Show the current state of synchronous replication
+        *  - :doc:`./box_info/ro`
+           - The current mode of the instance (writable or read-only)
 
         *  - :doc:`./box_info/ro_reason`
-           - Show the current mode of an instance (writable or read-only)
+           - The reason why the current instance is read-only
 
         *  - :doc:`./box_info/schema_version`
-           - Show the database schema version
+           - The database schema version
+
+        *  - :doc:`./box_info/signature`
+           - The sum of all ``lsn`` values from each vector clock for all instances in the replica set
+
+        *  - :doc:`./box_info/sql`
+           - Get information about the cache for all SQL prepared statements
+
+        *  - :doc:`./box_info/status`
+           - The current state of the instance
+
+        *  - :doc:`./box_info/synchro`
+           - The current state of synchronous replication
+
+        *  - :doc:`./box_info/uptime`
+           - The number of seconds since the instance started
+
+        *  - :doc:`./box_info/uuid`
+           - A globally unique identifier of the current instance
+
+        *  - :doc:`./box_info/vclock`
+           - A table with the vclock values of all instances in a replica set which have made data changes
+
+        *  - :doc:`./box_info/version`
+           - The Tarantool version
+
+        *  - :doc:`./box_info/vinyl`
+           - (Deprecated) Get runtime statistics for the vinyl storage engine
+
 
 ..  toctree::
     :hidden:
 
     box_info/info
-    box_info/gc
-    box_info/memory
-    box_info/replication_anon
-    box_info/replication
-    box_info/listen
+    box_info/cluster
+    box_info/config
     box_info/election
-    box_info/synchro
+    box_info/gc
+    box_info/hostname
+    box_info/id
+    box_info/listen
+    box_info/lsn
+    box_info/memory
+    box_info/name
+    box_info/package
+    box_info/pid
+    box_info/replicaset
+    box_info/replication
+    box_info/replication_anon
+    box_info/ro
     box_info/ro_reason
     box_info/schema_version
+    box_info/signature
+    box_info/sql
+    box_info/status
+    box_info/synchro
+    box_info/uptime
+    box_info/uuid
+    box_info/vclock
+    box_info/version
+    box_info/vinyl

--- a/doc/reference/reference_lua/box_info/cluster.rst
+++ b/doc/reference/reference_lua/box_info/cluster.rst
@@ -1,0 +1,18 @@
+.. _box_info_cluster:
+
+================================================================================
+box.info.cluster
+================================================================================
+
+.. module:: box.info
+
+.. data:: cluster
+
+    Information about the cluster to which the current instance belongs.
+    The returned table contains the following fields:
+
+    *   ``name`` -- the cluster name
+
+    See also: :ref:`compat.box_info_cluster_meaning <configuration_reference_compat_cluster_meaning>`
+
+    :rtype: table

--- a/doc/reference/reference_lua/box_info/config.rst
+++ b/doc/reference/reference_lua/box_info/config.rst
@@ -1,0 +1,29 @@
+.. _box_info_config:
+
+================================================================================
+box.info.config
+================================================================================
+
+.. module:: box.info
+
+.. data:: config
+
+    Since: :doc:`3.2.0 </release/3.2.0>`
+
+    The instance's state in regard to configuration.
+    Note that ``box.info.config`` returns the instance's state obtained using :ref:`config:info('v2') <config_api_reference_info>`.
+
+    :rtype: table
+
+    **Example**
+
+    ..  code-block:: tarantoolsession
+
+        sharded_cluster_crud:storage-a-002> box.info.config
+        ---
+        - status: ready
+          meta:
+            last: &0 []
+            active: *0
+          alerts: []
+        ...

--- a/doc/reference/reference_lua/box_info/election.rst
+++ b/doc/reference/reference_lua/box_info/election.rst
@@ -8,9 +8,9 @@ box.info.election
 
 ..  data:: election
 
-    Since version :doc:`2.6.1 </release/2.6.1>`.
+    Since: :doc:`2.6.1 </release/2.6.1>`
 
-    Show the current state of a replica set node in regards to :ref:`leader election <repl_leader_elect>`.
+    The current state of this replica set node in regards to :ref:`leader election <repl_leader_elect>`.
     The following information is provided:
 
     *   ``state`` -- the election state (mode) of the node. Possible values are ``leader``, ``follower``, or ``candidate``.

--- a/doc/reference/reference_lua/box_info/election.rst
+++ b/doc/reference/reference_lua/box_info/election.rst
@@ -10,7 +10,7 @@ box.info.election
 
     Since: :doc:`2.6.1 </release/2.6.1>`
 
-    The current state of this replica set node in regards to :ref:`leader election <repl_leader_elect>`.
+    The current state of this replica set node in regard to :ref:`leader election <repl_leader_elect>`.
     The following information is provided:
 
     *   ``state`` -- the election state (mode) of the node. Possible values are ``leader``, ``follower``, or ``candidate``.

--- a/doc/reference/reference_lua/box_info/gc.rst
+++ b/doc/reference/reference_lua/box_info/gc.rst
@@ -8,19 +8,17 @@ box.info.gc()
 
 .. function:: gc()
 
-    The **gc** function of ``box.info`` gives the ``admin`` user a
-    picture of the factors that affect the
-    :ref:`Tarantool garbage collector <cfg_checkpoint_daemon-garbage-collector>`.
+    Get information about the :ref:`Tarantool garbage collector <configuration_persistence_garbage_collector>`.
     The garbage collector compares vclock (:ref:`vector clock <replication-vector>`)
     values of users and checkpoints, so a look at ``box.info.gc()`` may show why the
     garbage collector has not removed old WAL files, or show what it may soon remove.
 
-    * **gc().consumers** -- a list of users whose requests might affect the garbage collector.
-    * **gc().checkpoints** -- a list of preserved checkpoints.
-    * **gc().checkpoints[n].references** -- a list of references to a checkpoint.
-    * **gc().checkpoints[n].vclock** -- a checkpoint's vclock value.
-    * **gc().checkpoints[n].signature** -- a sum of a checkpoint's vclock's components.
-    * **gc().checkpoint_is_in_progress** -- true if a checkpoint is in progress, otherwise false
-    * **gc().vclock** -- the garbage collector's vclock.
-    * **gc().signature** -- the sum of the garbage collector's checkpoint's components.
-    * **gc().wal_retention_vclock** -- a vclock value of the oldest write-ahead log file protected from removing by the garbage collector by using the :ref:`wal.retention_period <configuration_reference_wal_retention_period>` option.
+    * ``consumers`` -- a list of users whose requests might affect the garbage collector.
+    * ``checkpoints`` -- a list of preserved checkpoints.
+    * ``checkpoints[n].references`` -- a list of references to a checkpoint.
+    * ``checkpoints[n].vclock`` -- a checkpoint's vclock value.
+    * ``checkpoints[n].signature`` -- a sum of a checkpoint's vclock's components.
+    * ``checkpoint_is_in_progress`` -- true if a checkpoint is in progress, otherwise false
+    * ``vclock`` -- the garbage collector's vclock.
+    * ``signature`` -- the sum of the garbage collector's checkpoint's components.
+    * ``wal_retention_vclock`` -- a vclock value of the oldest write-ahead log file protected from removing by the garbage collector by using the :ref:`wal.retention_period <configuration_reference_wal_retention_period>` option.

--- a/doc/reference/reference_lua/box_info/hostname.rst
+++ b/doc/reference/reference_lua/box_info/hostname.rst
@@ -1,0 +1,15 @@
+.. _box_info_hostname:
+
+================================================================================
+box.info.hostname
+================================================================================
+
+.. module:: box.info
+
+.. data:: hostname
+
+    Since: :doc:`3.2.0 </release/3.2.0>`
+
+    The hostname that identifies a machine the current instance is running on.
+
+    :rtype: string

--- a/doc/reference/reference_lua/box_info/id.rst
+++ b/doc/reference/reference_lua/box_info/id.rst
@@ -1,0 +1,15 @@
+.. _box_info_id:
+
+================================================================================
+box.info.id
+================================================================================
+
+.. module:: box.info
+
+.. data:: id
+
+    A numeric identifier of the current instance within the replica set.
+    This value corresponds to ``replication[{n}].id``.
+    Learn more in :ref:`box_info_replication`.
+
+    :rtype: number

--- a/doc/reference/reference_lua/box_info/info.rst
+++ b/doc/reference/reference_lua/box_info/info.rst
@@ -8,6 +8,7 @@ box.info()
 
 .. function:: box.info()
 
+    Get all keys and values provided by the ``box.info`` submodule.
     Since ``box.info`` contents are dynamic, it's not possible to iterate over
     keys with the Lua ``pairs()`` function. For this purpose, ``box.info()``
     builds and returns a Lua table with all keys and values provided in the
@@ -16,36 +17,81 @@ box.info()
     :return: keys and values in the submodule
     :rtype:  table
 
-    **Example:**
+    **Example**
 
     This example is for a master-replica set that contains one master instance
     and one replica instance. The request was issued at the replica instance.
 
-    .. code-block:: tarantoolsession
+    ..  code-block:: tarantoolsession
 
-        tarantool> box.info()
+        sharded_cluster_crud:storage-a-002> box.info()
         ---
-        - version: 2.4.0-251-gc44ed3c08
-          id: 1
-          ro: false
-          uuid: 1738767b-afa3-4987-b485-c333cf83415b
-          package: Tarantool
-          cluster:
-            uuid: 40ee7f0f-7070-4650-8883-801e7014407c
-          listen: '[::1]:57122'
+        - version: 3.2.0-entrypoint-218-gf8d77dbec
+          id: 2
+          ro: true
+          uuid: 5a879b0e-9b53-4053-980a-be1a39ad1166
+          pid: 12059
+          replicaset:
+            uuid: 90dc4d6c-3f7d-45e5-aa5a-55903b0a79c9
+            name: storage-a
+          schema_version: 87
+          listen: 127.0.0.1:3303
+          replication_anon:
+            count: 0
           replication:
             1:
               id: 1
-              uuid: 1738767b-afa3-4987-b485-c333cf83415b
-              lsn: 16
-          signature: 16
+              uuid: ffb1b8bb-d59f-4eee-ad3e-91058e6f5486
+              lsn: 1092
+              upstream:
+                status: follow
+                idle: 0.99728900000082
+                peer: replicator@127.0.0.1:3302
+                lag: 0.00025296211242676
+              name: storage-a-001
+              downstream:
+                status: follow
+                idle: 0.18575600000077
+                vclock: {1: 1092}
+                lag: 0
+            2:
+              id: 2
+              uuid: 5a879b0e-9b53-4053-980a-be1a39ad1166
+              lsn: 0
+              name: storage-a-002
+          package: Tarantool
+          hostname: demo.example.com
+          election:
+            state: follower
+            vote: 0
+            leader: 0
+            term: 1
+          signature: 1092
+          synchro:
+            queue:
+              owner: 0
+              confirm_lag: 0
+              term: 0
+              age: 0
+              len: 0
+              busy: false
+            quorum: 2
           status: running
-          vinyl: []
-          uptime: 21
-          lsn: 16
           sql: []
-          gc: []
-          pid: 20293
+          vclock: {1: 1092}
+          uptime: 229
+          lsn: 0
+          vinyl: []
+          ro_reason: config
           memory: []
-          vclock: {1: 16}
+          gc: []
+          cluster:
+            name: null
+          name: storage-a-002
+          config:
+            status: ready
+            meta:
+              last: &0 []
+              active: *0
+            alerts: []
         ...

--- a/doc/reference/reference_lua/box_info/listen.rst
+++ b/doc/reference/reference_lua/box_info/listen.rst
@@ -8,30 +8,20 @@ box.info.listen
 
 .. data:: listen
 
-    Since version :doc:`2.4.1 </release/2.4.1>`.
-    Return a real address to which an instance was bound. For example, if
-    ``box.cfg{listen}`` was set with a zero port, ``box.info.listen`` will show
-    a real port. The address is stored as a string:
+    Since: :doc:`2.4.1 </release/2.4.1>`
 
-    * unix/:<path> for UNIX domain sockets
-    * <ip>:<port> for IPv4
-    * [ip]:<port> for IPv6
+    A real address to which an instance is bound.
+    If an instance does not listen to anything, ``box.info.listen`` is ``nil``.
 
-    If an instance does not listen to anything, ``box.info.listen`` is nil.
+    To learn how to configure URIs used to listen for incoming requests, see :ref:`iproto.listen <configuration_reference_iproto_listen>`.
 
-    **Example:**
+    :rtype: string
 
-    .. code-block:: tarantoolsession
+    **Example**
 
-      tarantool> box.cfg{listen=0}
-      ---
-      ...
-      tarantool> box.cfg.listen
-      ---
-      - '0'
-      ...
-      tarantool> box.info.listen
-      ---
-      - 0.0.0.0:44149
-      ...
+    ..  code-block:: tarantoolsession
 
+        sharded_cluster_crud:storage-a-002> box.info.listen
+        ---
+        - 127.0.0.1:3303
+        ...

--- a/doc/reference/reference_lua/box_info/lsn.rst
+++ b/doc/reference/reference_lua/box_info/lsn.rst
@@ -1,0 +1,15 @@
+.. _box_info_lsn:
+
+================================================================================
+box.info.lsn
+================================================================================
+
+.. module:: box.info
+
+.. data:: lsn
+
+    A :ref:`log sequence number <replication-mechanism>` (LSN) for the latest entry in the instance's :ref:`write-ahead log <index-box_persistence>` (WAL).
+    This value corresponds to ```replication[{n}].lsn``.
+    Learn more in :ref:`box_info_replication`.
+
+    :rtype: number

--- a/doc/reference/reference_lua/box_info/memory.rst
+++ b/doc/reference/reference_lua/box_info/memory.rst
@@ -8,42 +8,40 @@ box.info.memory()
 
 .. function:: memory()
 
-    The **memory** function of ``box.info`` gives the ``admin`` user a
-    picture of the whole Tarantool instance.
+    Get information about memory usage for the current instance.
 
     .. NOTE::
 
         To get a picture of the vinyl subsystem, use
         :ref:`box.stat.vinyl() <box_introspection-box_stat_vinyl>` instead.
 
-    * **memory().cache** -- number of bytes used for caching user data. The
+    * ``cache`` -- the number of bytes used for caching user data. The
       memtx storage engine does not require a cache, so in fact this is
       the number of bytes in the cache for the tuples stored for the vinyl
       storage engine.
-    * **memory().data** -- number of bytes used for storing user data
+    * ``data`` -- the number of bytes used for storing user data
       (the tuples) with the memtx engine and with level 0 of the vinyl engine,
       without taking memory fragmentation into account.
-    * **memory().index** -- number of bytes used for indexing user data,
+    * ``index`` -- the number of bytes used for indexing user data,
       including memtx and vinyl memory tree extents, the vinyl page index,
       and the vinyl bloom filters.
-    * **memory().lua** -- number of bytes used for Lua runtime.
-    * **memory().net** -- number of bytes used for network input/output buffers.
-    * **memory().tx** -- number of bytes in use by active transactions.
+    * ``lua`` -- the number of bytes used for Lua runtime.
+    * ``net`` -- the number of bytes used for network input/output buffers.
+    * ``tx`` -- the number of bytes in use by active transactions.
       For the vinyl storage engine, this is the total size of all allocated
       objects (struct ``txv``, struct ``vy_tx``, struct ``vy_read_interval``)
       and tuples pinned for those objects.
 
-    An example with a minimum allocation while only the memtx storage engine is
-    in use:
+    **Example**
 
-    .. code-block:: tarantoolsession
+    ..  code-block:: tarantoolsession
 
-        tarantool> box.info.memory()
+        sharded_cluster_crud:storage-a-002> box.info.memory()
         ---
         - cache: 0
-          data: 6552
+          data: 43848
+          index: 1130496
+          lua: 10516849
+          net: 1572864
           tx: 0
-          lua: 1315567
-          net: 98304
-          index: 1196032
         ...

--- a/doc/reference/reference_lua/box_info/name.rst
+++ b/doc/reference/reference_lua/box_info/name.rst
@@ -1,0 +1,25 @@
+.. _box_info_name:
+
+================================================================================
+box.info.name
+================================================================================
+
+.. module:: box.info
+
+.. data:: name
+
+    Since: :doc:`3.0.0 </release/3.0.0>`
+
+    The name of the current instance.
+    You can specify the names of instances when :ref:`configuring <configuration>` a cluster topology.
+
+    :rtype: string
+
+    **Example**
+
+    ..  code-block:: tarantoolsession
+
+        sharded_cluster_crud:storage-a-002> box.info.name
+        ---
+        - storage-a-002
+        ...

--- a/doc/reference/reference_lua/box_info/package.rst
+++ b/doc/reference/reference_lua/box_info/package.rst
@@ -8,8 +8,11 @@ box.info.package
 
 .. data:: package
 
-    The package name.
+    The package name. It can be:
 
-    See also: :ref:`tarantool --version <index-tarantool_version>`
+    -   ``Tarantool``
+    -   ``Tarantool Enterprise``
+
+    See also: :ref:`tarantool.package <tarantool-module>`, :ref:`tarantool --version <index-tarantool_version>`
 
     :rtype: string

--- a/doc/reference/reference_lua/box_info/package.rst
+++ b/doc/reference/reference_lua/box_info/package.rst
@@ -1,0 +1,15 @@
+.. _box_info_package:
+
+================================================================================
+box.info.package
+================================================================================
+
+.. module:: box.info
+
+.. data:: package
+
+    The package name.
+
+    See also: :ref:`tarantool --version <index-tarantool_version>`
+
+    :rtype: string

--- a/doc/reference/reference_lua/box_info/pid.rst
+++ b/doc/reference/reference_lua/box_info/pid.rst
@@ -1,0 +1,17 @@
+.. _box_info_pid:
+
+================================================================================
+box.info.pid
+================================================================================
+
+.. module:: box.info
+
+.. data:: pid
+
+    A process ID of the current instance.
+    You can also get the process ID as follows:
+
+    -   Using :ref:`tarantool.pid() <tarantool-build>`.
+    -   Using the ``ps -A`` Linux command.
+
+    :rtype: number

--- a/doc/reference/reference_lua/box_info/replicaset.rst
+++ b/doc/reference/reference_lua/box_info/replicaset.rst
@@ -1,0 +1,21 @@
+.. _box_info_replicaset:
+
+================================================================================
+box.info.replicaset
+================================================================================
+
+.. module:: box.info
+
+.. data:: replicaset
+
+    Since: :doc:`3.0.0 </release/3.0.0>`
+
+    Information about the replica set to which the current instance belongs.
+    The returned table contains the following fields:
+
+    *   ``name`` -- the replica set name
+    *   ``uuid`` -- the replica set UUID
+
+    You can specify the names of replica sets when :ref:`configuring <configuration>` a cluster topology.
+
+    :rtype: table

--- a/doc/reference/reference_lua/box_info/replication.rst
+++ b/doc/reference/reference_lua/box_info/replication.rst
@@ -8,7 +8,7 @@ box.info.replication
 
 ..  data:: replication
 
-    The **replication** section of ``box.info()`` is a table with statistics for all instances in the replica set that the current instance belongs to.
+    The ``replication`` section of :ref:`box.info() <box_info_info>` is a table with statistics for all instances in the replica set that the current instance belongs to.
     To see the example, refer to :ref:`Monitoring a replica set <replication-monitoring>`.
 
     In the following, *n* is the index number of one table item, for example,
@@ -27,6 +27,7 @@ box.info.replication
       :ref:`log sequence number <replication-mechanism>`
       (LSN) for the latest entry in instance *n*'s
       :ref:`write-ahead log <index-box_persistence>` (WAL).
+    * :samp:`replication[{n}].name` is the instance name. See also: :ref:`box_info_name`.
     * :samp:`replication[{n}].upstream` appears (is not ``nil``)
       if the current instance is following or intending to follow instance *n*,
       which ordinarily means
@@ -135,4 +136,3 @@ box.info.replication
       ``status = 'stopped'``, ``message = 'unexpected EOF when reading
       from socket'``, and ``system_message = 'Broken pipe'``.
       See also :ref:`degraded state <replication-recover>`.
-

--- a/doc/reference/reference_lua/box_info/ro.rst
+++ b/doc/reference/reference_lua/box_info/ro.rst
@@ -1,0 +1,23 @@
+..  _box_info_ro:
+
+================================================================================
+box.info.ro
+================================================================================
+
+..  module:: box.info
+
+..  data:: ro
+
+    The current mode of the instance (writable or read-only).
+    Learn more in :ref:`box_info_ro-reason`.
+
+    :rtype: boolean
+
+    **Example**
+
+    ..  code-block:: tarantoolsession
+
+        sharded_cluster_crud:storage-a-002> box.info.ro
+        ---
+        - true
+        ...

--- a/doc/reference/reference_lua/box_info/ro_reason.rst
+++ b/doc/reference/reference_lua/box_info/ro_reason.rst
@@ -8,33 +8,36 @@ box.info.ro_reason
 
 ..  data:: ro_reason
 
-    Since :doc:`2.10.0 </release/2.10.0>`.
-    Show the current mode of an instance (writable or read-only).
-    Contains ``nil`` if the instance is in writable mode.
-    When the field is not ``nil``, reports the reason why the instance is read-only.
+    Since: :doc:`2.10.0 </release/2.10.0>`
 
-    Possible error reasons:
+    The reason why the current instance is read-only.
+    To get whether the current instance is writable or read-only, use :ref:`box_info_ro`.
+    If the instance is in writable mode, ``box.info.ro_reason`` returns ``nil``.
+
+    The possible values returned by ``ro_reason``:
 
     *   ``election`` -- the instance is not the leader.
-        That is, ``box.cfg.election_mode`` is not ``off``.
         See :ref:`box.info.election <box_info_election>` for details.
 
     *   ``synchro`` -- the instance is not the owner of the synchronous transaction queue.
         For details, see :ref:`box.info.synchro <box_info_synchro>`.
 
-    *   ``config`` -- the server instance is in read-only mode.
-        That is, :ref:`box.cfg.read_only <cfg_basic-read_only>` is ``true``.
+    *   ``config`` -- the instance is is :ref:`configured <configuration>` to be read only.
 
     *   ``orphan`` -- the instance is in ``orphan`` state.
         For details, see :ref:`the orphan status page <internals-replication-orphan_status>`.
 
     :rtype: string
 
-    **Example:**
+    **Example**
 
     ..  code-block:: tarantoolsession
 
-        tarantool> box.info.ro_reason
+        sharded_cluster_crud:storage-a-002> box.info.ro
         ---
-        - null
+        - true
+        ...
+        sharded_cluster_crud:storage-a-002> box.info.ro_reason
+        ---
+        - config
         ...

--- a/doc/reference/reference_lua/box_info/schema_version.rst
+++ b/doc/reference/reference_lua/box_info/schema_version.rst
@@ -7,20 +7,21 @@ box.info.schema_version
 
 ..  data:: schema_version
 
-    Since :doc:`2.11.0 </release/2.11.0>`.
-    Show the database schema version.
+    Since: :doc:`2.11.0 </release/2.11.0>`
+
+    The database schema version.
     A schema version is a number that indicates whether the :ref:`database schema <index-box-data_schema_description>` is changed.
     For example, the ``schema_version`` value grows if a :ref:`space <index-box_space>` or :ref:`index <index-box_index>` is added or deleted, or a space, index, or field name is changed.
 
     :rtype: number
 
-    **Example:**
+    **Example**
 
     ..  code-block:: tarantoolsession
 
-        tarantool> box.info.schema_version
+        sharded_cluster_crud:storage-a-002> box.info.schema_version
         ---
-        - 84
+        - 87
         ...
 
     See also: :ref:`IPROTO_SCHEMA_VERSION <internals-iproto-keys-schema_version>`

--- a/doc/reference/reference_lua/box_info/signature.rst
+++ b/doc/reference/reference_lua/box_info/signature.rst
@@ -1,0 +1,13 @@
+.. _box_info_signature:
+
+================================================================================
+box.info.signature
+================================================================================
+
+.. module:: box.info
+
+.. data:: signature
+
+    The sum of all ``lsn`` values from each :ref:`vector clock <replication-vector>` (**vclock**) for all instances in the replica set the current instance belongs to.
+
+    :rtype: number

--- a/doc/reference/reference_lua/box_info/sql.rst
+++ b/doc/reference/reference_lua/box_info/sql.rst
@@ -1,0 +1,18 @@
+.. _box_info_sql:
+
+================================================================================
+box.info.sql
+================================================================================
+
+.. module:: box.info
+
+.. data:: sql
+
+    Get information about the cache for all :ref:`SQL prepared statements <box-sql_box_prepare>`.
+    The returned table contains the following fields:
+
+    -   ``cache.size`` -- the actual cache size (in bytes) for all SQL prepared statements.
+        To configure the maximum cache size, use the :ref:`sql.cache_size <configuration_reference_sql_cache_size>` option.
+    -   ``cache.stmt_count`` -- the number of statements in the SQL prepared statement cache.
+
+    :rtype: table

--- a/doc/reference/reference_lua/box_info/status.rst
+++ b/doc/reference/reference_lua/box_info/status.rst
@@ -1,0 +1,18 @@
+.. _box_info_status:
+
+================================================================================
+box.info.status
+================================================================================
+
+.. module:: box.info
+
+.. data:: status
+
+    The current state of the instance. It can be:
+
+    *   ``running`` -- the instance is loaded
+    *   ``loading`` -- the instance is either recovering xlogs/snapshots or bootstrapping
+    *   ``orphan`` --  the instance has not (yet) succeeded in joining the required number of masters (see :ref:`orphan status <replication-orphan_status>`)
+    *   ``hot_standby`` -- the instance is :ref:`standing by <configuration_reference_database_hot_standby>` another instance
+
+    :rtype: string

--- a/doc/reference/reference_lua/box_info/synchro.rst
+++ b/doc/reference/reference_lua/box_info/synchro.rst
@@ -10,7 +10,7 @@ box.info.synchro
 
     Since version :doc:`2.8.1 </release/2.8.1>`.
 
-    Show the current state of synchronous replication.
+    The current state of synchronous replication.
 
     In :ref:`synchronous replication <repl_sync>`, transaction is considered committed only after achieving
     the required quorum number.

--- a/doc/reference/reference_lua/box_info/uptime.rst
+++ b/doc/reference/reference_lua/box_info/uptime.rst
@@ -1,0 +1,14 @@
+.. _box_info_uptime:
+
+================================================================================
+box.info.uptime
+================================================================================
+
+.. module:: box.info
+
+.. data:: uptime
+
+    The number of seconds since the instance started.
+    This value can also be retrieved with :ref:`tarantool.uptime() <tarantool-build>`.
+
+    :rtype: number

--- a/doc/reference/reference_lua/box_info/uuid.rst
+++ b/doc/reference/reference_lua/box_info/uuid.rst
@@ -1,0 +1,15 @@
+.. _box_info_uuid:
+
+================================================================================
+box.info.uuid
+================================================================================
+
+.. module:: box.info
+
+.. data:: uuid
+
+    A globally unique identifier of the current instance.
+    This value corresponds to ``replication[{n}].uuid``.
+    Learn more in :ref:`box_info_replication`.
+
+    :rtype: string

--- a/doc/reference/reference_lua/box_info/vclock.rst
+++ b/doc/reference/reference_lua/box_info/vclock.rst
@@ -1,0 +1,13 @@
+.. _box_info_vclock:
+
+================================================================================
+box.info.vclock
+================================================================================
+
+.. module:: box.info
+
+.. data:: vclock
+
+    A table with the vclock values of all instances in a replica set which have made data changes.
+
+    :rtype: table

--- a/doc/reference/reference_lua/box_info/version.rst
+++ b/doc/reference/reference_lua/box_info/version.rst
@@ -1,0 +1,15 @@
+.. _box_info_version:
+
+================================================================================
+box.info.version
+================================================================================
+
+.. module:: box.info
+
+.. data:: version
+
+    The Tarantool version.
+
+    See also: :ref:`tarantool --version <index-tarantool_version>`
+
+    :rtype: string

--- a/doc/reference/reference_lua/box_info/version.rst
+++ b/doc/reference/reference_lua/box_info/version.rst
@@ -10,6 +10,6 @@ box.info.version
 
     The Tarantool version.
 
-    See also: :ref:`tarantool --version <index-tarantool_version>`
+    See also: :ref:`tarantool.version <tarantool-module>`, :ref:`tarantool --version <index-tarantool_version>`
 
     :rtype: string

--- a/doc/reference/reference_lua/box_info/vinyl.rst
+++ b/doc/reference/reference_lua/box_info/vinyl.rst
@@ -1,0 +1,12 @@
+.. _box_info_vinyl:
+
+================================================================================
+box.info.vinyl()
+================================================================================
+
+.. module:: box.info
+
+.. function:: vinyl()
+
+    Get runtime statistics for the vinyl storage engine.
+    This function is deprecated, use :ref:`box.stat.vinyl() <box_introspection-box_stat_vinyl>` instead.


### PR DESCRIPTION
This PR updates the `box.info` documentation to make its quality a bit better:
- All functions/fields exposed by `box.info` now have their own pages.
- The index page and the table of contents are consistent now and list all module members in alphabetical order.
- All the descriptions look more consistent now.

PR also includes updates introduced in v3.0.0 and later, for example, [box.info.config](https://github.com/tarantool/doc/issues/4238),  [box.info.hostname](https://github.com/tarantool/doc/issues/3473). See the staging here: https://docs.d.tarantool.io/en/doc/update-box-info/reference/reference_lua/box_info/

Also some new `box.cfg` options are documented (`instance_name`, `replicaset_name`, `cluster_name`): https://docs.d.tarantool.io/en/doc/update-box-info/reference/configuration/#replication

**UPD**: Specified the rules applied to names in the Configuration reference:
https://docs.d.tarantool.io/en/doc/update-box-info/reference/configuration/configuration_reference/#groups 
They are the same as for new `box.cfg` options.