### PR TITLE
Add description for the `age` and `confirm_lag` fields in `box.info.synchro.queue`

### DIFF
--- a/doc/code_snippets/snippets/replication/instances.enabled/box_info_synchro/README.md
+++ b/doc/code_snippets/snippets/replication/instances.enabled/box_info_synchro/README.md
@@ -1,0 +1,23 @@
+# Using box.info.synchro
+
+A sample application demonstrating how to work with [box.info.synchro](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_info/synchro/).
+
+## Running
+
+To start all instances, execute the following command in the [replication](../../../replication) directory:
+
+```console
+$ tt start box_info_synchro
+```
+
+To check the instance status, run:
+
+```console
+$ tt status box_info_synchro
+```
+
+To connect to the ``instance001`` instance, run:
+
+```console
+$ tt connect box_info_synchro:instance001
+```

--- a/doc/code_snippets/snippets/replication/instances.enabled/box_info_synchro/config.yaml
+++ b/doc/code_snippets/snippets/replication/instances.enabled/box_info_synchro/config.yaml
@@ -1,0 +1,31 @@
+credentials:
+  users:
+    replicator:
+      password: 'topsecret'
+      roles: [replication]
+
+iproto:
+  advertise:
+    peer:
+      login: replicator
+
+groups:
+  group001:
+    replicasets:
+      replicaset001:
+        instances:
+          instance001:
+            database:
+              mode: rw
+            replication:
+              synchro_quorum: 2
+              synchro_timeout: 1000
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3301'
+          instance002:
+            database:
+              mode: ro
+            iproto:
+              listen:
+              - uri: '127.0.0.1:3302'

--- a/doc/code_snippets/snippets/replication/instances.enabled/box_info_synchro/instances.yml
+++ b/doc/code_snippets/snippets/replication/instances.enabled/box_info_synchro/instances.yml
@@ -1,0 +1,2 @@
+instance001:
+instance002:

--- a/doc/reference/reference_lua/box_info/synchro.rst
+++ b/doc/reference/reference_lua/box_info/synchro.rst
@@ -30,7 +30,7 @@ box.info.synchro
             When Raft election is enabled and :ref:`replication.election_mode <configuration_reference_replication_election_mode>`
             is set to ``candidate``, the new Raft leader claims the queue automatically after winning the elections.
             It means that the value of ``box.info.synchro.queue.owner`` becomes equal to :ref:`box.info.election.leader <box_info_election>`.
-            When Raft enabled, no manual intervention with ``box.ctl.promote()`` or ``box.ctl.demote()`` is required.
+            When Raft is enabled, no manual intervention with ``box.ctl.promote()`` or ``box.ctl.demote()`` is required.
 
         -   ``term`` (since version :doc:`2.10.0 </release/2.10.0>`) -- current queue term.
             It contains the term of the last ``PROMOTE`` request.
@@ -98,13 +98,13 @@ box.info.synchro
 
         box_info_synchro:instance001> box.schema.user.grant('guest', 'super')
 
-    After that, use ``box.ctl.promote()`` function to claim the queue:
+    After that, use the ``box.ctl.promote()`` function to claim the queue:
 
     ..  code-block:: tarantoolsession
 
         box_info_synchro:instance001> box.ctl.promote()
 
-    Create a space called ``sync`` and enable synchronous replication on this space:
+    Create a space named ``sync`` and enable synchronous replication on this space:
 
     ..  code-block:: tarantoolsession
 

--- a/doc/reference/reference_lua/box_info/synchro.rst
+++ b/doc/reference/reference_lua/box_info/synchro.rst
@@ -25,15 +25,12 @@ box.info.synchro
             but they can't create any synchronous transactions.
             To claim or reclaim the queue, use :ref:`box.ctl.promote() <box_ctl-promote>` on the instance that you want
             to promote.
-            With elections enabled, an instance runs ``box.ctl.promote()`` command automatically after winning the elections.
             To clear the ownership, call :ref:`box.ctl.demote() <box_ctl-demote>` on the synchronous queue owner.
 
