### PR TITLE
Add tt 2.5 small features

### DIFF
--- a/doc/admin/server_introspection.rst
+++ b/doc/admin/server_introspection.rst
@@ -79,8 +79,6 @@ To check the instance status, run:
 .. code-block:: console
 
     $ tt status my_app
-    INSTANCE     STATUS      PID   MODE
-    my_app       RUNNING     67172 RW
 
     $ # - OR -
 

--- a/doc/getting_started/getting_started_db.rst
+++ b/doc/getting_started/getting_started_db.rst
@@ -76,8 +76,8 @@ Starting an instance
     ..  code-block:: console
 
         $ tt status create_db
-        INSTANCE                       STATUS      PID   MODE
-        create_db:instance001          RUNNING     54560 RW
+        INSTANCE               STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
+        create_db:instance001  RUNNING  8685  RW    ready   running  --
 
 #.  Connect to the instance with :ref:`tt connect <tt-connect>`:
 

--- a/doc/getting_started/getting_started_tcm.rst
+++ b/doc/getting_started/getting_started_tcm.rst
@@ -253,7 +253,7 @@ To deploy a local cluster based on the configuration from etcd:
     .. code-block:: console
 
         $ tt status cluster
-        INSTANCE               STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
+        INSTANCE              STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
         cluster:instance-001  RUNNING  8747  RW    ready   running  --
         cluster:instance-002  RUNNING  8748  RO    ready   running  --
         cluster:instance-003  RUNNING  8749  RO    ready   running  --

--- a/doc/getting_started/getting_started_tcm.rst
+++ b/doc/getting_started/getting_started_tcm.rst
@@ -253,10 +253,10 @@ To deploy a local cluster based on the configuration from etcd:
     .. code-block:: console
 
         $ tt status cluster
-        INSTANCE                 STATUS      PID   MODE
-        cluster:instance-001     RUNNING     2058  RW
-        cluster:instance-002     RUNNING     2059  RO
-        cluster:instance-003     RUNNING     2060  RO
+        INSTANCE               STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
+        cluster:instance-001  RUNNING  8747  RW    ready   running  --
+        cluster:instance-002  RUNNING  8748  RO    ready   running  --
+        cluster:instance-003  RUNNING  8749  RO    ready   running  --
 
 ..  _getting_started_tcm_manage:
 

--- a/doc/platform/replication/replication_tutorials/repl_bootstrap.rst
+++ b/doc/platform/replication/replication_tutorials/repl_bootstrap.rst
@@ -137,9 +137,9 @@ Starting instances
     .. code-block:: console
 
         $ tt status manual_leader
-        INSTANCE                      STATUS      PID   MODE
-        manual_leader:instance001     RUNNING     15272 RW
-        manual_leader:instance002     RUNNING     15273 RO
+        INSTANCE                   STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
+        manual_leader:instance001  RUNNING  8841  RW    ready   running  --
+        manual_leader:instance002  RUNNING  8842  RO    ready   running  --
 
 
 .. _replication-master_replica_status:
@@ -292,10 +292,10 @@ Starting an instance
     .. code-block:: console
 
         $ tt status manual_leader
-        INSTANCE                      STATUS      PID   MODE
-        manual_leader:instance001     RUNNING     15272 RW
-        manual_leader:instance002     RUNNING     15273 RO
-        manual_leader:instance003     RUNNING     15551 RO
+        INSTANCE                   STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
+        manual_leader:instance001  RUNNING  8841  RW    ready   running  --
+        manual_leader:instance002  RUNNING  8842  RO    ready   running  --
+        manual_leader:instance003  RUNNING  8856  RO    ready   running  --
 
 
 ..  _replication-add_instances-reload-config:

--- a/doc/platform/replication/replication_tutorials/repl_bootstrap_auto.rst
+++ b/doc/platform/replication/replication_tutorials/repl_bootstrap_auto.rst
@@ -135,10 +135,10 @@ Starting instances
     .. code-block:: console
 
         $ tt status auto_leader
