### PR TITLE
Add ` replication.autoexpel` configuration option

### DIFF
--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3634,7 +3634,8 @@ The ``replication`` section defines configuration parameters related to :ref:`re
         global levels. It is not applicable at the instance level.
 
 
-    Configuration fields
+Configuration fields
+^^^^^^^^^^^^^^^^^^^^
 
     - ``by`` (string, default: ``nil``): specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
 
@@ -3644,7 +3645,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
 
 
-replication.autoexpel_by.*
+replication.autoexpel.by
 ~~~~~~~~~~~~~
 
     ``replication.autoexpel_by`` purpose is to define the criterion used for determining which instances in a cluster are
@@ -3654,10 +3655,10 @@ replication.autoexpel_by.*
 
     - Instances that are part of the cluster and should adhere to the YAML configuration.
 
-	- Instances or tools (e.g., CDC tools) that use the replication channel but are not part of the cluster configuration.
+    - Instances or tools (e.g., CDC tools) that use the replication channel but are not part of the cluster configuration.
 
 
-    The default value of by is ``nil``, meaning no ``autoexpel`` criterion is applied unless explicitly set.
+    The default value of ``by`` is ``nil``, meaning no ``autoexpel`` criterion is applied unless explicitly set.
 
     Currently, the only supported value for by is ``prefix``. The ``prefix`` value instructs the system to identify instances
     based on their names, matching them against a prefix pattern defined in the configuration.
@@ -3681,7 +3682,7 @@ replication.autoexpel_by.*
 
 
 
-replication.autoexpel_enabled.*
+replication.autoexpel.enabled
 ~~~~~~~~~~~~~
 
     The ``replication.autoexpel_enabled`` field is a boolean configuration option that determines whether the autoexpel logic is active for the cluster.
@@ -3691,8 +3692,8 @@ replication.autoexpel_enabled.*
 
         By default, the ``enabled`` field is set to ``false``, meaning the ``autoexpel`` logic is turned off. This ensures that no instances are automatically removed unless explicitly configured.
 
-    Enabling ``autoexpel`` logic
-
+Enabling ``autoexpel`` logic
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     To enable ``autoexpel``, you should set enabled to true in the ``replication.autoexpel`` section of your YAML configuration:
 
     .. code-block:: yaml
@@ -3707,7 +3708,8 @@ replication.autoexpel_enabled.*
     To disable ``autoexpel``, set enabled to ``false``.
 
 
-    Dependencies
+Dependencies
+^^^^^^^^^^^^
 
     If ``enabled`` is set to ``true``, the following fields are required:
 
@@ -3722,7 +3724,7 @@ replication.autoexpel_enabled.*
     | Environment variable: TT_REPLICATION_AUTOEXPEL_ENABLED
 
 
-replication.autoexpel_prefix.*
+replication.autoexpel.prefix
 ~~~~~~~~~~~~~
 
     The ``prefix`` field filters instances for expulsion by differentiating cluster instances (from the YAML configuration) from external services (e.g., CDC tools). Only instances matching the prefix are considered.
@@ -3753,7 +3755,7 @@ replication.autoexpel_prefix.*
 
     In this setup:
 
-	- Instances are grouped by replicaset names (e.g., ``r-001-i-001`` for ``replicaset r-001``).
+	- Instances are prefixed with a replicaset name (e.g., ``r-001-i-001`` for replicaset ``r-001``).
 	- The prefix ensures that only instances with names matching the replicaset name are auto expelled when removed from the configuration.
 
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3545,6 +3545,7 @@ replication
 The ``replication`` section defines configuration parameters related to :ref:`replication <replication>`.
 
 -   :ref:`replication.anon <configuration_reference_replication_anon>`
+-   :ref:`replication.anon <configuration_reference_replication_autoexpel>`
 -   :ref:`replication.bootstrap_strategy <configuration_reference_replication_bootstrap_strategy>`
 -   :ref:`replication.connect_timeout <configuration_reference_replication_connect_timeout>`
 -   :ref:`replication.election_mode <configuration_reference_replication_election_mode>`
@@ -3599,6 +3600,142 @@ The ``replication`` section defines configuration parameters related to :ref:`re
     | Type: boolean
     | Default: ``false``
     | Environment variable: TT_REPLICATION_ANON
