### PR TITLE
Add TCM initial settings doc

### DIFF
--- a/doc/tooling/tcm/tcm_configuration.rst
+++ b/doc/tooling/tcm/tcm_configuration.rst
@@ -162,6 +162,8 @@ multiple |tcm| installations:
 -   Command-line options for parameters that must be unique for different |tcm| instances
     running on a single server. For example, ``http.port``.
 
+.. _tcm_configuration_types:
+
 Configuration parameter types
 -----------------------------
 
@@ -219,6 +221,8 @@ packages documentation <https://pkg.go.dev/>`__.
         websession-cookie:
             same-site: SameSiteStrictMode
 
+.. _tcm_configuration_template:
+
 Creating a configuration template
 ---------------------------------
 
@@ -230,3 +234,93 @@ To write a default |tcm| configuration to the ``tcm.example.yml`` file, run:
 .. code-block:: console
 
     $ tcm generate-config > tcm.example.yml.
+
+.. _tcm_configuration_initial:
+
+Initial settings
+----------------
+
+You can use YAML configuration files to create entities in |tcm| automatically
+upon the first start. These entities are defined in the :ref:`tcm_configuration_reference_initial`
+section of the configuration files.
+
+.. important::
+
+    The initial settings are applied **only once** upon the first |tcm| start.
+    Further changes are **not applied** upon |tcm| restarts.
+
+.. _tcm_configuration_initial_clusters:
+
+Clusters
+~~~~~~~~
+
+To add clusters to |tcm| upon the first start, specify their settings in the
+:ref:`initial-settings.clusters <tcm_configuration_reference_initial_clusters>`
+configuration section.
+
+The ``initial-settings.clusters`` section is an array whose items describe separate clusters,
+for example:
+
+.. code-block:: yaml
+
+    initial-settings:
+      clusters:
+        - name: "Cluster 1"
+          description: "First cluster"
+          # cluster settings
+        - name: "Cluster 2"
+          description: "Second cluster"
+          # cluster settings
+
+In this configuration, you can specify all cluster settings that you define
+when :ref:`connecting clusters` through the |tcm| web interface. This includes
+the cluster name, a text description, additional URLs, configuration storage connection,
+Tarantool instances connection, and other settings. For the full list of cluster
+configuration parameters, see the :ref:`initial-settings.clusters <tcm_configuration_reference_initial_clusters>`
+reference. For example, this is how you add a cluster that uses an etcd configuration
+storage:
+
+
+.. code-block:: yaml
+
+    initial-settings:
+      clusters:
+        - name: "My cluster"
+          description: "Cluster description"
+          urls:
+          - label: Test
+            url: http://example.com
+          storage-connection:
+            provider: etcd
+            etcd-connection:
+              endpoints:
+                - http://127.0.0.1:2379
+              username: ""
+              password: ""
+              prefix: /cluster1
+            tarantool-connection:
+              username: "guest"
+              password: ""
+
+By default, |tcm| contains a cluster named **Default cluster** with ID
+``00000000-0000-0000-0000-000000000000``. You can specify this ID to modify
+the default cluster settings upon the first |tcm| start. For example, rename it
+and add its connection settings:
+
+.. code-block:: yaml
+
+    initial-settings:
+      clusters:
+        - id: 00000000-0000-0000-0000-000000000000
+          name: "My cluster"
+          storage-connection:
+            provider: etcd
+            etcd-connection:
+              endpoints:
+                - http://127.0.0.1:2379
+              username: etcd-user
+              password: secret
+              prefix: /cluster1
+            tarantool-connection:
+              username: "guest"
+              password: ""

--- a/doc/tooling/tcm/tcm_configuration.rst
+++ b/doc/tooling/tcm/tcm_configuration.rst
@@ -242,7 +242,7 @@ Initial settings
 
 You can use YAML configuration files to create entities in |tcm| automatically
 upon the first start. These entities are defined in the :ref:`tcm_configuration_reference_initial`
-section of the configuration files.
+section of the configuration file.
 
 .. important::
 
@@ -265,18 +265,25 @@ for example:
 
     initial-settings:
       clusters:
-        - name: "Cluster 1"
-          description: "First cluster"
+        - name: Cluster 1
+          description: First cluster
           # cluster settings
-        - name: "Cluster 2"
-          description: "Second cluster"
+        - name: Cluster 2
+          description: Second cluster
           # cluster settings
 
 In this configuration, you can specify all cluster settings that you define
-when :ref:`connecting clusters` through the |tcm| web interface. This includes
-the cluster name, a text description, additional URLs, configuration storage connection,
-Tarantool instances connection, and other settings. For the full list of cluster
-configuration parameters, see the :ref:`initial-settings.clusters <tcm_configuration_reference_initial_clusters>`
+when :ref:`connecting clusters <tcm_connect_clusters>` through the |tcm| web interface.
+This includes:
+
+-   the cluster name
+-   description
+-   additional URLs
+-   configuration storage connection
+-   Tarantool instances connection
+-   and other settings.
+
+For the full list of cluster configuration parameters, see the :ref:`initial-settings.clusters <tcm_configuration_reference_initial_clusters>`
 reference. For example, this is how you add a cluster that uses an etcd configuration
 storage:
 
@@ -285,8 +292,8 @@ storage:
 
     initial-settings:
       clusters:
-        - name: "My cluster"
-          description: "Cluster description"
+        - name: My cluster
+          description: Cluster description
           urls:
           - label: Test
             url: http://example.com
