### PR TITLE
Add tt 2.4.0 features: log, enable, --self, start -i

### DIFF
--- a/doc/tooling/tt_cli/commands.rst
+++ b/doc/tooling/tt_cli/commands.rst
@@ -54,6 +54,8 @@ help for the given command.
             -   List enabled applications
         *   -   :doc:`kill <kill>`
             -   Terminate Tarantool applications or instances
+        *   -   :doc:`log <log>`
+            -   Print instance logs
         *   -   :doc:`logrotate <logrotate>`
             -   Rotate instance logs
         *   -   :doc:`pack <pack>`
@@ -107,6 +109,7 @@ help for the given command.
     install <install>
     instances <instances>
     kill <kill>
+    log <log>
     logrotate <logrotate>
     pack <pack>
     play <play>

--- a/doc/tooling/tt_cli/commands.rst
+++ b/doc/tooling/tt_cli/commands.rst
@@ -102,6 +102,7 @@ help for the given command.
     create <create>
     crud <crud>
     download <download>
+    enable <enable>
     export <export>
     help <help>
     import <import>

--- a/doc/tooling/tt_cli/enable.rst
+++ b/doc/tooling/tt_cli/enable.rst
@@ -1,0 +1,21 @@
+.. _tt-enable:
+
+Adding external applications to environments
+============================================
+
+..  code-block:: console
+
+    $ tt enable {APPLICATION|SCRIPT}
+
+``tt enable`` adds an external Tarantool application to the current environment
+by creating a symlink to it in the ``instances.enabled`` directory.
+
+To add the application located in ``/home/tt-user/external_app`` to the current
+``tt`` environment:
+
+..  code-block:: console
+
+    $ tt enable /home/tt-user/external_app
+
+Once the application is added, you can work with it the same way as with applications
+created in this environment.

--- a/doc/tooling/tt_cli/global_options.rst
+++ b/doc/tooling/tt_cli/global_options.rst
@@ -46,8 +46,8 @@ Global options
 
 .. option:: -s, --self
 
-    Execute the same ``tt`` installation in presence of other active ``tt`` versions
-    in :ref:`bin_dir <tt-config_file_env>`.
+    Use the current ``tt`` version instead of executing the one located
+    in the :ref:`bin_dir <tt-config_file_env>` directory.
 
 .. option:: -S, --system
 

--- a/doc/tooling/tt_cli/global_options.rst
+++ b/doc/tooling/tt_cli/global_options.rst
@@ -44,6 +44,11 @@ Global options
     Use the ``tt`` environment from the specified directory.
     Learn more about the :ref:`local launch mode <tt-config_modes-local>`.
 
+.. option:: -s, --self
+
+    Execute the same ``tt`` installation in presence of other active ``tt`` versions
+    in :ref:`bin_dir <tt-config_file_env>`.
+
 .. option:: -S, --system
 
     Use the ``tt`` environment installed in the system.

--- a/doc/tooling/tt_cli/kill.rst
+++ b/doc/tooling/tt_cli/kill.rst
@@ -13,19 +13,19 @@ To terminate all instances of the ``app`` application:
 
 ..  code-block:: console
 
-    $ tt stop app
+    $ tt kill app
 
 To terminate the ``storage-001-r`` instance of the ``app`` application without confirmation:
 
 ..  code-block:: console
 
-    $ tt stop app:storage-001-r --force
+    $ tt kill app:storage-001-r --force
 
 To terminate the ``storage-001-r`` instance of the ``app`` application and generate its core dump:
 
 ..  code-block:: console
 
-    $ tt stop app:storage-001-r --dump
+    $ tt kill app:storage-001-r --dump
 
 Options
 -------

--- a/doc/tooling/tt_cli/log.rst
+++ b/doc/tooling/tt_cli/log.rst
@@ -9,7 +9,7 @@ Printing Tarantool logs
 
 ``tt log`` prints the last lines of instance logs.
 
-To print 10 last log lines of all instances of the ``app`` application:
+To print 10 last log lines of all the ``app`` application instances:
 
 ..  code-block:: console
 
@@ -21,7 +21,7 @@ To print 50 last log lines of the ``router`` instance of the ``app`` application
 
     $ tt log -n 50 app:router
 
