### PR TITLE
Add lua memory option

### DIFF
--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3163,7 +3163,7 @@ Specifies the maximum memory amount available to Lua scripts, measured in bytes.
 When the specified value exceeds the current memory usage, the new limit takes effect immediately without a restart.
 However, **when the specified value is lower than the current memory usage, a restart of the instance is required** for the change to take effect.
 
-Example to set the Lua memory limit for 4 GB:
+Example to set the Lua memory limit to 4 GB:
 
 .. code-block:: yaml
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3138,9 +3138,9 @@ log.syslog.*
 lua
 ---
 
-The ``lua`` section outlines the configuration parameters related to the Lua environment within Tarantool.
+The ``lua`` section outlines the configuration parameters related to the ``lua`` environment within Tarantool.
 
-Below is an overview of the available configuration options for Lua:
+Below is an overview of the available configuration options for ``lua``:
 
 - :ref:`lua.memory <configuration_reference_lua>`
 
@@ -3149,7 +3149,7 @@ Below is an overview of the available configuration options for Lua:
 
 .. confval:: lua.memory
 
-Specifies the amount of memory allocated to Lua, measured in bytes.
+Specifies the amount of memory allocated to ``lua``, measured in bytes.
 
 - **Type**: integer
 - **Default Value**: 2GB

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3165,8 +3165,9 @@ However, **when the specified value is lower than the current memory usage, a re
 
 Example to set the Lua memory limit for 4 GB:
 
-``lua:
-    memory: 4294967296``
+.. code-block:: none
+    lua:
+        memory: 4294967296``
 
 ..  _configuration_reference_memtx:
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3165,9 +3165,9 @@ However, **when the specified value is lower than the current memory usage, a re
 
 Example to set the Lua memory limit for 4 GB:
 
-.. code-block:: yaml
+.. code-block:: text
     lua:
-        memory: 4294967296``
+        memory: 4294967296
 
 ..  _configuration_reference_memtx:
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3165,7 +3165,7 @@ However, **when the specified value is lower than the current memory usage, a re
 
 Example to set the Lua memory limit for 4 GB:
 
-.. code-block:: text
+.. code-block:: yaml
 
     lua:
         memory: 4294967296

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3141,7 +3141,7 @@ lua
 The ``lua`` section outlines the configuration parameters related to the Lua environment within Tarantool.
 
 lua.memory
-----------
+~~~~~~~~~~
 
 Specifies the amount of memory allocated to Lua, measured in bytes.
 
@@ -3149,7 +3149,7 @@ Specifies the amount of memory allocated to Lua, measured in bytes.
 - **Minimum Value**: 256MB
 
 Dynamic adjustment behavior
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - If the specified value is **greater** than the current memory usage, the new limit is applied immediately without requiring a restart.
 - If the specified value is **less** than the current memory usage, a **restart** of the instance is required for the change to take effect.

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3138,7 +3138,7 @@ log.syslog.*
 lua
 ---
 
-The lua section outlines the configuration parameters related to the Lua environment within Tarantool.
+The ``lua`` section outlines the configuration parameters related to the Lua environment within Tarantool.
 
 .. NOTE::
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3165,7 +3165,7 @@ However, **when the specified value is lower than the current memory usage, a re
 
 Example to set the Lua memory limit for 4 GB:
 
-.. code-block:: none
+.. code-block:: yaml
     lua:
         memory: 4294967296``
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3136,7 +3136,7 @@ log.syslog.*
 .. _configuration_reference_lua:
 
 lua
-===
+---
 
 The ``lua`` section outlines the configuration parameters related to the Lua environment within Tarantool.
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3166,6 +3166,7 @@ However, **when the specified value is lower than the current memory usage, a re
 Example to set the Lua memory limit for 4 GB:
 
 .. code-block:: text
+
     lua:
         memory: 4294967296
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3153,12 +3153,12 @@ The ``lua`` section outlines the configuration parameters related to the Lua env
 
 .. confval:: lua.memory
 
-Specifies the amount of memory allocated to lua, measured in bytes.
+Specifies the maximum memory amount available to Lua scripts, measured in bytes.
 
  |
  | Type: integer
  | Default Value: 2147483648 (2GB)
- | Environment variable: TT_LUA_MEMORY for the cast value and TT_LUA_MEMORY_DEFAULT for the default value
+ | Environment variable: TT_LUA_MEMORY
 
 When the specified value exceeds the current memory usage, the new limit takes effect immediately without a restart.
 However, **when the specified value is lower than the current memory usage, a restart of the instance is required** for the change to take effect.

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3133,6 +3133,28 @@ log.syslog.*
     | Default: box.NULL
     | Environment variable: TT_LOG_SYSLOG_SERVER
 