-        INSTANCE                    STATUS      PID   MODE
-        auto_leader:instance001     RUNNING     24768 RO
-        auto_leader:instance002     RUNNING     24769 RW
-        auto_leader:instance003     RUNNING     24767 RO
+        INSTANCE                 STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
+        auto_leader:instance001  RUNNING  9170  RO    ready   running  --
+        auto_leader:instance002  RUNNING  9171  RO    ready   running  --
+        auto_leader:instance003  RUNNING  9172  RW    ready   running  --
 
 
 

--- a/doc/platform/replication/replication_tutorials/repl_bootstrap_master_master.rst
+++ b/doc/platform/replication/replication_tutorials/repl_bootstrap_master_master.rst
@@ -141,9 +141,9 @@ Starting instances
     .. code-block:: console
 
         $ tt status master_master
-        INSTANCE                      STATUS      PID   MODE
-        master_master:instance001     RUNNING     30818 RW
-        master_master:instance002     RUNNING     30819 RW
+        INSTANCE                   STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
+        master_master:instance001  RUNNING  9263  RW    ready   running  --
+        master_master:instance002  RUNNING  9264  RW    ready   running  --
 
 
 .. _replication-master-master-check-status:

--- a/doc/tooling/tt_cli/install.rst
+++ b/doc/tooling/tt_cli/install.rst
@@ -62,8 +62,9 @@ Details
 -------
 
 When called without an explicitly specified version, ``tt install`` installs the
-latest available version. To check versions available for installation, use
-:doc:`tt search <search>`.
+latest available version. If the version is specified in the incomplete format ``<MAJOR>.<MINOR>``,
+the command installs the latest available patch version in the series.
+To check versions available for installation, use :doc:`tt search <search>`.
 
 By default, available versions of Tarantool Community Edition and ``tt`` are taken from their git repositories.
 Their installation includes building from sources, which requires some tools and
@@ -143,6 +144,12 @@ Example
     ..  code-block:: console
 
         $ tt install tarantool
+
+*   Install the latest available patch version of Tarantool CE 3.2 release series:
+
+    ..  code-block:: console
+
+        $ tt install tarantool 3.2
 
 *   Install Tarantool 2.11.1 from the local repository:
 

--- a/doc/tooling/tt_cli/install.rst
+++ b/doc/tooling/tt_cli/install.rst
@@ -24,7 +24,7 @@ or ``tt``. The possible values of ``PROGRAM_NAME`` are:
 Additionally, ``tt install`` can build open source programs ``tarantool`` and ``tt``
 from a specific commit or a pull request on their GitHub repositories.
 
-To uninstall a Tarantool or ``tt`` version, use :doc:`tt uninstall <uninstall>`.
+To uninstall a Tarantool or ``tt`` version, use :ref:`tt uninstall <tt-uninstall>`.
 
 Options
 -------
@@ -64,7 +64,7 @@ Details
 When called without an explicitly specified version, ``tt install`` installs the
 latest available version. If the version is specified in the incomplete format ``<MAJOR>.<MINOR>``,
 the command installs the latest available patch version in the series.
-To check versions available for installation, use :doc:`tt search <search>`.
+To check versions available for installation, use :ref:`tt search <tt-search>`.
 
 By default, available versions of Tarantool Community Edition and ``tt`` are taken from their git repositories.
 Their installation includes building from sources, which requires some tools and

--- a/doc/tooling/tt_cli/start_stop_instance.rst
+++ b/doc/tooling/tt_cli/start_stop_instance.rst
@@ -73,21 +73,20 @@ To check the status of instances, execute :ref:`tt status <tt-status>`:
 .. code-block:: console
 
     $ tt status sharded_cluster_crud
-    INSTANCE                          STATUS      PID   MODE
-    sharded_cluster_crud:storage-a-001     RUNNING     2023  RW
-    sharded_cluster_crud:storage-a-002     RUNNING     2026  RO
-    sharded_cluster_crud:storage-b-001     RUNNING     2020  RW
-    sharded_cluster_crud:storage-b-002     RUNNING     2021  RO
-    sharded_cluster_crud:router-a-001      RUNNING     2022  RW
+     INSTANCE                            STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
+     sharded_cluster_crud:router-a-001   RUNNING  8382  RW    ready   running  --
+     sharded_cluster_crud:storage-a-001  RUNNING  8386  RW    ready   running  --
+     sharded_cluster_crud:storage-a-002  RUNNING  8390  RO    ready   running  --
+     sharded_cluster_crud:storage-b-001  RUNNING  8379  RW    ready   running  --
+     sharded_cluster_crud:storage-b-002  RUNNING  8380  RO    ready   running  --
 
 To check the status of a specific instance, you need to specify its name:
 
 .. code-block:: console
 
     $ tt status sharded_cluster_crud:storage-a-001