+
+.. _configuration_reference_replication_autoexpel:
+
+.. confval:: replication.autoexpel
+
+    The ``replication.autoexpel`` option designed for managing dynamic clusters using YAML-based configurations.
+    It enables the automatic expulsion of instances that are removed from the YAML configuration.
+
+    Only instances with names that match the specified prefix are considered for expulsion; all others are excluded.
+    Additionally, instances without a persistent name are ignored.
+
+    If an instance is in read-write mode and has the latest database schema, it initiates the expulsion of instances that:
+	- Match the specified prefix
+	- Absent from the updated YAML configuration
+
+    The expulsion process follows the standard procedure, involving the removal of the instance from the ``_cluster`` system space.
+
+    The ``autoexpel`` logic is activated during specific events:
+	- **Startup**. When the cluster starts, ``autoexpel`` checks and removes instances not matching the updated configuration.
+	- **Reconfiguration**. When the YAML configuration is reloaded, ``autoexpel`` compares the current state to the updated configuration and performs necessary expulsions.
+	- ``box.status`` **Watcher Event**. Changes detected by the ``box.status watcher`` also trigger the ``autoexpel`` mechanism.
+
+    New instances
+    ``Autoexpel`` does not take any actions on newly joined instances unless one of the triggering events occurs.
+    This means that an instance meeting the ``autoexpel`` criterion can still join the cluster, but it may be removed
+    later during reconfiguration or on subsequent triggering events.
+
+    ..  NOTE::
+        The ``replication.autoexpel`` option governs the expelling process and is configurable at the replicaset, group, and
+        global levels. It is not applicable at the instance level.
+
+    Configuration fields
+    - **`enabled`** *(boolean, default: `false`)*: enables or disables the ``autoexpel`` logic.
+
+    - **`by`** *(string, default: `nil`)*: specifies the ``autoexpel`` criterion. Currently, only `prefix` is supported and must be explicitly set.
+
+    - **`prefix`** *(string, default: `nil`)*: defines the pattern for instance names that are considered part of the cluster.
+
+      **Example Patterns**:
+      - If instances are prefixed with the replicaset name, set:
+        ``prefix: '{{ replicaset_name }}'``
+      - For instances matching a specific pattern (e.g., `i-\d\d\d`), set:
+        ``prefix: 'i-'``
+
+    **Example**
+
+    1. Create a ``config.yaml`` file with the following content:
+
+    .. code-block:: yaml
+
+        credentials:
+          users:
+            guest:
+              roles: [super]
+
+        replication:
+          failover: manual
+          autoexpel:
+            enabled: true
+            by: prefix
+            prefix: '{{ replicaset_name }}'
+
+        iproto:
+          listen:
+            - uri: 'unix/:./var/run/{{ instance_name }}.iproto'
+
+        groups:
+          g-001:
+            replicasets:
+              r-001:
+                leader: r-001-i-001
+                instances:
+                  r-001-i-001: {}
+                  r-001-i-002: {}
+                  r-001-i-003: {}
+
+
+    This configuration:
+	- Sets up authentication with a guest user assigned the super role.
+	- Enables the autoexpel option to automatically expel instances not present in the YAML file.
+	- Defines instance names based on a prefix pattern: {{ replicaset_name }}.
+	- Lists three instances: r-001-i-001, r-001-i-002, and r-001-i-003.
+
+
+    2. Open terminal window and start three instances using the following commands:
+
+    ``tarantool --name r-001-i-001 --config config.yaml -i``
+
+    ``tarantool --name r-001-i-002 --config config.yaml -i``
+
+    ``tarantool --name r-001-i-003 --config config.yaml -i``
+
+    3. Edit ``config.yaml`` and remove the following entry for ``r-001-i-003``:
+
+    ``r-001-i-003: {}``
+
+
+    The updated ``config.yaml`` should look like this:
+
+    .. code-block:: yaml
+
+        groups:
+          g-001:
+            replicasets:
+              r-001:
+                leader: r-001-i-001
+                instances:
+                  r-001-i-001: {}
+                  r-001-i-002: {}
+
+    Save the file.
+
+    4. For the leader instance (``r-001-i-001``), check the _cluster space:
+
+        ..  admonition:: Info
+        :class: fact
+
+        The ``_cluster`` system space in Tarantool stores metadata about all instances currently recognized as part of the cluster.
+        It shows which instances are registered and active.
+
+    You should see ``r-001-i-003`` still listed in the ``_cluster`` system space.
+
+    5. Reload the configuration:
+
+    .. code-block:: lua
+
+        config = require('config')
+            config:reload()
+
+    6. Verify the changes:
+
+    ``box.space._cluster:fselect()``
+
+    After the reload, ``r-001-i-003`` should no longer appear in the ``_cluster`` system space.
+
+
 
 .. _configuration_reference_replication_bootstrap_strategy:
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3620,9 +3620,8 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
 	- **Startup**. When the cluster starts, ``autoexpel`` checks and removes instances not matching the updated configuration.
 	- **Reconfiguration**. When the YAML configuration is reloaded, ``autoexpel`` compares the current state to the updated configuration and performs necessary expulsions.
-	- ``box.status`` **Watcher event**. Changes detected by the ``box.status watcher`` also trigger the ``autoexpel`` mechanism.
+	- ``box.status`` **Watcher event**. Changes detected by the ``box.status`` watcher also trigger the ``autoexpel`` mechanism.
 