-To print logs of the ``app`` application instances interactively:
+To keep printing logs of the ``app`` application instances as they grow:
 
 ..  code-block:: console
 

--- a/doc/tooling/tt_cli/log.rst
+++ b/doc/tooling/tt_cli/log.rst
@@ -5,7 +5,7 @@ Printing Tarantool logs
 
 ..  code-block:: console
 
-    $ tt log APPLICATION[:APP_INSTANCE]
+    $ tt log [APPLICATION[:APP_INSTANCE]]
 
 ``tt log`` prints the last lines of instance logs.
 

--- a/doc/tooling/tt_cli/log.rst
+++ b/doc/tooling/tt_cli/log.rst
@@ -1,0 +1,39 @@
+.. _tt-log:
+
+Printing Tarantool logs
+=======================
+
+..  code-block:: console
+
+    $ tt log APPLICATION[:APP_INSTANCE]
+
+``tt log`` prints the last lines of instance logs.
+
+To print 10 last log lines of all instances of the ``app`` application:
+
+..  code-block:: console
+
+    $ tt log app
+
+To print 50 last log lines of the ``router`` instance of the ``app`` application:
+
+..  code-block:: console
+
+    $ tt log -n 50 app:router
+
+To print logs of the ``app`` application instances interactively:
+
+..  code-block:: console
+
+    $ tt log -f app
+
+Options
+-------
+
+.. option:: -f, --follow
+
+    Keep printing new lines added to the log file.
+
+.. option:: -n, --lines
+
+    The number of last lines to output. Default: ``10``.

--- a/doc/tooling/tt_cli/start.rst
+++ b/doc/tooling/tt_cli/start.rst
@@ -21,6 +21,13 @@ To start all instances of the application stored in the ``app`` directory inside
 
     $ tt start app
 
+To start all instances of the ``app`` application appending their logs to stdout
+(in the interactive mode):
+
+..  code-block:: console
+
+    $ tt start -i app
+
 To start the ``router`` instance of the ``app`` application:
 
 ..  code-block:: console
@@ -124,6 +131,14 @@ If an integrity check fails, ``tt`` stops the application.
 
 Options
 -------
+
+..  option:: -i, --interactive
+
+    Start the application or instance in the interactive mode.
+    In this mode, instance logs are printed to the standard output in real time.
+
+    You can use the ``SIGINT`` signal (``CTRL+C``) to stop ``tt`` and its child
+    Tarantool processes in the interactive mode. No watchdog processes are created.
 
 ..  option:: --integrity-check-interval NUMBER
 

--- a/doc/tooling/tt_cli/start.rst
+++ b/doc/tooling/tt_cli/start.rst
@@ -5,7 +5,7 @@ Starting Tarantool applications
 
 ..  code-block:: console
 
-    $ tt start APPLICATION[:APP_INSTANCE]
+    $ tt start [APPLICATION[:APP_INSTANCE]]
 
 ``tt start`` starts Tarantool applications. The application files must be stored
 inside the ``instances_enabled`` directory specified in the :ref:`tt configuration file <tt-config_file_app>`.

--- a/doc/tooling/tt_cli/stop.rst
+++ b/doc/tooling/tt_cli/stop.rst
@@ -5,7 +5,7 @@ Stopping a Tarantool instance
 
 ..  code-block:: console
 
-    $ tt stop APPLICATION[:APP_INSTANCE]
+    $ tt stop [APPLICATION[:APP_INSTANCE]]
 
 ``tt stop`` stops the specified running Tarantool applications or instances.
 When called without arguments, stops all running applications in the current environment.

--- a/doc/tooling/tt_cli/tt_interactive_console.rst
+++ b/doc/tooling/tt_cli/tt_interactive_console.rst
@@ -119,7 +119,7 @@ using the ``\set output`` console command:
     app:storage001> \set output table
     app:storage001> box.space.bands:select { }
     +------+-------------+------+
-    | col1 | col2        | col3 |
+    | id   | band_name   | year |
     +------+-------------+------+
     | 1    | Roxette     | 1986 |
     +------+-------------+------+
