### PR TITLE
Add TCM migrations doc

### DIFF
--- a/doc/tooling/tcm/index.rst
+++ b/doc/tooling/tcm/index.rst
@@ -40,6 +40,7 @@ to read data. LDAP authorization is supported as well.
     tcm_connect_clusters
     tcm_cluster_management/index
     tcm_cluster_data_access
+    tcm_cluster_migrations
     tcm_access_control
     tcm_audit_log
     tcm_configuration

--- a/doc/tooling/tcm/tcm_cluster_migrations.rst
+++ b/doc/tooling/tcm/tcm_cluster_migrations.rst
@@ -1,17 +1,18 @@
 ..  _tcm_cluster_migrations:
 
-Performing migrations in TCM
-============================
+Performing migrations
+=====================
 
 ..  include:: index.rst
     :start-after: ee_note_tcm_start
     :end-before: ee_note_tcm_end
 
 |tcm_full_name| provides a web interface for managing and performing migrations
-in connected clusters. To learn more about migrations in Tarantool, see :ref:`_migrations`.
+in connected clusters. To learn more about migrations in Tarantool, see :ref:`migrations`.
 
-In |tcm|, migrations are named Lua files with code that alters the cluster data
-schema.
+Migrations are named Lua files with code that alters the cluster data schema, for example,
+creates a space, changes it format, or adds indexes. In |tcm|, there is a dedicated
+page on which you can organize migrations, edit their code, and apply them to the cluster.
 
 ..  _tcm_cluster_migrations_manage:
 
@@ -28,18 +29,24 @@ To create a migration:
     .. important::
 
         When naming migrations, remember that they are applied in the lexicographical order.
+        Use ordered numbers as filename prefixes to define the migrations order.
+        For example, ``001_create_table``, ``002_add_column``, ``003_create_index``.
 
-#.  Write the migration code in Lua in the editor window.
+#.  Write the migration code in Lua in the editor window. Use the :ref:`box module reference <box-module>`
+    to learn how to work with Tarantool data schema.
 
-To save the migration without sending it to the cluster instances, click **Save**.
+To save the migration without applying it to the cluster, click **Save**.
+This saves the currently selected migration.
 
-To apply all saved migrations at once, click **Apply**.
+To apply all _saved_ migrations to the cluster at once, click **Apply**.
 
 .. important::
 
-    Applying all saved migrations at once is the only way supported in |tcm|.
-    If a migration has already been applied, it is skipped. To learn to find out
-    the migration status, see :ref:`tcm_cluster_migrations_check`.
+    Applying all saved migrations **at once in the lexicographical** order is the
+    only way to apply migrations in |tcm|. There is no way to select a single  or
+    several migrations to apply.
+    The migrations that are already applied are skipped. To learn how to find out
+    a migration status, see :ref:`tcm_cluster_migrations_check`.
 
 
 ..  _tcm_cluster_migrations_check:
@@ -47,17 +54,19 @@ To apply all saved migrations at once, click **Apply**.
 Checking migrations status
 --------------------------
 
-To check how the loaded migrations are applied to the cluster, use the **Migrations**
-widget on the :ref:`cluster stateboard <tcm_ui_cluster_stateboard>`. It reflects the
-general result of the last applied migration set. If any migration from this set fails
-on certain instances, the widget color changes to yellow. If the set of migrations
-has changes that are not applied yet, the widget becomes grey.
+To check the migration results on the cluster, use the **Migrations** widget on the
+:ref:`cluster stateboard <tcm_ui_cluster_stateboard>`. It reflects the general result
+of the last applied migration set:
 
+-   If all saved migration are applied successfully,
+    the widget is green.
+-   If any migration from this set fails on certain instances, the widget color changes to yellow.
+-   If there are saved migrations that are not applied yet, the widget becomes gray.
 
-Hovering a cursor over the widget shows
-the number of instances on which the migrations have failed.
+Hovering a cursor over the widget shows the number of instances on which the currently
+saved migration set is already applied.
 
 You can also check the status of each particular migration on the **Migrations** page.
 The migrations that are successfully applied are marked with green check marks.
-Failed migrations are marked with red icons. Hover the cursor over the icon to see
-the information about the error.
+Failed migrations are marked with exclamation mark icons (**!**). Hover the cursor over
+the icon to see the information about the error.