-    New instances
 
     ``autoexpel`` does not take any actions on newly joined instances unless one of the triggering events occurs.
     This means that an instance meeting the ``autoexpel`` criterion can still join the cluster, but it may be removed
@@ -3635,7 +3634,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     Configuration fields
 
-    - ``by`` (string, default: ``nil``): specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
+    - ``by`` :ref:`replication.autoexpel_by.*` (string, default: ``nil``): specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
 
     - ``enabled`` (boolean, default: ``false``): enables or disables the ``autoexpel`` logic.
 
@@ -3762,7 +3761,7 @@ replication.autoexpel_prefix.*
             prefix: 'i-'
 
     In this setup:
-    - All instances with names starting with ``i-`` (e.g., v``i-001``, ``i-002``) are considered for expulsion.
+    - All instances with names starting with ``i-`` (e.g., ``i-001``, ``i-002``) are considered for expulsion.
     - This is useful when instances follow a uniform naming convention.
 
     |
@@ -3771,7 +3770,7 @@ replication.autoexpel_prefix.*
     | Environment variable: TT_REPLICATION_PREFIX
 
 
-    ** Full Example**
+    **Full Example**
 
     1. Create a ``config.yaml`` file with the following content:
 
@@ -3862,7 +3861,7 @@ replication.autoexpel_prefix.*
     .. code-block:: lua
 
         config = require('config')
-            config:reload()
+        config:reload()
 
     6. Verify the changes:
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3656,7 +3656,7 @@ replication.autoexpel.by
     Currently, the only supported value for by is ``prefix``. The ``prefix`` value instructs the system to identify instances
     based on their names, matching them against a prefix pattern defined in the configuration.
 
-    If the ``autoexpel`` feature is enabled (``enabled: true``), the ``by`` field must be explicitly set to ``prefix``.
+    If the ``autoexpel`` feature is enabled, the ``by`` field must be explicitly set to ``prefix``.
 
     The absence of this field or an unsupported value will result in configuration errors.
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3690,15 +3690,24 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     2. Open terminal window and start three instances using the following commands:
 
-    ``tarantool --name r-001-i-001 --config config.yaml -i``
+    .. code-block:: lua
 
-    ``tarantool --name r-001-i-002 --config config.yaml -i``
+        tarantool --name r-001-i-001 --config config.yaml -i
 
-    ``tarantool --name r-001-i-003 --config config.yaml -i``
+
+    .. code-block:: lua
+
+        tarantool --name r-001-i-002 --config config.yaml -i``
+
+
+    .. code-block:: lua
+
+        tarantool --name r-001-i-003 --config config.yaml -i
 
     3. Edit ``config.yaml`` and remove the following entry for ``r-001-i-003``:
 
-    ``r-001-i-003: {}``
+    .. code-block:: lua
+        r-001-i-003: {}
 
 
     The updated ``config.yaml`` should look like this:
@@ -3734,7 +3743,9 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     6. Verify the changes:
 
-    ``box.space._cluster:fselect()``
+    .. code-block:: lua
+
+        box.space._cluster:fselect()
 
     After the reload, ``r-001-i-003`` should no longer appear in the ``_cluster`` system space.
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3617,6 +3617,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
     The expulsion process follows the standard procedure, involving the removal of the instance from the ``_cluster`` system space.
 
     The ``autoexpel`` logic is activated during specific events:
+
 	- **Startup**. When the cluster starts, ``autoexpel`` checks and removes instances not matching the updated configuration.
 	- **Reconfiguration**. When the YAML configuration is reloaded, ``autoexpel`` compares the current state to the updated configuration and performs necessary expulsions.
 	- ``box.status`` **Watcher event**. Changes detected by the ``box.status watcher`` also trigger the ``autoexpel`` mechanism.
@@ -3633,15 +3634,17 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     Configuration fields
 
-    - **`enabled`** *(boolean, default: `false`)*: enables or disables the ``autoexpel`` logic.
+    - ``enabled`` *(boolean, default: ``false``)*: enables or disables the ``autoexpel`` logic.
 
-    - **`by`** *(string, default: `nil`)*: specifies the ``autoexpel`` criterion. Currently, only `prefix` is supported and must be explicitly set.
+    - ``by`` *(string, default: ``nil``)*: specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
 
-    - **`prefix`** *(string, default: `nil`)*: defines the pattern for instance names that are considered part of the cluster.
+    - ``prefix`` *(string, default: ``nil``)*: defines the pattern for instance names that are considered part of the cluster.
 
       **Example Patterns**:
+
       - If instances are prefixed with the replicaset name, set:
         ``prefix: '{{ replicaset_name }}'``
+
       - For instances matching a specific pattern (e.g., `i-\d\d\d`), set:
         ``prefix: 'i-'``
 
@@ -3679,7 +3682,6 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
 
     This configuration:
-
 	- Sets up authentication with a guest user assigned the super role.
 	- Enables the ``autoexpel`` option to automatically expel instances not present in the YAML file.
 	- Defines instance names based on a prefix pattern: ``{{ replicaset_name }}``.

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3545,7 +3545,7 @@ replication
 The ``replication`` section defines configuration parameters related to :ref:`replication <replication>`.
 
 -   :ref:`replication.anon <configuration_reference_replication_anon>`
--   :ref:`replication.anon <configuration_reference_replication_autoexpel>`
+-   :ref:`replication.autoexpel <configuration_reference_replication_autoexpel>`
 -   :ref:`replication.bootstrap_strategy <configuration_reference_replication_bootstrap_strategy>`
 -   :ref:`replication.connect_timeout <configuration_reference_replication_connect_timeout>`
 -   :ref:`replication.election_mode <configuration_reference_replication_election_mode>`

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3634,11 +3634,11 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     Configuration fields
 
-    - ``enabled`` *(boolean, default: ``false``)*: enables or disables the ``autoexpel`` logic.
+    - ``enabled`` (boolean, default: ``false``): enables or disables the ``autoexpel`` logic.
 
-    - ``by`` *(string, default: ``nil``)*: specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
+    - ``by`` (string, default: ``nil``): specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
 
-    - ``prefix`` *(string, default: ``nil``)*: defines the pattern for instance names that are considered part of the cluster.
+    - ``prefix`` (string, default: ``nil``): defines the pattern for instance names that are considered part of the cluster.
 
       **Example Patterns**:
 
@@ -3716,7 +3716,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     Save the file.
 
-    4. For the leader instance (``r-001-i-001``), check the _cluster space:
+    4. For the leader instance (``r-001-i-001``), check the ``_cluster`` space:
 
     .. hint::
 
@@ -3738,6 +3738,13 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     After the reload, ``r-001-i-003`` should no longer appear in the ``_cluster`` system space.
 