@@ -128,6 +128,11 @@ using the ``\set output`` console command:
     | 3    | Ace of Base | 1987 |
     +------+-------------+------+
 
+.. note::
+
+    Field names are printed since Tarantool 3.2. On earlier versions,
+    actual names are replaced by numbered placeholders ``col1``, ``col2``, and so on.
+
 The table output can be printed in the transposed format, where an object's fields
 are arranged in columns instead of rows:
 
@@ -135,13 +140,13 @@ are arranged in columns instead of rows:
 
     app:storage001> \set output ttable
     app:storage001> box.space.bands:select { }
-    +------+---------+-----------+-------------+
-    | col1 | 1       | 2         | 3           |
-    +------+---------+-----------+-------------+
-    | col2 | Roxette | Scorpions | Ace of Base |
-    +------+---------+-----------+-------------+
-    | col3 | 1986    | 1965      | 1987        |
-    +------+---------+-----------+-------------+
+    +-----------+---------+-----------+-------------+
+    | id        | 1       | 2         | 3           |
+    +-----------+---------+-----------+-------------+
+    | band_name | Roxette | Scorpions | Ace of Base |
+    +-----------+---------+-----------+-------------+
+    | year      | 1986    | 1965      | 1987        |
+    +-----------+---------+-----------+-------------+
 
 .. note::
 
@@ -162,9 +167,9 @@ following commands:
 
         app:storage001> \set table_format jira
         app:storage001> box.space.bands:select {}
-        | col1 | 1 | 2 | 3 |
-        | col2 | Roxette | Scorpions | Ace of Base |
-        | col3 | 1986 | 1965 | 1987 |
+        | id | 1 | 2 | 3 |
+        | band_name | Roxette | Scorpions | Ace of Base |
+        | year | 1986 | 1965 | 1987 |
 
 *   ``\set grahpics`` -- enable or disable graphics for table cells in the default format:
 
@@ -173,9 +178,9 @@ following commands:
         app:storage001> \set table_format default
         app:storage001> \set graphics false
         app:storage001> box.space.bands:select {}
-         col1  1        2          3
-         col2  Roxette  Scorpions  Ace of Base
-         col3  1986     1965       1987
+         id         1        2          3
+         band_name  Roxette  Scorpions  Ace of Base
+         year       1986     1965       1987
 
 *   ``\set table_column_width`` -- maximum column width.
 
@@ -183,10 +188,10 @@ following commands:
 
         app:storage001> \set table_column_width 6
         app:storage001> box.space.bands:select {}
-         col1  1       2       3
-         col2  Roxett  Scorpi  Ace of
-               +e      +ons    + Base
-         col3  1986    1965    1987
+         id      1       2       3
+         band_n  Roxett  Scorpi  Ace of
+         +ame    +e      +ons    + Base
+         year    1986    1965    1987
 
 
 .. _tt-interactive-console-commands:


### PR DESCRIPTION
Resolves #4308, #4313, #4392, #4447, #4449

- Add `-s`/`--self` global option to [Global options](https://docs.d.tarantool.io/en/doc/gh-4387-tt-2-4-updates/tooling/tt_cli/global_options/) page
- Add new command [tt log](https://docs.d.tarantool.io/en/doc/gh-4387-tt-2-4-updates/tooling/tt_cli/log/)
- Add new command [tt enable](https://docs.d.tarantool.io/en/doc/gh-4387-tt-2-4-updates/tooling/tt_cli/enable/)
- Add `-i`/`--interactive` option to [tt start](https://docs.d.tarantool.io/en/doc/gh-4387-tt-2-4-updates/tooling/tt_cli/start/) page
- Update [tt console output](https://docs.d.tarantool.io/en/doc/gh-4387-tt-2-4-updates/tooling/tt_cli/tt_interactive_console/#console-output) examples - use field names instead of `col1`, `col2` etc.
- Fix copy-paste error in examples of [tt kill](https://docs.d.tarantool.io/en/doc/gh-4387-tt-2-4-updates/tooling/tt_cli/kill/)

Deployment: https://docs.d.tarantool.io/en/doc/gh-4387-tt-2-4-updates/tooling/tt_cli/global_options/