--- a/doc/tooling/tcm/tcm_cluster_migrations.rst
+++ b/doc/tooling/tcm/tcm_cluster_migrations.rst
@@ -1,0 +1,63 @@
+..  _tcm_cluster_migrations:
+
+Performing migrations in TCM
+============================
+
+..  include:: index.rst
+    :start-after: ee_note_tcm_start
+    :end-before: ee_note_tcm_end
+
+|tcm_full_name| provides a web interface for managing and performing migrations
+in connected clusters. To learn more about migrations in Tarantool, see :ref:`_migrations`.
+
+In |tcm|, migrations are named Lua files with code that alters the cluster data
+schema.
+
+..  _tcm_cluster_migrations_manage:
+
+Managing migrations
+-------------------
+
+The tools for managing migrations from |tcm| are located on the **Cluster** > **Migrations** page.
+
+To create a migration:
+
+#.  Click **Add** (the **+** icon) on the **Migrations** page.
+#.  Enter the migration name.
+
+    .. important::
+
+        When naming migrations, remember that they are applied in the lexicographical order.
+
+#.  Write the migration code in Lua in the editor window.
+
+To save the migration without sending it to the cluster instances, click **Save**.
+
+To apply all saved migrations at once, click **Apply**.
+
+.. important::
+
+    Applying all saved migrations at once is the only way supported in |tcm|.
+    If a migration has already been applied, it is skipped. To learn to find out
+    the migration status, see :ref:`tcm_cluster_migrations_check`.
+
+
+..  _tcm_cluster_migrations_check:
+
+Checking migrations status
+--------------------------
+
+To check how the loaded migrations are applied to the cluster, use the **Migrations**
+widget on the :ref:`cluster stateboard <tcm_ui_cluster_stateboard>`. It reflects the
+general result of the last applied migration set. If any migration from this set fails
+on certain instances, the widget color changes to yellow. If the set of migrations
+has changes that are not applied yet, the widget becomes grey.
+
+
+Hovering a cursor over the widget shows
+the number of instances on which the migrations have failed.
+
+You can also check the status of each particular migration on the **Migrations** page.
+The migrations that are successfully applied are marked with green check marks.
+Failed migrations are marked with red icons. Hover the cursor over the icon to see
+the information about the error.

--- a/doc/tooling/tcm/tcm_cluster_migrations.rst
+++ b/doc/tooling/tcm/tcm_cluster_migrations.rst
@@ -38,6 +38,12 @@ To create a migration:
 Once you complete writing the migration, save it by clicking **Save**.
 This saves the migration that is currently opened in the editor.
 
+..  _tcm_cluster_migrations_apply:
+
+Appliyng migrations
+-------------------
+
+After you prepare a set of migrations, apply it to the cluster.
 To apply all saved migrations to the cluster at once, click **Apply**.
 
 .. important::
@@ -55,7 +61,7 @@ Migrations that were created but not saved yet are not applied when you click **
 Checking migrations status
 --------------------------
 
-To check the migration results on the cluster, use the **Migrations** widget on the
+To check the migration results on the cluster, use the **Migrated** widget on the
 :ref:`cluster stateboard <tcm_ui_cluster_stateboard>`. It reflects the general result
 of the last applied migration set:
 
@@ -70,4 +76,34 @@ saved migration set is successfully applied.
 You can also check the status of each particular migration on the **Migrations** page.
 The migrations that are successfully applied are marked with green check marks.
 Failed migrations are marked with exclamation mark icons (**!**). Hover the cursor over
-the icon to see the information about the error.
+the icon to see the information about the error. To reapply a failed migration,
+click **Force apply** in the pop-up with the error information.
+
+..  _tcm_cluster_migrations_example:
+
+Migration file example
+----------------------
+
+The following migration code creates a formatted space with two indexes in a
+sharded cluster:
+
+.. code-block:: lua
+
+    local function apply_scenario()
+        local space = box.schema.space.create('customers')
+
+        space:format {
+            { name = 'id',        type = 'number' },
+            { name = 'bucket_id', type = 'number' },
+            { name = 'name',      type = 'string' },
+        }
+
+        space:create_index('primary', { parts = { 'id' } })
+        space:create_index('bucket_id', { parts = { 'bucket_id' }, unique = false })
+    end
+
+    return {
+        apply = {
+            scenario = apply_scenario,
+        },
+    }