@@ -299,11 +306,11 @@ storage:
               password: ""
               prefix: /cluster1
             tarantool-connection:
-              username: "guest"
+              username: guest
               password: ""
 
 By default, |tcm| contains a cluster named **Default cluster** with ID
-``00000000-0000-0000-0000-000000000000``. You can specify this ID to modify
+``00000000-0000-0000-0000-000000000000``. You can use this ID to modify
 the default cluster settings upon the first |tcm| start. For example, rename it
 and add its connection settings:
 
@@ -312,7 +319,7 @@ and add its connection settings:
     initial-settings:
       clusters:
         - id: 00000000-0000-0000-0000-000000000000
-          name: "My cluster"
+          name: My cluster
           storage-connection:
             provider: etcd
             etcd-connection:
@@ -322,5 +329,5 @@ and add its connection settings:
               password: secret
               prefix: /cluster1
             tarantool-connection:
-              username: "guest"
+              username: guest
               password: ""

--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -2292,7 +2292,7 @@ initial-settings
 The ``initial-settings`` group defines entities that are created automatically
 upon the first |tcm| startup.
 
-TODO: doc link :ref:`tcm_connect_clusters`
+TODO: doc link :ref:`tcm_configuration_initial`
 
 
 -   :ref:`initial-settings.clusters <tcm_configuration_reference_initial_clusters>`
@@ -2309,7 +2309,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     An array of clusters to create in |tcm| automatically upon the first startup.
 
-    See also :ref:`tcm_connect_clusters`.
+    See also :ref:`tcm_configuration_initial`.
 
     |
     | Type: []Cluster
@@ -2524,8 +2524,8 @@ TODO: doc link :ref:`tcm_connect_clusters`
     TODO: ??
 
     |
-    | Type: bool TBD:check
-    | Default:
+    | Type: bool
+    | Default: false
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_permitwostream:
 

--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -1276,7 +1276,7 @@ Tarantool backend store parameters:
 
     |
     | Type: time.Duration
-    | Default: 0s
+    | Default: 0 (disabled)
     | Environment variable: TCM_STORAGE_ETCD_AUTO_SYNC_INTERVAL
     | Command-line option: ``--storage.etcd.auto-sync-interval``
 
@@ -1550,10 +1550,11 @@ storage.etcd.embed.*
 ~~~~~~~~~~~~~~~~~~~~
 
 The ``storage.etcd.embed`` group defines the configuration of the embedded etcd
-cluster that can used as a |tcm| configuration storage.
+cluster to use as a |tcm| backend store.
 This cluster can be used for development purposes when the production or testing
 etcd cluster is not available or not needed.
 
+See also :ref:`tcm_backend_store_embed`.
 
 .. _tcm_configuration_reference_storage_tarantool_prefix:
 
@@ -1912,10 +1913,11 @@ storage.tarantool.embed.*
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``storage.tarantool.embed`` group parameters define the configuration of the
-embedded Tarantool cluster that can used as a |tcm| configuration storage.
+embedded Tarantool cluster to use as a |tcm| backend store.
 This cluster can be used for development purposes when the production or testing
 cluster is not available or not needed.
 
+See also :ref:`tcm_backend_store_embed`.
 
 .. _tcm_configuration_reference_addon:
 
@@ -2292,7 +2294,7 @@ initial-settings
 The ``initial-settings`` group defines entities that are created automatically
 upon the first |tcm| startup.
 
-TODO: doc link :ref:`tcm_configuration_initial`
+See also :ref:`tcm_configuration_initial`.
 
 
 -   :ref:`initial-settings.clusters <tcm_configuration_reference_initial_clusters>`
@@ -2444,7 +2446,7 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
     |
     | Type: time.Duration
-    | Default: TODO??
+    | Default: 0 (disabled)
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_dialtimeout:
 
@@ -2454,7 +2456,7 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
     |
     | Type: time.Duration
-    | Default: TODO??
+    | Default: 0 (not set)
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_dialkatime:
 
@@ -2464,7 +2466,7 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
     |
     | Type: time.Duration
-    | Default: TODO??
+    | Default: 0 (not set)
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_dialkatimeout:
 
@@ -2474,29 +2476,29 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
     |
     | Type: time.Duration
-    | Default: TODO??
+    | Default: 0 (not set)
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_maxcallsend:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.max-call-send-msg-size
 
-    The maximum size (in bytes) of a message between the cluster and its etcd
-    configuration storage. TODO:check
+    The maximum size (in bytes) of a request from the cluster to its etcd
+    configuration storage.
 
     |
     | Type: int
-    | Default: TODO?? 2097152?
+    | Default: 2097152
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_maxcallrecv:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.max-call-recv-msg-size
 
-    The maximum size (in bytes) of a message between the cluster and its etcd
-    configuration storage. TBD:check
+    The maximum size (in bytes) of a response to the cluster from its etcd
+    configuration storage.
 
     |
     | Type: int
-    | Default: TODO?? 2097152
+    | Default: 0 (unlimited)
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_username:
 
@@ -2522,7 +2524,7 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.reject-old-cluster
 
-    TODO: ??
+    Whether etcd should refuse to create a client against an outdated cluster.
 
     |
     | Type: bool
@@ -2871,7 +2873,7 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
     |
     | Type: time.Duration
-    | Default: TODO
+    | Default: 0 (not set)
 
 .. _tcm_configuration_reference_initial_cluster_tarantool_rate-limit:
 
@@ -2881,7 +2883,7 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
     |
     | Type: uint