+    |
+    | Type: boolean
+    | Default: false
+    | Environment variable:
+    | TT_REPLICATION_AUTOEXPEL_BY
+    | TT_REPLICATION_AUTOEXPEL_ENABLED
+    | TT_REPLICATION_AUTOEXPEL_PREFIX
 
 
 .. _configuration_reference_replication_bootstrap_strategy:

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3632,23 +3632,146 @@ The ``replication`` section defines configuration parameters related to :ref:`re
         The ``replication.autoexpel`` option governs the expelling process and is configurable at the replicaset, group, and
         global levels. It is not applicable at the instance level.
 
-    Configuration fields
 
-    - ``enabled`` (boolean, default: ``false``): enables or disables the ``autoexpel`` logic.
+    Configuration fields
 
     - ``by`` (string, default: ``nil``): specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
 
+    - ``enabled`` (boolean, default: ``false``): enables or disables the ``autoexpel`` logic.
+
     - ``prefix`` (string, default: ``nil``): defines the pattern for instance names that are considered part of the cluster.
 
-      **Example Patterns**:
 
-      - If instances are prefixed with the replicaset name, set:
-        ``prefix: '{{ replicaset_name }}'``
 
-      - For instances matching a specific pattern (e.g., `i-\d\d\d`), set:
-        ``prefix: 'i-'``
+replication.autoexpel_by.*
+~~~~~~~~~~~~~
 
-    **Example**
+    ``replication.autoexpel_by`` purpose is to define the criterion used for determining which instances in a cluster are
+    subject to the ``autoexpel`` process.
+
+    The by field helps differentiate between:
+    - Instances that are part of the cluster and should adhere to the YAML configuration.
+	- Instances or tools (e.g., CDC tools) that use the replication channel but are not part of the cluster configuration.
+
+    The default value of by is ``nil``, meaning no ``autoexpel`` criterion is applied unless explicitly set.
+
+    Currently, the only supported value for by is ``prefix``. The ``prefix`` value instructs the system to identify instances
+    based on their names, matching them against a prefix pattern defined in the configuration.
+
+    If the ``autoexpel`` feature is enabled (``enabled: true``), the ``by`` field must be explicitly set to ``prefix``.
+	The absence of this field or an unsupported value will result in configuration errors.
+
+    .. code-block:: yaml
+
+        replication:
+          autoexpel:
+            enabled: true
+            by: prefix
+            prefix: '{{ replicaset_name }}'
+
+    |
+    | Type: string
+    | Default: ``nil``
+    | Environment variable: TT_REPLICATION_BY
+
+
+
+replication.autoexpel_enabled.*
+~~~~~~~~~~~~~
+
+    The ``replication.autoexpel_enabled`` field is a boolean configuration option that determines whether the autoexpel logic is active for the cluster.
+    This feature is designed to automatically manage dynamic cluster configurations by removing instances that are no longer present in the YAML configuration.
+
+    ..  NOTE::
+
+        By default, the ``enabled`` field is set to ``false``, meaning the ``autoexpel`` logic is turned off. This ensures that no instances are automatically removed unless explicitly configured.
+
+    Enabling ``autoexpel`` Logic
+
+    To enable ``autoexpel``, you should set enabled to true in the ``replication.autoexpel`` section of your YAML configuration:
+
+    .. code-block:: yaml
+
+        replication:
+          autoexpel:
+            enabled: true
+            by: prefix
+            prefix: '{{ replicaset_name }}'
+
+
+    To disable ``autoexpel``, set enabled to ``false``.
+
+
+    Dependencies
+
+    If ``enabled`` is set to ``true``, the following fields are required:
+
+        1.	``by``: specifies the criterion for ``autoexpel`` (e.g., ``prefix``).
+        2.	``prefix``: defines the pattern used to match instance names for expulsion.
+
+    Failure to configure these fields when enabled is true will result in a configuration error.
+
+    |
+    | Type: boolean
+    | Default: ``false``
+    | Environment variable: TT_REPLICATION_ENABLED
+
+
+replication.autoexpel_prefix.*
+~~~~~~~~~~~~~
+
+    The ``prefix`` field filters instances for expulsion by differentiating cluster instances (from the YAML configuration) from external services (e.g., CDC tools). Only instances matching the prefix are considered.
+
+    A consistent naming pattern ensures the ``_cluster`` system space automatically aligns with the YAML configuration.
+
+
+    If the ``prefix`` field is not set (``nil``), the ``autoexpel`` logic cannot identify instances for expulsion, and the feature will not function.
+    This field is **mandatory** when ``replication.autoexpel_enabled`` is set to ``true``.
+
+
+    How It Works:
+
+	1.	The prefix filters instance names (e.g., ``{{ replicaset_name }}`` for replicaset-specific names or i- for names starting with i-).
+	2.	Instances matching the prefix and removed from the YAML configuration are expelled.
+	3.	Unnamed instances or those not matching the prefix are ignored.
+
+    Dynamic Prefix Based on Replicaset Name:
+
+    .. code-block:: yaml
+
+        replication:
+          autoexpel:
+            enabled: true
+            by: prefix
+            prefix: '{{ replicaset_name }}'
+
+
+    In this setup:
+	- Instances are grouped by replicaset names (e.g., ``r-001-i-001`` for ``replicaset r-001``).
+	- The prefix ensures that only instances with names matching the replicaset name are auto expelled when removed from the configuration.
+
+
+    Static Prefix for Matching Patterns:
+
+    .. code-block:: yaml
+
+        replication:
+          autoexpel:
+            enabled: true
+            by: prefix
+            prefix: 'i-'
+
+    In this setup:
+    - All instances with names starting with ``i-`` (e.g., v``i-001``, ``i-002``) are considered for expulsion.
+    - This is useful when instances follow a uniform naming convention.
+
+    |
+    | Type: string
+    | Default: ``nil``
+    | Environment variable: TT_REPLICATION_PREFIX
+
+
+    ** Full Example**
 
     1. Create a ``config.yaml`` file with the following content:
 
@@ -3697,7 +3820,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     .. code-block:: lua
 
-        tarantool --name r-001-i-002 --config config.yaml -i``
+        tarantool --name r-001-i-002 --config config.yaml -i
 
 
     .. code-block:: lua

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3620,7 +3620,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
 	- **Startup**. When the cluster starts, ``autoexpel`` checks and removes instances not matching the updated configuration.
 	- **Reconfiguration**. When the YAML configuration is reloaded, ``autoexpel`` compares the current state to the updated configuration and performs necessary expulsions.
-	- ``box.status`` **Watcher event**. Changes detected by the ``box.status`` watcher also trigger the ``autoexpel`` mechanism.
+	- ``box.status`` **watcher event**. Changes detected by the ``box.status`` watcher also trigger the ``autoexpel`` mechanism.
 
 
     ``autoexpel`` does not take any actions on newly joined instances unless one of the triggering events occurs.
@@ -3634,7 +3634,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     Configuration fields
 
-    - ``by`` :ref:`replication.autoexpel_by.*` (string, default: ``nil``): specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
+    - ``by`` (string, default: ``nil``): specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
 
     - ``enabled`` (boolean, default: ``false``): enables or disables the ``autoexpel`` logic.
 
@@ -3649,6 +3649,7 @@ replication.autoexpel_by.*
     subject to the ``autoexpel`` process.
 
     The by field helps differentiate between:
+
     - Instances that are part of the cluster and should adhere to the YAML configuration.
 	- Instances or tools (e.g., CDC tools) that use the replication channel but are not part of the cluster configuration.
 
@@ -3658,7 +3659,8 @@ replication.autoexpel_by.*
     based on their names, matching them against a prefix pattern defined in the configuration.
 
     If the ``autoexpel`` feature is enabled (``enabled: true``), the ``by`` field must be explicitly set to ``prefix``.
-	The absence of this field or an unsupported value will result in configuration errors.
+
+    The absence of this field or an unsupported value will result in configuration errors.
 
     .. code-block:: yaml
 
@@ -3671,7 +3673,7 @@ replication.autoexpel_by.*
     |
     | Type: string
     | Default: ``nil``
-    | Environment variable: TT_REPLICATION_BY
+    | Environment variable: TT_REPLICATION_AUTOEXPEL_BY
 
 
 
@@ -3713,7 +3715,7 @@ replication.autoexpel_enabled.*
     |
     | Type: boolean
     | Default: ``false``
-    | Environment variable: TT_REPLICATION_ENABLED
+    | Environment variable: TT_REPLICATION_AUTOEXPEL_ENABLED
 
 
 replication.autoexpel_prefix.*
@@ -3728,13 +3730,13 @@ replication.autoexpel_prefix.*
     This field is **mandatory** when ``replication.autoexpel_enabled`` is set to ``true``.
 
 
-    How It Works:
+    How it works:
 
-	1.	The prefix filters instance names (e.g., ``{{ replicaset_name }}`` for replicaset-specific names or i- for names starting with i-).
+	1.	The prefix filters instance names (e.g., ``{{ replicaset_name }}`` for replicaset-specific names or ``i-`` for names starting with ``i-``).
 	2.	Instances matching the prefix and removed from the YAML configuration are expelled.
 	3.	Unnamed instances or those not matching the prefix are ignored.
 
-    Dynamic Prefix Based on Replicaset Name:
+    Dynamic prefix based on replicaset name:
 
     .. code-block:: yaml
 
@@ -3746,11 +3748,12 @@ replication.autoexpel_prefix.*
 
 
     In this setup:
+
 	- Instances are grouped by replicaset names (e.g., ``r-001-i-001`` for ``replicaset r-001``).
 	- The prefix ensures that only instances with names matching the replicaset name are auto expelled when removed from the configuration.
 
 
-    Static Prefix for Matching Patterns:
+    Static prefix for matching patterns:
 
     .. code-block:: yaml
 
@@ -3761,13 +3764,15 @@ replication.autoexpel_prefix.*
             prefix: 'i-'
 
     In this setup:
+
     - All instances with names starting with ``i-`` (e.g., ``i-001``, ``i-002``) are considered for expulsion.
     - This is useful when instances follow a uniform naming convention.
 
     |
     | Type: string
     | Default: ``nil``
-    | Environment variable: TT_REPLICATION_PREFIX
+    | Environment variable: TT_REPLICATION_AUTOEXPEL_PREFIX
+
 
 
     **Full Example**
@@ -3871,13 +3876,6 @@ replication.autoexpel_prefix.*
 
     After the reload, ``r-001-i-003`` should no longer appear in the ``_cluster`` system space.
 
-    |
-    | Type: boolean
-    | Default: false
-    | Environment variable:
-    | TT_REPLICATION_AUTOEXPEL_BY
-    | TT_REPLICATION_AUTOEXPEL_ENABLED
-    | TT_REPLICATION_AUTOEXPEL_PREFIX
 
 
 .. _configuration_reference_replication_bootstrap_strategy:

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3544,7 +3544,6 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
 -   :ref:`replication.anon <configuration_reference_replication_anon>`
 -   :ref:`replication.autoexpel <configuration_reference_replication_autoexpel>`
--   :ref:`replication.anon <configuration_reference_replication_autoexpel>`
 -   :ref:`replication.bootstrap_strategy <configuration_reference_replication_bootstrap_strategy>`
 -   :ref:`replication.connect_timeout <configuration_reference_replication_connect_timeout>`
 -   :ref:`replication.election_mode <configuration_reference_replication_election_mode>`

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3603,6 +3603,8 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
 .. confval:: replication.autoexpel
 
+    **Since:** :doc:`3.3.0 </release/3.3.0>`
+
     The ``replication.autoexpel`` option designed for managing dynamic clusters using YAML-based configurations.
     It enables the automatic expulsion of instances that are removed from the YAML configuration.
 
@@ -3777,7 +3779,7 @@ replication.autoexpel_prefix.*
 
 
 
-Full example
+autoexpel full example
 ~~~~~~~~~~~~~
 
     1. Create a ``config.yaml`` file with the following content:

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3651,7 +3651,9 @@ replication.autoexpel_by.*
     The ``by`` field helps differentiate between:
 
     - Instances that are part of the cluster and should adhere to the YAML configuration.
+
 	- Instances or tools (e.g., CDC tools) that use the replication channel but are not part of the cluster configuration.
+
 
     The default value of by is ``nil``, meaning no ``autoexpel`` criterion is applied unless explicitly set.
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3621,7 +3621,8 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 	- ``box.status`` **Watcher Event**. Changes detected by the ``box.status watcher`` also trigger the ``autoexpel`` mechanism.
 
     New instances
-    ``Autoexpel`` does not take any actions on newly joined instances unless one of the triggering events occurs.
+
+    ``autoexpel`` does not take any actions on newly joined instances unless one of the triggering events occurs.
     This means that an instance meeting the ``autoexpel`` criterion can still join the cluster, but it may be removed
     later during reconfiguration or on subsequent triggering events.
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3634,8 +3634,8 @@ The ``replication`` section defines configuration parameters related to :ref:`re
         global levels. It is not applicable at the instance level.
 
 
