### PR TITLE
Update datetime timezone handling after the fix

### DIFF
--- a/doc/reference/reference_lua/datetime.rst
+++ b/doc/reference/reference_lua/datetime.rst
@@ -221,7 +221,7 @@ Functions
                     tz = 'Europe/Moscow'
                     }
         ---
-        - 2022-07-01T08:30:05.122999906 Europe/Moscow
+        - 2022-07-01T11:30:05.122999906 Europe/Moscow
         ...
 
         tarantool> datetime.new {
@@ -230,7 +230,7 @@ Functions
                     tz = 'Europe/Moscow'
                     }
         ---
-        - 2022-07-01T08:30:05.000000123 Europe/Moscow
+        - 2022-07-01T11:30:05.000000123 Europe/Moscow
         ...
 
 
@@ -713,7 +713,7 @@ datetime_object
 
             tarantool> dt:set {tzoffset = 60}
             ---
-            - 2021-08-20T18:25:20.567+0100
+            - 2021-08-20T16:25:20.567+0100
             ...
 
 


### PR DESCRIPTION
This patch fixes Tarantool output on using `datetime.new()` and `datetime.set()` with timezones specified.

After tarantool/tarantool#10970 datetime objects created/modified with timestamps plus timezones are handled differently from the way they are described in the doc. Now setting timezone only changes the local time of day represented by the datetime object instead of affecting the timestamp.

PR tarantool/tarantool#10970
Issue tarantool/tarantool#10363