+.. _configuration_reference_lua:
+
+lua
+===
+
+The ``lua`` section outlines the configuration parameters related to the Lua environment within Tarantool.
+
+lua.memory
+----------
+
+Specifies the amount of memory allocated to Lua, measured in bytes.
+
+- **Default Value**: 2GB
+- **Minimum Value**: 256MB
+
+Dynamic adjustment behavior
+---------------------------
+
+- If the specified value is **greater** than the current memory usage, the new limit is applied immediately without requiring a restart.
+- If the specified value is **less** than the current memory usage, a **restart** of the instance is required for the change to take effect.
+
+
 ..  _configuration_reference_memtx:
 
 memtx

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3140,16 +3140,18 @@ lua
 
 The ``lua`` section outlines the configuration parameters related to the Lua environment within Tarantool.
 
-lua.memory
-~~~~~~~~~~
+.. _configuration_reference_lua_memory:
+
+.. confval:: lua.memory
 
 Specifies the amount of memory allocated to Lua, measured in bytes.
 
+- **Type**: integer
 - **Default Value**: 2GB
 - **Minimum Value**: 256MB
 
 Dynamic adjustment behavior
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - If the specified value is **greater** than the current memory usage, the new limit is applied immediately without requiring a restart.
 - If the specified value is **less** than the current memory usage, a **restart** of the instance is required for the change to take effect.

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3138,9 +3138,13 @@ log.syslog.*
 lua
 ---
 
-The ``lua`` section outlines the configuration parameters related to the ``lua`` environment within Tarantool.
+The lua section outlines the configuration parameters related to the Lua environment within Tarantool.
 
-Below is an overview of the available configuration options for ``lua``:
+.. NOTE::
+
+    ``lua`` can be defined in any :ref:`scope <configuration_scopes>`.
+
+..  NOTE::
 
 - :ref:`lua.memory <configuration_reference_lua>`
 
@@ -3149,18 +3153,20 @@ Below is an overview of the available configuration options for ``lua``:
 
 .. confval:: lua.memory
 
-Specifies the amount of memory allocated to ``lua``, measured in bytes.
+Specifies the amount of memory allocated to lua, measured in bytes.
 
-- **Type**: integer
-- **Default Value**: 2GB
-- **Minimum Value**: 256MB
+ |
+ | Type: integer
+ | Default Value: 2147483648 (2GB)
+ | Environment variable: TT_LUA_MEMORY for the cast value and TT_LUA_MEMORY_DEFAULT for the default value
 
+When the specified value exceeds the current memory usage, the new limit takes effect immediately without a restart.
+However, **when the specified value is lower than the current memory usage, a restart of the instance is required** for the change to take effect.
 
-**Dynamic adjustment behavior:**
+Example to set the Lua memory limit for 4 GB:
 
-- If the specified value is **greater** than the current memory usage, the new limit is applied immediately without requiring a restart.
-- If the specified value is **less** than the current memory usage, a **restart** of the instance is required for the change to take effect.
-
+``lua:
+    memory: 4294967296``
 
 ..  _configuration_reference_memtx:
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3140,6 +3140,11 @@ lua
 
 The ``lua`` section outlines the configuration parameters related to the Lua environment within Tarantool.
 
+Below is an overview of the available configuration options for Lua:
+
+- :ref:`lua.memory`
+
+
 .. _configuration_reference_lua_memory:
 
 .. confval:: lua.memory
@@ -3150,8 +3155,8 @@ Specifies the amount of memory allocated to Lua, measured in bytes.
 - **Default Value**: 2GB
 - **Minimum Value**: 256MB
 
-Dynamic adjustment behavior
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Dynamic adjustment behavior**
 
 - If the specified value is **greater** than the current memory usage, the new limit is applied immediately without requiring a restart.
 - If the specified value is **less** than the current memory usage, a **restart** of the instance is required for the change to take effect.

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3142,7 +3142,7 @@ The ``lua`` section outlines the configuration parameters related to the Lua env
 
 Below is an overview of the available configuration options for Lua:
 
-- :ref:`lua.memory`
+- :ref:`lua.memory <configuration_reference_lua>`
 
 
 .. _configuration_reference_lua_memory:
@@ -3156,7 +3156,7 @@ Specifies the amount of memory allocated to Lua, measured in bytes.
 - **Minimum Value**: 256MB
 
 
-**Dynamic adjustment behavior**
+**Dynamic adjustment behavior:**
 
 - If the specified value is **greater** than the current memory usage, the new limit is applied immediately without requiring a restart.
 - If the specified value is **less** than the current memory usage, a **restart** of the instance is required for the change to take effect.


### PR DESCRIPTION
Resolves #4649. 

Configuration reference: new section **lua** and subsection **lua.memory** [added.](https://docs.d.tarantool.io/en/doc/gh-4649-newluamemory/reference/configuration/configuration_reference/#configuration-reference-lua)

Deployment https://docs.d.tarantool.io/doc/gh-4649-newluamemory/