-Configuration fields
-^^^^^^^^^^^^^^^^^^^^
+    **Configuration fields**
+
 
     - ``by`` (string, default: ``nil``): specifies the ``autoexpel`` criterion. Currently, only ``prefix`` is supported and must be explicitly set.
 
@@ -3692,8 +3692,8 @@ replication.autoexpel.enabled
 
         By default, the ``enabled`` field is set to ``false``, meaning the ``autoexpel`` logic is turned off. This ensures that no instances are automatically removed unless explicitly configured.
 
-Enabling ``autoexpel`` logic
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    **Enabling ``autoexpel`` logic**
+
     To enable ``autoexpel``, you should set enabled to true in the ``replication.autoexpel`` section of your YAML configuration:
 
     .. code-block:: yaml
@@ -3708,8 +3708,8 @@ Enabling ``autoexpel`` logic
     To disable ``autoexpel``, set enabled to ``false``.
 
 
-Dependencies
-^^^^^^^^^^^^
+    **Dependencies**
+
 
     If ``enabled`` is set to ``true``, the following fields are required:
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3610,6 +3610,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
     Additionally, instances without a persistent name are ignored.
 
     If an instance is in read-write mode and has the latest database schema, it initiates the expulsion of instances that:
+
 	- Match the specified prefix
 	- Absent from the updated YAML configuration
 