-            ..  note::
-
-                When Raft election is enabled and :ref:`replication.election_mode <configuration_reference_replication_election_mode>`
-                is set to ``candidate``, the new Raft leader claims the queue automatically.
-                It means that the value of ``box.info.synchro.queue.owner`` becomes equal to :ref:`box.info.election.leader <box_info_election>`.
-                When Raft enabled, no manual intervention with ``box.ctl.promote()`` or ``box.ctl.demote()`` is required.
+            When Raft election is enabled and :ref:`replication.election_mode <configuration_reference_replication_election_mode>`
+            is set to ``candidate``, the new Raft leader claims the queue automatically after winning the elections.
+            It means that the value of ``box.info.synchro.queue.owner`` becomes equal to :ref:`box.info.election.leader <box_info_election>`.
+            When Raft enabled, no manual intervention with ``box.ctl.promote()`` or ``box.ctl.demote()`` is required.
 
         -   ``term`` (since version :doc:`2.10.0 </release/2.10.0>`) -- current queue term.
             It contains the term of the last ``PROMOTE`` request.
@@ -97,22 +94,30 @@ box.info.synchro
         app:instance001> box.info.synchro
         ---
         - queue:
-            owner: 2
+            owner: 1
             confirm_lag: 0
-            term: 28
+            term: 2
             age: 0
             len: 0
             busy: false
           quorum: 2
         ...
 
-    Create a space called ``sync`` and enable synchronous replication on this space.
-    Then, create an index.
+    Create a space called ``sync`` and enable synchronous replication on this space:
 
     ..  code-block:: console
 
         app:instance001> s = box.schema.space.create("sync", {is_sync=true})
+        ---
+        ...
+
+    Then, create an index:
+
+    ..  code-block:: console
+
         app:instance001> _ = s:create_index('pk')
+        ---
+        ...
 
     After that, use ``box.ctl.promote()`` function to claim a queue:
 
@@ -128,19 +133,19 @@ box.info.synchro
         ---
         - status: suspended
           name: lua
-          id: 127
+          id: 130
         ...
         app:instance001> require('fiber').new(function() box.space.sync:replace{1} end)
         ---
         - status: suspended
           name: lua
-          id: 128
+          id: 131
         ...
         app:instance001> require('fiber').new(function() box.space.sync:replace{1} end)
         ---
         - status: suspended
           name: lua
-          id: 129
+          id: 132
         ...
 
     If you call the ``box.info.synchro`` command again,
@@ -153,7 +158,7 @@ box.info.synchro
         - queue:
             owner: 1
             confirm_lag: 0
-            term: 29
+            term: 2
             age: 0
             len: 0
             busy: false

--- a/doc/reference/reference_lua/box_info/synchro.rst
+++ b/doc/reference/reference_lua/box_info/synchro.rst
@@ -87,10 +87,10 @@ box.info.synchro
     - ``instance002`` is a follower instance.
 
     ..  literalinclude:: /code_snippets/snippets/replication/instances.enabled/box_info_synchro/config.yaml
-    :language: yaml
-    :start-at: groups
-    :end-at: 3302
-    :dedent:
+        :language: yaml
+        :start-at: groups
+        :end-at: 3302
+        :dedent:
 
     On the **first** instance, grant the user with the ``super`` role:
 
@@ -149,7 +149,7 @@ box.info.synchro
         ---
         ...
         box_info_synchro:instance001> for i = 1, 3 do fiber.new(function() box.space.sync:replace{i} end) end
-        ---                                                                                          end
+        ---
         ...
 
     Call the ``box.info.synchro`` command on the first instance again:


### PR DESCRIPTION
Staging: https://docs.d.tarantool.io/en/doc/gh-4284-box_info_synchro_queue/reference/reference_lua/box_info/synchro/

Fixes #4284 
Fixes https://github.com/tarantool/doc/issues/4400