-    | Default: TODO
+    | Default: 0 (not set)
 
 
 .. _tcm_configuration_reference_initial_cluster__tarantool_ssl_key-file:

--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -2299,15 +2299,17 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
 .. important::
 
-    no env vars?
-    no cli opts?
+    The ``initial-settings.*`` configuration options can be set in the YAML
+    configuration file only. There are no environment variables nor
+    command-line options for them.
 
 .. _tcm_configuration_reference_initial_clusters:
 
 .. confval:: initial-settings.clusters
 
-    An array of clusters to connect to |tcm| automatically upon the first startup.
-    TODO: link to instruction
+    An array of clusters to create in |tcm| automatically upon the first startup.
+
+    See also :ref:`tcm_connect_clusters`.
 
     |
     | Type: []Cluster
@@ -2324,7 +2326,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: string
-    | Default: ""
+    | Default: "" (ID is generated automatically)
 
 
 .. _tcm_configuration_reference_initial_cluster_name:
@@ -2369,11 +2371,11 @@ TODO: doc link :ref:`tcm_connect_clusters`
     -   ``yellow``
     -   ``orange``
     -   ``teal``
-    -   empty string (no highlighting)
+    -   empty string (no color)
 
     |
     | Type: string
-    | Default: ""
+    | Default: "" (no color)
 
 
 .. _tcm_configuration_reference_initial_cluster_urls:
@@ -2391,7 +2393,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
 .. confval:: initial-settings.clusters.<cluster>.<url>.label
 
-    URL label to show in |tcm|.
+    URL label to show in |tcm|. Typically, this is the linked service name.
 
     |
     | Type: string
@@ -2401,7 +2403,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
 .. confval:: initial-settings.clusters.<cluster>.<url>.url
 
-    The URL address.
+    The URL address of the linked service.
 
     |
     | Type: string
@@ -2421,18 +2423,17 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: string
-    | Default: TBD??
+    | Default: ??TODO
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_endpoints:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.endpoints
 
-    An array of node URIs of the etcd cluster where the Tarantool cluster configuration is stored,
-    separated by semicolons (;).
+    An array of node URIs of the etcd cluster where the Tarantool cluster configuration is stored.
 
     |
     | Type: []string
-    | Default: TBD??
+    | Default: []
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_autosync:
 
@@ -2441,8 +2442,8 @@ TODO: doc link :ref:`tcm_connect_clusters`
     An automated sync interval.
 
     |
-    | Type: string
-    | Default:
+    | Type: time.Duration
+    | Default: TODO??
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_dialtimeout:
 
@@ -2452,7 +2453,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: time.Duration
-    | Default: 10s TBD:check
+    | Default: TODO??
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_dialkatime:
 
@@ -2462,7 +2463,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: time.Duration
-    | Default: 30s TBD:check
+    | Default: TODO??
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_dialkatimeout:
 
@@ -2472,29 +2473,29 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: time.Duration
-    | Default: 30s TBD:check
+    | Default: TODO??
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_maxcallsend:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.max-call-send-msg-size
 
-    The maximum size (in bytes) of a transaction between the cluster and its etcd
-    configuration storage. TBD:check
+    The maximum size (in bytes) of a message between the cluster and its etcd
+    configuration storage. TODO:check
 
     |
     | Type: int
-    | Default: 2097152 TBD:check
+    | Default: TODO?? 2097152?
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_maxcallrecv:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.max-call-recv-msg-size
 
-    The maximum size (in bytes) of a transaction between the cluster and its etcd
+    The maximum size (in bytes) of a message between the cluster and its etcd
     configuration storage. TBD:check
 
     |
     | Type: int
-    | Default: 2097152 TBD:check
+    | Default: TODO?? 2097152
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_username:
 
@@ -2520,7 +2521,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.reject-old-cluster
 
-    TBD: ??
+    TODO: ??
 
     |
     | Type: bool TBD:check
@@ -2534,7 +2535,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: bool
-    | Default: false TBD:check
+    | Default: false
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_method:
 
@@ -2554,7 +2555,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: string
-    | Default: "" TBD:check
+    | Default: ""
 
 
 .. _tcm_configuration_reference_initial_cluster_etcd_tls_enabled:
@@ -2696,7 +2697,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: string
-    | Default:
+    | Default: ""
 
 .. _tcm_configuration_reference_initial_cluster_storage_tarantool_password:
 
@@ -2706,7 +2707,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: string
-    | Default:
+    | Default: ""
 
 
 .. _tcm_configuration_reference_initial_cluster_storage_tarantool_endpoints:
@@ -2717,7 +2718,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: []string
-    | Default: ""
+    | Default: []
 
 .. _tcm_configuration_reference_initial_cluster_storage_tarantool_method:
 
@@ -2744,7 +2745,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: string
-    | Default: "" TBD:check
+    | Default: "" TODO:check
 
 
 .. _tcm_configuration_reference_initial_cluster_storage_tarantool_ssl_key-file:
@@ -2852,7 +2853,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     An authentication method for connecting to the cluster.
 
-    TBD: values
+    TODO: values
 
     |
     | Type: string
@@ -2866,7 +2867,7 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: time.Duration
-    | Default: TBD
+    | Default: TODO
 
 .. _tcm_configuration_reference_initial_cluster_tarantool_rate-limit:
 
@@ -2876,13 +2877,78 @@ TODO: doc link :ref:`tcm_connect_clusters`
 
     |
     | Type: uint
-    | Default: TBD
+    | Default: TODO
 
-.. _tcm_configuration_reference_initial_cluster_tarantool_ssl:
 