@@ -3618,7 +3619,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
     The ``autoexpel`` logic is activated during specific events:
 	- **Startup**. When the cluster starts, ``autoexpel`` checks and removes instances not matching the updated configuration.
 	- **Reconfiguration**. When the YAML configuration is reloaded, ``autoexpel`` compares the current state to the updated configuration and performs necessary expulsions.
-	- ``box.status`` **Watcher Event**. Changes detected by the ``box.status watcher`` also trigger the ``autoexpel`` mechanism.
+	- ``box.status`` **Watcher event**. Changes detected by the ``box.status watcher`` also trigger the ``autoexpel`` mechanism.
 
     New instances
 
@@ -3631,6 +3632,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
         global levels. It is not applicable at the instance level.
 
     Configuration fields
+
     - **`enabled`** *(boolean, default: `false`)*: enables or disables the ``autoexpel`` logic.
 
     - **`by`** *(string, default: `nil`)*: specifies the ``autoexpel`` criterion. Currently, only `prefix` is supported and must be explicitly set.
@@ -3677,10 +3679,11 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
 
     This configuration:
+
 	- Sets up authentication with a guest user assigned the super role.
-	- Enables the autoexpel option to automatically expel instances not present in the YAML file.
-	- Defines instance names based on a prefix pattern: {{ replicaset_name }}.
-	- Lists three instances: r-001-i-001, r-001-i-002, and r-001-i-003.
+	- Enables the ``autoexpel`` option to automatically expel instances not present in the YAML file.
+	- Defines instance names based on a prefix pattern: ``{{ replicaset_name }}``.
+	- Lists three instances: ``r-001-i-001``, ``r-001-i-002``, and ``r-001-i-003``.
 
 
     2. Open terminal window and start three instances using the following commands:
@@ -3713,8 +3716,7 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     4. For the leader instance (``r-001-i-001``), check the _cluster space:
 
-        ..  admonition:: Info
-        :class: fact
+    .. hint::
 
         The ``_cluster`` system space in Tarantool stores metadata about all instances currently recognized as part of the cluster.
         It shows which instances are registered and active.

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3648,7 +3648,7 @@ replication.autoexpel_by.*
     ``replication.autoexpel_by`` purpose is to define the criterion used for determining which instances in a cluster are
     subject to the ``autoexpel`` process.
 
-    The by field helps differentiate between:
+    The ``by`` field helps differentiate between:
 
     - Instances that are part of the cluster and should adhere to the YAML configuration.
 	- Instances or tools (e.g., CDC tools) that use the replication channel but are not part of the cluster configuration.
@@ -3687,7 +3687,7 @@ replication.autoexpel_enabled.*
 
         By default, the ``enabled`` field is set to ``false``, meaning the ``autoexpel`` logic is turned off. This ensures that no instances are automatically removed unless explicitly configured.
 