-    INSTANCE                          STATUS      PID   MODE
-    sharded_cluster_crud:storage-a-001     RUNNING     2023  RW
-
+     INSTANCE                            STATUS   PID   MODE  CONFIG  BOX      UPSTREAM
+     sharded_cluster_crud:storage-a-001  RUNNING  8386  RW    ready   running  --
 
 .. _admin-start_stop_instance_connect:
 

--- a/doc/tooling/tt_cli/status.rst
+++ b/doc/tooling/tt_cli/status.rst
@@ -5,15 +5,18 @@ Checking instance status
 
 ..  code-block:: console
 
-    $ tt status [APPLICATION[:APP_INSTANCE]] [-p|--pretty]
+    $ tt status [APPLICATION[:APP_INSTANCE]] [OPTION ...]
 
 ``tt status`` prints the information about Tarantool applications and instances
 in the current environment. This includes:
 
-- Application and instance names
-- Instance statuses: running or not
-- PIDs
-- Instance modes: read-write or read-only
+-   ``INSTANCE`` -- application and instance names
+-   ``STATUS`` -- instance status: running, not running, or terminated with an error
+-   ``PID`` -- process IDs
+-   ``MODE`` -- instance modes: read-write or read-only
+-   ``CONFIG`` -- the instances' states in regard to configuration for Tarantool 3.0 or later (see :ref:`config.info() <config_api_reference_info>`)
+-   ``BOX`` -- the instances' :ref:`box.info() <box_info_info>` statuses
+-   ``UPSTREAM`` -- the instances' :ref:`box.info.replication[*].upstream <box_info_replication>` statuses
 
 When called without arguments, prints the status of all enabled applications in the current environment.
 
@@ -40,6 +43,10 @@ Examples
 
 Options
 -------
+
+..  option:: -d, --details
+
+    Print detailed alerts.
 
 ..  option:: -p, --pretty
 

--- a/doc/tooling/tt_cli/stop.rst
+++ b/doc/tooling/tt_cli/stop.rst
@@ -8,7 +8,9 @@ Stopping a Tarantool instance
     $ tt stop [APPLICATION[:APP_INSTANCE]]
 
 ``tt stop`` stops the specified running Tarantool applications or instances.
-When called without arguments, stops all running applications in the current environment.
+Before stopping the instances, the command prompts the user for confirmation.
+
+When called without arguments, ``tt stop`` stops all running applications in the current environment.
 
 See also: :ref:`tt-start`, :ref:`tt-restart`, :ref:`tt-status`.
 
@@ -21,9 +23,23 @@ Examples
 
         $ tt stop app
 
+
+*   Stop all instances of the ``app`` application without confirmation:
+
+    ..  code-block:: console
+
+        $ tt stop app -y
+
 *   Stop the ``replica`` instance of the ``app`` application:
 
     ..  code-block:: console
 
         $ tt stop app:replica
 
+
+Options
+-------
+
+.. option:: -y, --yes
+
+    Stop instances without confirmation.


### PR DESCRIPTION
Resolves #4607, #4606, #4566 

- [tt install](https://docs.d.tarantool.io/en/doc/gh-4606-tt-2-5/tooling/tt_cli/install/): add info how to use incomplete version and an example
- [tt stop](https://docs.d.tarantool.io/en/doc/gh-4606-tt-2-5/tooling/tt_cli/stop/): add info about confirmation and `-y`/`--yes`
- [tt status](https://docs.d.tarantool.io/en/doc/gh-4606-tt-2-5/tooling/tt_cli/status/): add info about the extended output structure and `-d`/`--details`
- Update examples of `tt status` output in tutorials throughout the docs

Deployment: https://docs.d.tarantool.io/en/doc/gh-4606-tt-2-5/tooling/tt_cli/commands/