-.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.ssl
+.. _tcm_configuration_reference_initial_cluster__tarantool_ssl_key-file:
 
-    tbd
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.ssl.key-file
+
+    A path to a TLS private key file to use for connecting to the cluster instances.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_ssl_cert-file:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.ssl.cert-file
+
+    A path to an SSL certificate to use for connecting to the cluster instances.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_ssl_ca-file:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.ssl.ca-file
+
+    A path to a trusted CA certificate to use for connecting to the cluster instances.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_ssl_ciphers:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.ssl.ciphers
+
+    A list of SSL cipher suites that can be used for connecting to the cluster instances.
+    Possible values are listed in :ref:`<uri>.params.ssl_ciphers <configuration_reference_iproto_uri_params_ssl_ciphers>`.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_ssl_enabled:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.ssl.enabled
+
+    A password for an encrypted private SSL key to use for connecting to the cluster instances.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_ssl_password-file:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.ssl.password-file
+
+    A text file with passwords for encrypted private SSL keys to use
+    for connecting to the cluster instances.
+
+    See also: :ref:`configuration_connections_ssl`.
 
     |
     | Type: string

--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -132,7 +132,7 @@ Tarantool clusters.
     The name of the space field that is used as a sharding key.
 
     |
-    | Type: String
+    | Type: string
     | Default: `bucket_id`
     | Environment variable: TCM_CLUSTER_SHARDING_INDEX
     | Command-line option: ``--cluster.sharding-index``
@@ -2292,7 +2292,10 @@ initial-settings
 The ``initial-settings`` group defines entities that are created automatically
 upon the first |tcm| startup.
 
--   :ref:`clusters <tcm_configuration_reference_initial_clusters>`
+TODO: doc link :ref:`tcm_connect_clusters`
+
+
+-   :ref:`initial-settings.clusters <tcm_configuration_reference_initial_clusters>`
 
 .. important::
 
@@ -2315,52 +2318,69 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.id
 
-    An id to use for the cluster.
-    Use 00-00 to customize default cluster settings
+    Cluster ID. Skip this option to generate an ID automatically.
+    Specify the value ``00000000-0000-0000-0000-000000000000``
+    to customize the default cluster upon |tcm| startup.
 
     |
-    | Type: String
-    | Default: ?
+    | Type: string
+    | Default: ""
 
 
 .. _tcm_configuration_reference_initial_cluster_name:
 
 .. confval:: initial-settings.clusters.<cluster>.name
 
-    A name to use for the cluster.
+    Cluster name.
 
     |
-    | Type: String
-    | Default: ?
+    | Type: string
+    | Default: ""
 
 .. _tcm_configuration_reference_initial_cluster_description:
 
 .. confval:: initial-settings.clusters.<cluster>.description
 
-    A name to use for the cluster.
+    Cluster description.
 
     |
-    | Type: String
-    | Default: ?
+    | Type: string
+    | Default: ""
 
 
 .. _tcm_configuration_reference_initial_cluster_color:
 
 .. confval:: initial-settings.clusters.<cluster>.color
 
-    An id to use for the cluster.
-    Use 00-00 to customize default cluster settings
+    A color to highlight the cluster in |tcm|.
+    Possible values:
+
+    -   ``dark``
+    -   ``gray``
+    -   ``red``
+    -   ``pink``
+    -   ``grape``
+    -   ``violet``
+    -   ``indigo``
+    -   ``blue``
+    -   ``cyan``
+    -   ``green``
+    -   ``lime``
+    -   ``yellow``
+    -   ``orange``
+    -   ``teal``
+    -   empty string (no highlighting)
 
     |
-    | Type: String
-    | Default: ?
+    | Type: string
+    | Default: ""
 
 
 .. _tcm_configuration_reference_initial_cluster_urls:
 
 .. confval:: initial-settings.clusters.<cluster>.urls
 
-    An array of URLs.
+    URLs of additional services for the cluster. See also :ref:`tcm_connect_clusters_connect_new`.
 
     |
     | Type: []ClusterUrl
@@ -2371,170 +2391,177 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.<url>.label
 
-    An array of URLs.
+    URL label to show in |tcm|.
 
     |
-    | Type: String
-    | Default:
+    | Type: string
+    | Default: ""
 
 .. _tcm_configuration_reference_initial_cluster_url_url:
 
 .. confval:: initial-settings.clusters.<cluster>.<url>.url
 
-    An array of URLs.
+    The URL address.
 
     |
-    | Type: String
-    | Default:
-
+    | Type: string
+    | Default: ""
 
 
 .. _tcm_configuration_reference_initial_cluster_storage_provider:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.provider
 
-    etcd or tarantool
+    The type of the storage used for storing the cluster configuration.
+
+    Possible values:
+
+    -   ``etcd``
+    -   ``tarantool``
 
     |
-    | Type: String
-    | Default:
+    | Type: string
+    | Default: TBD??
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_endpoints:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.endpoints
 
-    etcd or tarantool
+    An array of node URIs of the etcd cluster where the Tarantool cluster configuration is stored,
+    separated by semicolons (;).
 
     |
-    | Type: String
-    | Default:
+    | Type: []string
+    | Default: TBD??
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_autosync:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.auto-sync-interval
 
-    etcd or tarantool
+    An automated sync interval.
 
     |
-    | Type: String
+    | Type: string
     | Default:
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_dialtimeout:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.dial-timeout
 
-    etcd or tarantool
+    An etcd dial timeout.
 
     |
