### PR TITLE
Add box.watch_once()

### DIFF
--- a/doc/reference/reference_lua/box_events.rst
+++ b/doc/reference/reference_lua/box_events.rst
@@ -68,7 +68,7 @@ Below is a list of all functions and pages related to watchers or events.
            - Create a local watcher.
 
         *  - :ref:`box.watch_once() <box-watch>`
-           - Create a local watcher for a single use.
+           - Get the current key value.
 
         *  - :ref:`conn:watch() <conn-watch>`
            - Create a watcher for the remote host.

--- a/doc/reference/reference_lua/box_events.rst
+++ b/doc/reference/reference_lua/box_events.rst
@@ -64,8 +64,11 @@ Below is a list of all functions and pages related to watchers or events.
         *   - Name
             - Use
 
-        *  - :doc:`./box_events/watch`
+        *  - :ref:`box.watch() <box-watch>`
            - Create a local watcher.
+
+        *  - :ref:`box.watch_once() <box-watch>`
+           - Create a local watcher for a single use.
 
         *  - :ref:`conn:watch() <conn-watch>`
            - Create a watcher for the remote host.
@@ -80,5 +83,6 @@ Below is a list of all functions and pages related to watchers or events.
     :hidden:
 
     box_events/watch
+    box_events/watch_once
     box_events/broadcast
     box_events/system_events

--- a/doc/reference/reference_lua/box_events/watch_once.rst
+++ b/doc/reference/reference_lua/box_events/watch_once.rst
@@ -1,0 +1,37 @@
+.. _box-watch_once:
+
+box.watch_once()
+================
+
+..  function:: box.watch_once(key, func)
+
+    Returns the current value of a given notification key.
+    The function can be used as an alternative to :ref:`box.watch() <box-watch>`
+    for cases when the caller only needs to retrieve the current value without
+    subscribing to future changes.
+
+    :param string key: key name
+
+    :return: the key value
+
+    To read more about watchers, see the :ref:`Functions for watchers <box-watchers>` section.
+
+    **Example:**
+
+    ..  code-block:: lua
+
+        -- Broadcast value 42 for the 'foo' key.
+        box.broadcast('foo', 42)
+
+        -- Get the value of this key
+        tarantool> box.watch_once('foo')
+        ---
+        ...
+
+        -- Non-existent keys' values are empty
+        tarantool> box.watch_once('none')
+        ---
+        ...
+
+
+

--- a/doc/reference/reference_lua/box_events/watch_once.rst
+++ b/doc/reference/reference_lua/box_events/watch_once.rst
@@ -7,14 +7,13 @@ box.watch_once()
 
     Returns the current value of a given notification key.
     The function can be used as an alternative to :ref:`box.watch() <box-watch>`
-    for cases when the caller only needs to retrieve the current value without
-    subscribing to future changes.
+    when the caller only needs the current value without subscribing to future changes.
 
     :param string key: key name
 
     :return: the key value
 
-    To read more about watchers, see the :ref:`Functions for watchers <box-watchers>` section.
+    To read more about watchers, see the :ref:`box-watchers` section.
 
     **Example:**
 

--- a/doc/reference/reference_lua/box_events/watch_once.rst
+++ b/doc/reference/reference_lua/box_events/watch_once.rst
@@ -25,6 +25,7 @@ box.watch_once()
         -- Get the value of this key
         tarantool> box.watch_once('foo')
         ---
+        - 42
         ...
 
         -- Non-existent keys' values are empty


### PR DESCRIPTION
Resolves #3510 

- Add new reference page [box.watch_once()](https://docs.d.tarantool.io/en/doc/gh-3510-box-watch-once/reference/reference_lua/box_events/watch_once/) in **Event watchers**
- Mention the new function on the [Event watchers](https://docs.d.tarantool.io/en/doc/gh-3510-box-watch-once/reference/reference_lua/box_events/) page

Deployment: https://docs.d.tarantool.io/en/doc/gh-3510-box-watch-once/reference/reference_lua/box_events/watch_once/