-    Enabling ``autoexpel`` Logic
+    Enabling ``autoexpel`` logic
 
     To enable ``autoexpel``, you should set enabled to true in the ``replication.autoexpel`` section of your YAML configuration:
 
@@ -3775,7 +3775,8 @@ replication.autoexpel_prefix.*
 
 
 
-    **Full Example**
+Full example
+~~~~~~~~~~~~~
 
     1. Create a ``config.yaml`` file with the following content:
 

--- a/doc/reference/configuration/configuration_reference.rst
+++ b/doc/reference/configuration/configuration_reference.rst
@@ -3618,13 +3618,6 @@ The ``replication`` section defines configuration parameters related to :ref:`re
 
     The expulsion process follows the standard procedure, involving the removal of the instance from the ``_cluster`` system space.
 
-    The ``autoexpel`` logic is activated during specific events:
-
-	- **Startup**. When the cluster starts, ``autoexpel`` checks and removes instances not matching the updated configuration.
-	- **Reconfiguration**. When the YAML configuration is reloaded, ``autoexpel`` compares the current state to the updated configuration and performs necessary expulsions.
-	- ``box.status`` **watcher event**. Changes detected by the ``box.status`` watcher also trigger the ``autoexpel`` mechanism.
-
-
     ``autoexpel`` does not take any actions on newly joined instances unless one of the triggering events occurs.
     This means that an instance meeting the ``autoexpel`` criterion can still join the cluster, but it may be removed
     later during reconfiguration or on subsequent triggering events.
@@ -3778,111 +3771,6 @@ replication.autoexpel.prefix
     | Type: string
     | Default: ``nil``
     | Environment variable: TT_REPLICATION_AUTOEXPEL_PREFIX
-
-
-
-autoexpel full example
-~~~~~~~~~~~~~
-
-    1. Create a ``config.yaml`` file with the following content:
-
-    .. code-block:: yaml
-
-        credentials:
-          users:
-            guest:
-              roles: [super]
-
-        replication:
-          failover: manual
-          autoexpel:
-            enabled: true
-            by: prefix
-            prefix: '{{ replicaset_name }}'
-
-        iproto:
-          listen:
-            - uri: 'unix/:./var/run/{{ instance_name }}.iproto'
-
-        groups:
-          g-001:
-            replicasets:
-              r-001:
-                leader: r-001-i-001
-                instances:
-                  r-001-i-001: {}
-                  r-001-i-002: {}
-                  r-001-i-003: {}
-
-
-    This configuration:
-	- Sets up authentication with a guest user assigned the super role.
-	- Enables the ``autoexpel`` option to automatically expel instances not present in the YAML file.
-	- Defines instance names based on a prefix pattern: ``{{ replicaset_name }}``.
-	- Lists three instances: ``r-001-i-001``, ``r-001-i-002``, and ``r-001-i-003``.
-
-
-    2. Open terminal window and start three instances using the following commands:
-
-    .. code-block:: lua
-
-        tarantool --name r-001-i-001 --config config.yaml -i
-
-
-    .. code-block:: lua
-
-        tarantool --name r-001-i-002 --config config.yaml -i
-
-
-    .. code-block:: lua
-
-        tarantool --name r-001-i-003 --config config.yaml -i
-
-    3. Edit ``config.yaml`` and remove the following entry for ``r-001-i-003``:
-
-    .. code-block:: lua
-        r-001-i-003: {}
-
-
-    The updated ``config.yaml`` should look like this:
-
-    .. code-block:: yaml
-
-        groups:
-          g-001:
-            replicasets:
-              r-001:
-                leader: r-001-i-001
-                instances:
-                  r-001-i-001: {}
-                  r-001-i-002: {}
-
-    Save the file.
-
-    4. For the leader instance (``r-001-i-001``), check the ``_cluster`` space:
-
-    .. hint::
-
-        The ``_cluster`` system space in Tarantool stores metadata about all instances currently recognized as part of the cluster.
-        It shows which instances are registered and active.
-
-    You should see ``r-001-i-003`` still listed in the ``_cluster`` system space.
-
-    5. Reload the configuration:
-
-    .. code-block:: lua
-
-        config = require('config')
-        config:reload()
-
-    6. Verify the changes:
-
-    .. code-block:: lua
-
-        box.space._cluster:fselect()
-
-    After the reload, ``r-001-i-003`` should no longer appear in the ``_cluster`` system space.
-
 
 
 .. _configuration_reference_replication_bootstrap_strategy:


### PR DESCRIPTION
Resolves https://github.com/tarantool/doc/issues/4668.

Configuration reference: new subsection replicatition.autoexpel in https://www.tarantool.io/en/doc/latest/reference/configuration/configuration_reference/#replication

Deployment https://docs.d.tarantool.io/en/doc/gh-4668-rep-autoexpel/reference/configuration/configuration_reference/#configuration-reference-replication-autoexpel