-    | Type: String
-    | Default:
+    | Type: time.Duration
+    | Default: 10s TBD:check
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_dialkatime:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.dial-keep-alive-time
 
-    etcd or tarantool
+    A dial keep-alive time.
 
     |
-    | Type: String
-    | Default:
+    | Type: time.Duration
+    | Default: 30s TBD:check
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_dialkatimeout:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.dial-keep-alive-timeout
 
-    etcd or tarantool
+    A dial keep-alive timeout.
 
     |
-    | Type: String
-    | Default:
+    | Type: time.Duration
+    | Default: 30s TBD:check
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_maxcallsend:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.max-call-send-msg-size
 
-    etcd or tarantool
+    The maximum size (in bytes) of a transaction between the cluster and its etcd
+    configuration storage. TBD:check
 
     |
-    | Type: String
-    | Default:
+    | Type: int
+    | Default: 2097152 TBD:check
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_maxcallrecv:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.max-call-recv-msg-size
 
-    etcd or tarantool
+    The maximum size (in bytes) of a transaction between the cluster and its etcd
+    configuration storage. TBD:check
 
     |
-    | Type: String
-    | Default:
+    | Type: int
+    | Default: 2097152 TBD:check
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_username:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.username
 
-    etcd or tarantool
+    A username for accessing the cluster's etcd storage.
 
     |
-    | Type: String
-    | Default:
+    | Type: string
+    | Default: ""
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_password:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.password
 
-    etcd or tarantool
+    A password for accessing the cluster's etcd storage.
 
     |
-    | Type: String
-    | Default:
+    | Type: string
+    | Default: ""
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_rejectold:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.reject-old-cluster
 
-    etcd or tarantool
+    TBD: ??
 
     |
-    | Type: String
+    | Type: bool TBD:check
     | Default:
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_permitwostream:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.permit-without-stream
 
-    etcd or tarantool
+    Whether keepalive pings can be send to the etcd server without active streams.
 
     |
-    | Type: String
-    | Default:
+    | Type: bool
+    | Default: false TBD:check
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_method:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.method
 
-    etcd or tarantool
+    TBD: ??
 
     |
-    | Type: String
+    | Type: string
     | Default:
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_prefix:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.prefix
 
-    etcd or tarantool
+    A prefix for the cluster configuration parameters in etcd.
 
     |
-    | Type: String
-    | Default:
+    | Type: string
+    | Default: "" TBD:check
 
 
 .. _tcm_configuration_reference_initial_cluster_etcd_tls_enabled:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.enabled
 
-    Indicates whether TLS is enabled for etcd connections.
+    Indicates whether TLS is enabled for connections to the cluster's etcd storage.
 
     |
     | Type: bool
@@ -2665,20 +2692,20 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.username
 
-    etcd or tarantool
+    A username for connecting to the cluster's Tarantool-based configuration storage.
 
     |
-    | Type: String
+    | Type: string
     | Default:
 
 .. _tcm_configuration_reference_initial_cluster_storage_tarantool_password:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.password
 
-    etcd or tarantool
+    A password for connecting to the cluster's Tarantool-based configuration storage.
 
     |
-    | Type: String
+    | Type: string
     | Default:
 
 
@@ -2686,38 +2713,45 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.endpoints
 
-    etcd or tarantool
+    An array of the cluster's Tarantool-based configuration storage URIs.
 
     |
-    | Type: String
-    | Default:
+    | Type: []string
+    | Default: ""
 
 .. _tcm_configuration_reference_initial_cluster_storage_tarantool_method:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.method
 
-    etcd or tarantool
+    TBD: check
+    An authentication method for the cluster's Tarantool-based configuration storage.
+
+    Possible values are the Go's `go-tarantool/Auth <https://pkg.go.dev/github.com/tarantool/go-tarantool#Auth>`__ constants:
+
+    -   ``AutoAuth`` (0)
+    -   ``ChapSha1Auth``
+    -   ``PapSha256Auth``
 
     |
-    | Type: String
-    | Default:
+    | Type: string
+    | Default: ""
 
 .. _tcm_configuration_reference_initial_cluster_storage_tarantool_prefix:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.prefix
 
-    etcd or tarantool
+    A prefix for the cluster configuration parameters in the Tarantool-based configuration storage.
 
     |
-    | Type: String
-    | Default:
+    | Type: string
+    | Default: "" TBD:check
 
 
 .. _tcm_configuration_reference_initial_cluster_storage_tarantool_ssl_key-file:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.key-file
 
-    A path to a TLS private key file to use for connecting to the Tarantool |tcm|
+    A path to a TLS private key file to use for connecting to the cluster's Tarantool-based
     configuration storage.
 
     See also: :ref:`configuration_connections_ssl`.
@@ -2730,7 +2764,7 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.cert-file
 
-    A path to an SSL certificate to use for connecting to the Tarantool |tcm|
+    A path to an SSL certificate to use for connecting to the cluster's Tarantool-based
     configuration storage.
 
     See also: :ref:`configuration_connections_ssl`.
@@ -2743,7 +2777,7 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.ca-file
 
-    A path to a trusted CA certificate to use for connecting to the Tarantool |tcm|
+    A path to a trusted CA certificate to use for connecting to the cluster's Tarantool-based
     configuration storage.
 
     See also: :ref:`configuration_connections_ssl`.
@@ -2756,7 +2790,7 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.ciphers
 