--- a/doc/tooling/tcm/tcm_cluster_migrations.rst
+++ b/doc/tooling/tcm/tcm_cluster_migrations.rst
@@ -32,13 +32,13 @@ To create a migration:
         Use ordered numbers as filename prefixes to define the migrations order.
         For example, ``001_create_table``, ``002_add_column``, ``003_create_index``.
 
-#.  Write the migration code in Lua in the editor window. Use the :ref:`box module reference <box-module>`
+#.  Write the migration code in the editor window. Use the :ref:`box.schema module reference <box_schema>`
     to learn how to work with Tarantool data schema.
 
-To save the migration without applying it to the cluster, click **Save**.
-This saves the currently selected migration.
+Once you complete writing the migration, save it by clicking **Save**.
+This saves the migration that is currently opened in the editor.
 
-To apply all _saved_ migrations to the cluster at once, click **Apply**.
+To apply all *saved* migrations to the cluster at once, click **Apply**.
 
 .. important::
 
@@ -64,7 +64,7 @@ of the last applied migration set:
 -   If there are saved migrations that are not applied yet, the widget becomes gray.
 
 Hovering a cursor over the widget shows the number of instances on which the currently
-saved migration set is already applied.
+saved migration set is successfully applied.
 
 You can also check the status of each particular migration on the **Migrations** page.
 The migrations that are successfully applied are marked with green check marks.

--- a/doc/tooling/tcm/tcm_cluster_migrations.rst
+++ b/doc/tooling/tcm/tcm_cluster_migrations.rst
@@ -11,8 +11,8 @@ Performing migrations
 in connected clusters. To learn more about migrations in Tarantool, see :ref:`migrations`.
 
 Migrations are named Lua files with code that alters the cluster data schema, for example,
-creates a space, changes it format, or adds indexes. In |tcm|, there is a dedicated
-page on which you can organize migrations, edit their code, and apply them to the cluster.
+creates a space, changes its format, or adds indexes. In |tcm|, there is a dedicated
+page where you can organize migrations, edit their code, and apply them to the cluster.
 
 ..  _tcm_cluster_migrations_manage:
 
@@ -48,10 +48,10 @@ To apply all saved migrations to the cluster at once, click **Apply**.
 
 .. important::
 
-    Applying all saved migrations **at once in the lexicographical** order is the
-    only way to apply migrations in |tcm|. There is no way to select a single  or
+    Applying all saved migrations **at once, in the lexicographical order** is the
+    only way to apply migrations in |tcm|. There is no way to select a single or
     several migrations to apply.
-    The migrations that are already applied are skipped. To learn how to find out
+    The migrations that are already applied are skipped. To learn how to check
     a migration status, see :ref:`tcm_cluster_migrations_check`.
 
 Migrations that were created but not saved yet are not applied when you click **Apply**.

--- a/doc/tooling/tcm/tcm_cluster_migrations.rst
+++ b/doc/tooling/tcm/tcm_cluster_migrations.rst
@@ -38,7 +38,7 @@ To create a migration:
 Once you complete writing the migration, save it by clicking **Save**.
 This saves the migration that is currently opened in the editor.
 
-To apply all *saved* migrations to the cluster at once, click **Apply**.
+To apply all saved migrations to the cluster at once, click **Apply**.
 
 .. important::
 
@@ -48,6 +48,7 @@ To apply all *saved* migrations to the cluster at once, click **Apply**.
     The migrations that are already applied are skipped. To learn how to find out
     a migration status, see :ref:`tcm_cluster_migrations_check`.
 
+Migrations that were created but not saved yet are not applied when you click **Apply**.
 
 ..  _tcm_cluster_migrations_check:
 


### PR DESCRIPTION
Resolves #4349 

Add new TCM doc page [Performing migrations](https://docs.d.tarantool.io/en/doc/gh-4349-tcm-migrations/tooling/tcm/tcm_cluster_migrations/)

Deployment: https://docs.d.tarantool.io/en/doc/gh-4349-tcm-migrations/tooling/tcm/tcm_cluster_migrations/

> [!NOTE]  
> The description of how to write migration code to apply with the new tt mechanism (which is used by TCM under the hood) is out of this PR's scope. Will be documented in scope of #4387. Adding a simple example of a migration file as a hint.