### PR TITLE
Fix popen_handle:info() and popen_handle:wait() description

### DIFF
--- a/doc/reference/reference_lua/popen.rst
+++ b/doc/reference/reference_lua/popen.rst
@@ -613,7 +613,6 @@ Below is a list of all ``popen`` functions and handle methods.
         :param handle ph: handle of a child process created with
                           :ref:`popen.new() <popen-new>` or
                           :ref:`popen.shell() <popen-shell>`
-        :param number signo: signal to send
         :return: (if success) formatted result
         :rtype: res
 
@@ -746,7 +745,6 @@ Below is a list of all ``popen`` functions and handle methods.
         :param handle ph: handle of a child process created with
                           :ref:`popen.new() <popen-new>` or
                           :ref:`popen.shell() <popen-shell>`
-        :param number signo: signal to send
         :return: (if success) formatted result
         :rtype: res
 


### PR DESCRIPTION
Removed parameter signo (number) from the descriptions of popen_handle:info() and popen_handle:wait(). Parameter never belonged to mentioned functiones and was placed there by a mistake.

Fixes #4579