-    A list of SSL cipher suites that can be used for connecting to the Tarantool |tcm|
+    A list of SSL cipher suites that can be used for connecting to the cluster's Tarantool-based
     configuration storage. Possible values are listed in :ref:`<uri>.params.ssl_ciphers <configuration_reference_iproto_uri_params_ssl_ciphers>`.
 
     See also: :ref:`configuration_connections_ssl`.
@@ -2769,7 +2803,7 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.enabled
 
-    A password for an encrypted private SSL key to use for connecting to the Tarantool |tcm|
+    A password for an encrypted private SSL key to use for connecting to the cluster's Tarantool-based
     configuration storage.
 
     See also: :ref:`configuration_connections_ssl`.
@@ -2783,7 +2817,7 @@ upon the first |tcm| startup.
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.password-file
 
     A text file with passwords for encrypted private SSL keys to use
-    for connecting to the Tarantool |tcm| configuration storage.
+    for connecting to the cluster's Tarantool-based configuration storage.
 
     See also: :ref:`configuration_connections_ssl`.
 
@@ -2796,7 +2830,7 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.tarantool-connection.username
 
-    tbd
+    A username for connecting to the cluster instances.
 
     |
     | Type: string
@@ -2806,7 +2840,7 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.tarantool-connection.password
 
-    tbd
+    A password for connecting to the cluster instances.
 
     |
     | Type: string
@@ -2816,7 +2850,9 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.tarantool-connection.method
 
-    tbd
+    An authentication method for connecting to the cluster.
+
+    TBD: values
 
     |
     | Type: string
@@ -2826,21 +2862,21 @@ upon the first |tcm| startup.
 
 .. confval:: initial-settings.clusters.<cluster>.tarantool-connection.timeout
 
-    tbd
+    The cluster request timeout.
 
     |
-    | Type: string
-    | Default: ""
+    | Type: time.Duration
+    | Default: TBD
 
 .. _tcm_configuration_reference_initial_cluster_tarantool_rate-limit:
 
 .. confval:: initial-settings.clusters.<cluster>.tarantool-connection.rate-limit
 
-    tbd
+    The cluster rate limit.
 
     |
-    | Type: string
-    | Default: ""
+    | Type: uint
+    | Default: TBD
 
 .. _tcm_configuration_reference_initial_cluster_tarantool_ssl:
 

--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -2325,7 +2325,7 @@ upon the first |tcm| startup.
 
 .. _tcm_configuration_reference_initial_cluster_name:
 
-.. confval:: initial-settings.clusters.<cluster>.id
+.. confval:: initial-settings.clusters.<cluster>.name
 
     A name to use for the cluster.
 

--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -19,6 +19,7 @@ There are the following groups of |tcm| configuration parameters:
 - :ref:`limits <tcm_configuration_reference_limits>`
 - :ref:`security <tcm_configuration_reference_security>`
 - :ref:`mode <tcm_configuration_reference_mode>`
+- :ref:`initial-settings <tcm_configuration_reference_initial>`
 
 .. _tcm_configuration_reference_cluster:
 
@@ -1096,11 +1097,11 @@ The ``log`` section defines the |tcm|  logging parameters.
 storage
 -------
 
-The ``storage`` section defines the parameters of the |tcm| data storage.
+The ``storage`` section defines the parameters of the |tcm| :ref:`backend store <tcm_backend_store>`.
 
 -   :ref:`storage.provider <tcm_configuration_reference_storage_provider>`
 
-etcd storage parameters:
+etcd backend store parameters:
 
 -   :ref:`storage.etcd.prefix <tcm_configuration_reference_storage_etcd_prefix>`
 -   :ref:`storage.etcd.endpoints <tcm_configuration_reference_storage_etcd_endpoints>`
@@ -1176,7 +1177,7 @@ etcd storage parameters:
 -   :ref:`storage.etcd.embed.initial-cluster-state <tcm_configuration_reference_storage_etcd_embed>`
 -   :ref:`storage.etcd.embed.self-signed-cert-validity <tcm_configuration_reference_storage_etcd_embed>`
 
-Tarantool storage parameters:
+Tarantool backend store parameters:
 
 -   :ref:`storage.tarantool.prefix <tcm_configuration_reference_storage_tarantool_prefix>`
 -   :ref:`storage.tarantool.addr <tcm_configuration_reference_storage_tarantool_addr>`
@@ -2282,3 +2283,571 @@ The ``feature`` section defines the security parameters of |tcm|.
     | Default: false
     | Environment variable: TCM_FEATURE_API_TOKEN
     | Command-line option: ``--feature.api-token``
