### PR TITLE
Add ref on box.stat.memtx().data and box.stat.memtx().index

### DIFF
--- a/doc/reference/reference_lua/box_stat/memtx.rst
+++ b/doc/reference/reference_lua/box_stat/memtx.rst
@@ -9,6 +9,64 @@ box.stat.memtx()
 
     Shows ``memtx`` storage engine activity.
 
+.. _box_introspection-box_stat_memtx_data:
+
+box.stat.memtx().data
+---------------------
+
+``data`` shows how much memory (in bytes) is allocated for memtx tuples:
+
+* ``data.garbage`` is the amount of memory that is unused and scheduled to be freed
+  (freed lazily on memory allocation).
+
+* ``data.total`` is the total amount of memory allocated for data tuples.
+  This includes ``data.read_view`` and ``data.garbage`` plus tuples that are
+  actually stored in memtx spaces.
+
+* ``data.read_view`` is the amount of memory held for read views.
+  This includes memory allocated both for system read views (snapshot, replication)
+  and user read views (EE-only). This should be non-zero only if there are open read views.
+
+  To list all open read views, use :ref:`box.read_view.list() <reference_lua-box_read_view_list>`.
+
+  **Example:**
+
+  .. code-block:: tarantoolsession
+
+     tarantool> box.stat.memtx().data
+     ---
+     - garbage: 0
+       total: 25334
+       read_view: 0
+     ...
+
+.. _box_introspection-box_stat_memtx_index:
+
+box.stat.memtx().index
+----------------------
+
+``index`` shows how much memory (in bytes) is allocated for memtx index extentions:
+
+* ``index.read_view`` is the amount of memory held for read views.
+  This includes memory allocated both for system read views (snapshot, replication)
+  and user read views (EE-only). This should be non-zero only if there are open read views.
+
+  To list all open read views, use :ref:`box.read_view.list() <reference_lua-box_read_view_list>`.
+
+* ``index.total`` is the total amount of memory allocated for
+  indexing data. This includes ``index.read_view`` plus memory used for indexing
+  tuples that are actually stored in memtx spaces.
+
+  **Example:**
+
+  .. code-block:: tarantoolsession
+
+     tarantool> box.stat.memtx().index
+     ---
+     - read_view: 0
+       total: 1032192
+     ...
+
 .. _box_introspection-box_stat_memtx_tx:
 
 box.stat.memtx().tx

--- a/doc/reference/reference_lua/box_stat/memtx.rst
+++ b/doc/reference/reference_lua/box_stat/memtx.rst
@@ -45,7 +45,7 @@ box.stat.memtx().data
 box.stat.memtx().index
 ----------------------
 
-``index`` shows how much memory (in bytes) is allocated for memtx index extentions:
+``index`` shows how much memory (in bytes) is allocated for indexing memtx tuples:
 
 * ``index.read_view`` is the amount of memory held for read views.
   This includes memory allocated both for system read views (snapshot, replication)

--- a/doc/reference/reference_lua/box_stat/memtx.rst
+++ b/doc/reference/reference_lua/box_stat/memtx.rst
@@ -31,14 +31,14 @@ box.stat.memtx().data
 
   **Example:**
 
-  .. code-block:: tarantoolsession
+.. code-block:: tarantoolsession
 
-     tarantool> box.stat.memtx().data
-     ---
-     - garbage: 0
-       total: 25334
-       read_view: 0
-     ...
+   tarantool> box.stat.memtx().data
+   ---
+   - garbage: 0
+     total: 25334
+     read_view: 0
+   ...
 
 .. _box_introspection-box_stat_memtx_index:
 
@@ -59,13 +59,13 @@ box.stat.memtx().index
 
   **Example:**
 
-  .. code-block:: tarantoolsession
+.. code-block:: tarantoolsession
 
-     tarantool> box.stat.memtx().index
-     ---
-     - read_view: 0
-       total: 1032192
-     ...
+   tarantool> box.stat.memtx().index
+   ---
+   - read_view: 0
+     total: 1032192
+   ...
 
 .. _box_introspection-box_stat_memtx_tx:
 
@@ -182,52 +182,52 @@ Calling ``box.stat.memtx.tx()`` now returns the following result:
 .. code-block:: tarantoolsession
    :emphasize-lines: 33-39
 
-	tarantool> box.stat.memtx.tx()
-	---
-	- txn:
-	    statements:
-	      max: 720
-	      avg: 720
-	      total: 720
-	    user:
-	      max: 0
-	      avg: 0
-	      total: 0
-	    system:
-	      max: 916
-	      avg: 916
-	      total: 916
-	  mvcc:
-	    trackers:
-	      max: 0
-	      avg: 0
-	      total: 0
-	    conflicts:
-	      max: 0
-	      avg: 0
-	      total: 0
-	    tuples:
-	      tracking:
-	        stories:
-	          count: 0
-	          total: 0
-	        retained:
-	          count: 0
-	          total: 0
-	      used:
-	        stories:
-	          count: 6
-	          total: 944
-	        retained:
-	          count: 2
-	          total: 119
-	      read_view:
-	        stories:
-	          count: 0
-	          total: 0
-	        retained:
-	          count: 0
-	          total: 0
-	...
+   tarantool> box.stat.memtx.tx()
+   ---
+   - txn:
+       statements:
+         max: 720
+         avg: 720
+         total: 720
+       user:
+         max: 0
+         avg: 0
+         total: 0
+       system:
+         max: 916
+         avg: 916
+         total: 916
+     mvcc:
+       trackers:
+         max: 0
+         avg: 0
+         total: 0
+       conflicts:
+         max: 0
+         avg: 0
+         total: 0
+       tuples:
+         tracking:
+           stories:
+             count: 0
+             total: 0
+           retained:
+             count: 0
+             total: 0
+         used:
+           stories:
+             count: 6
+             total: 944
+           retained:
+             count: 2
+             total: 119
+         read_view:
+           stories:
+             count: 0
+             total: 0
+           retained:
+             count: 0
+             total: 0
+   ...
 
 Pay attention to highlighted lines -- it's the memory allocated for `used` tuples.


### PR DESCRIPTION
Resolves: #3422

Add two new subsections for [box.stat.memtx()](https://docs.d.tarantool.io/en/doc/gh-3422-memtx-read-view/reference/reference_lua/box_stat/memtx/):
- [data](https://docs.d.tarantool.io/en/doc/gh-3422-memtx-read-view/reference/reference_lua/box_stat/memtx/#box-stat-memtx-data)
- [index](https://docs.d.tarantool.io/en/doc/gh-3422-memtx-read-view/reference/reference_lua/box_stat/memtx/#box-stat-memtx-index)

Deploy: https://docs.d.tarantool.io/en/doc/gh-3422-memtx-read-view/reference/reference_lua/box_stat/memtx/