+
+.. _tcm_configuration_reference_initial:
+
+initial-settings
+----------------
+
+The ``initial-settings`` group defines entities that are created automatically
+upon the first |tcm| startup.
+
+-   :ref:`clusters <tcm_configuration_reference_initial_clusters>`
+
+.. important::
+
+    no env vars?
+    no cli opts?
+
+.. _tcm_configuration_reference_initial_clusters:
+
+.. confval:: initial-settings.clusters
+
+    An array of clusters to connect to |tcm| automatically upon the first startup.
+    TODO: link to instruction
+
+    |
+    | Type: []Cluster
+    | Default: []
+
+
+.. _tcm_configuration_reference_initial_cluster_id:
+
+.. confval:: initial-settings.clusters.<cluster>.id
+
+    An id to use for the cluster.
+    Use 00-00 to customize default cluster settings
+
+    |
+    | Type: String
+    | Default: ?
+
+
+.. _tcm_configuration_reference_initial_cluster_name:
+
+.. confval:: initial-settings.clusters.<cluster>.id
+
+    A name to use for the cluster.
+
+    |
+    | Type: String
+    | Default: ?
+
+.. _tcm_configuration_reference_initial_cluster_description:
+
+.. confval:: initial-settings.clusters.<cluster>.description
+
+    A name to use for the cluster.
+
+    |
+    | Type: String
+    | Default: ?
+
+
+.. _tcm_configuration_reference_initial_cluster_color:
+
+.. confval:: initial-settings.clusters.<cluster>.color
+
+    An id to use for the cluster.
+    Use 00-00 to customize default cluster settings
+
+    |
+    | Type: String
+    | Default: ?
+
+
+.. _tcm_configuration_reference_initial_cluster_urls:
+
+.. confval:: initial-settings.clusters.<cluster>.urls
+
+    An array of URLs.
+
+    |
+    | Type: []ClusterUrl
+    | Default: []
+
+
+.. _tcm_configuration_reference_initial_cluster_url_label:
+
+.. confval:: initial-settings.clusters.<cluster>.<url>.label
+
+    An array of URLs.
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_url_url:
+
+.. confval:: initial-settings.clusters.<cluster>.<url>.url
+
+    An array of URLs.
+
+    |
+    | Type: String
+    | Default:
+
+
+
+.. _tcm_configuration_reference_initial_cluster_storage_provider:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.provider
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_endpoints:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.endpoints
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_autosync:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.auto-sync-interval
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_dialtimeout:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.dial-timeout
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_dialkatime:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.dial-keep-alive-time
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_dialkatimeout:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.dial-keep-alive-timeout
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_maxcallsend:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.max-call-send-msg-size
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_maxcallrecv:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.max-call-recv-msg-size
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_username:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.username
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_password:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.password
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_rejectold:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.reject-old-cluster
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_permitwostream:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.permit-without-stream
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_method:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.method
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_etcd_prefix:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.prefix
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_enabled:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.enabled
+
+    Indicates whether TLS is enabled for etcd connections.
+
+    |
+    | Type: bool
+    | Default: false
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_cert-file:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.cert-file
+
+    A path to a TLS certificate file to use for etcd connections.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_key-file:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.key-file
+
+    A path to a TLS private key file to use for etcd connections.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_trusted-ca-file:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.trusted-ca-file
+
+    A path to a trusted CA certificate file to use for etcd connections.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_client-cert-auth:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.client-cert-auth
+
+    Indicates whether client cert authentication is enabled.
+
+    |
+    | Type: bool
+    | Default: false
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_crl-file:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.crl-file
+
+    A path to the client certificate revocation list file.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_insecure-skip-verify:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.insecure-skip-verify
+
+    Skip checking client certificate in etcd connections.
+
+    |
+    | Type: bool
+    | Default: false
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_skip-client-san-verify:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.skip-client-san-verify
+
+    Skip verification of SAN field in client certificate for etcd connections.
+
+    |
+    | Type: bool
+    | Default: false
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_server-name:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.server-name
+
+    Name of the TLS server for etcd connections.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_cipher-suites:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.cipher-suites
+
+    TLS cipher suites for etcd connections. Possible values are the Golang `tls.TLS_* <https://pkg.go.dev/crypto/tls#pkg-constants>`__ constants.
+
+    |
+    | Type: []uint16
+    | Default: []
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_allowed-cn:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.allowed-cn
+
+    An allowed common name for authentication in etcd connections.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_allowed-hostname:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.allowed-hostname
+
+    An allowed TLS certificate name for authentication in etcd connections.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_etcd_tls_empty-cn:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.tls.empty-cn
+
+    Whether the empty common name is allowed in etcd connections.
+
+    |
+    | Type: bool
+    | Default: false
+
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_username:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.username
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_password:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.password
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_endpoints:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.endpoints
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_method:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.method
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_prefix:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.prefix
+
+    etcd or tarantool
+
+    |
+    | Type: String
+    | Default:
+
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_ssl_key-file:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.key-file
+
+    A path to a TLS private key file to use for connecting to the Tarantool |tcm|
+    configuration storage.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_ssl_cert-file:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.cert-file
+
+    A path to an SSL certificate to use for connecting to the Tarantool |tcm|
+    configuration storage.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_ssl_ca-file:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.ca-file
+
+    A path to a trusted CA certificate to use for connecting to the Tarantool |tcm|
+    configuration storage.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_ssl_ciphers:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.ciphers
+
+    A list of SSL cipher suites that can be used for connecting to the Tarantool |tcm|
+    configuration storage. Possible values are listed in :ref:`<uri>.params.ssl_ciphers <configuration_reference_iproto_uri_params_ssl_ciphers>`.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_ssl_enabled:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.enabled
+
+    A password for an encrypted private SSL key to use for connecting to the Tarantool |tcm|
+    configuration storage.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_storage_tarantool_ssl_password-file:
+
+.. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.ssl.password-file
+
+    A text file with passwords for encrypted private SSL keys to use
+    for connecting to the Tarantool |tcm| configuration storage.
+
+    See also: :ref:`configuration_connections_ssl`.
+
+    |
+    | Type: string
+    | Default: ""
+
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_username:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.username
+
+    tbd
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_password:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.password
+
+    tbd
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_method:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.method
+
+    tbd
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_timeout:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.timeout
+
+    tbd
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_rate-limit:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.rate-limit
+
+    tbd
+
+    |
+    | Type: string
+    | Default: ""
+
+.. _tcm_configuration_reference_initial_cluster_tarantool_ssl:
+
+.. confval:: initial-settings.clusters.<cluster>.tarantool-connection.ssl
+
+    tbd
+
+    |
+    | Type: string
+    | Default: ""

--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -2420,10 +2420,11 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
     -   ``etcd``
     -   ``tarantool``
+    -   empty string (undefined)
 
     |
     | Type: string
-    | Default: ??TODO
+    | Default: ""
 
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_endpoints:
 
@@ -2724,7 +2725,6 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.tarantool-connection.method
 
-    TBD: check
     An authentication method for the cluster's Tarantool-based configuration storage.
 
     Possible values are the Go's `go-tarantool/Auth <https://pkg.go.dev/github.com/tarantool/go-tarantool#Auth>`__ constants:
@@ -2745,7 +2745,7 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
     |
     | Type: string
-    | Default: "" TODO:check
+    | Default: ""
 
 
 .. _tcm_configuration_reference_initial_cluster_storage_tarantool_ssl_key-file:
@@ -2853,7 +2853,11 @@ TODO: doc link :ref:`tcm_configuration_initial`
 
     An authentication method for connecting to the cluster.
 
-    TODO: values
+    Possible values are the Go's `go-tarantool/Auth <https://pkg.go.dev/github.com/tarantool/go-tarantool#Auth>`__ constants:
+
+    -   ``AutoAuth`` (0)
+    -   ``ChapSha1Auth``
+    -   ``PapSha256Auth``
 
     |
     | Type: string

--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -2540,16 +2540,6 @@ See also :ref:`tcm_configuration_initial`.
     | Type: bool
     | Default: false
 
-.. _tcm_configuration_reference_initial_cluster_storage_etcd_method:
-
-.. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.method
-
-    TBD: ??
-
-    |
-    | Type: string
-    | Default:
-
 .. _tcm_configuration_reference_initial_cluster_storage_etcd_prefix:
 
 .. confval:: initial-settings.clusters.<cluster>.storage-connection.etcd-connection.prefix

--- a/doc/tooling/tcm/tcm_connect_clusters.rst
+++ b/doc/tooling/tcm/tcm_connect_clusters.rst
@@ -16,13 +16,18 @@ A single |tcm| installation can have multiple connected clusters. A connection t
 |tcm| doesn't affect the cluster's functioning. You can connect clusters to |tcm|
 and disconnect them on the fly.
 
-There are two ways to add a cluster to |tcm|:
+There are two scenarios of cluster connection to |tcm|:
 
 -   Connect an existing cluster.
--   Add a new cluster and :ref:`write its configuration <getting_started_tcm_cluster_config>` from scratch in the |tcm| web UI.
+-   Add a new cluster and :ref:`write its configuration <getting_started_tcm_cluster_config>` from scratch in the |tcm|
+    web interface.
 
 In both cases, you need to deploy Tarantool and start the cluster instances using
 the :ref:`tt-cli` or another suitable way.
+
+To add a cluster to |tcm|, you can use either the |tcm| web interface as described on this page,
+or the ``initial-settings.clusters`` section of the |tcm| configuration. To learn
+more, see :ref:`tcm_configuration_initial`.
 
 ..  _tcm_connect_clusters_parameters:
 

--- a/doc/tooling/tcm/tcm_connect_clusters.rst
+++ b/doc/tooling/tcm/tcm_connect_clusters.rst
@@ -25,9 +25,11 @@ There are two scenarios of cluster connection to |tcm|:
 In both cases, you need to deploy Tarantool and start the cluster instances using
 the :ref:`tt-cli` or another suitable way.
 
-To add a cluster to |tcm|, you can use either the |tcm| web interface as described on this page,
-or the ``initial-settings.clusters`` section of the |tcm| configuration. To learn
-more, see :ref:`tcm_configuration_initial`.
+To add a cluster to |tcm|, you can use two ways:
+
+-   Use the |tcm| web interface as described on this page.
+-   Specify the ``initial-settings.clusters`` section of the |tcm| configuration.
+    To learn more, see :ref:`tcm_configuration_initial`.
 
 ..  _tcm_connect_clusters_parameters:
 

--- a/doc/tooling/tcm/tcm_connect_clusters.rst
+++ b/doc/tooling/tcm/tcm_connect_clusters.rst
@@ -10,7 +10,7 @@ Connecting clusters
 |tcm_full_name| works with clusters that:
 
 *   run on Tarantool EE 3.0 or later
-*   use :ref:`centralized configuration <configuration>` stored in etcd or another Tarantool cluster.
+*   use :ref:`centralized configuration <configuration_etcd>` storage: etcd or Tarantool-based.
 
 A single |tcm| installation can have multiple connected clusters. A connection to
 |tcm| doesn't affect the cluster's functioning. You can connect clusters to |tcm|


### PR DESCRIPTION
Resolves #4612 

- Add [initial-settings](https://docs.d.tarantool.io/en/doc/gh-4612-initial-settings/tooling/tcm/tcm_configuration_reference/#tcm-configuration-reference-initial) section to the TCM config reference
- Add a section about adding clusters via config to [TCM > Configuration](https://docs.d.tarantool.io/en/doc/gh-4612-initial-settings/tooling/tcm/tcm_configuration/#initial-settings) page
- Add a link to the section above to [TCM > Connecting clusters](https://docs.d.tarantool.io/en/doc/gh-4612-initial-settings/tooling/tcm/tcm_connect_clusters/)

Deployment: https://docs.d.tarantool.io/en/doc/gh-4612-initial-settings/tooling/tcm/tcm_configuration/