### PR TITLE
Add array of strings return type

### DIFF
--- a/doc/reference/reference_lua/box_info/listen.rst
+++ b/doc/reference/reference_lua/box_info/listen.rst
@@ -11,11 +11,12 @@ box.info.listen
     Since: :doc:`2.4.1 </release/2.4.1>`
 
     A real address to which an instance is bound.
+    If multiple URIs are configured, returns an array of strings.
     If an instance does not listen to anything, ``box.info.listen`` is ``nil``.
 
     To learn how to configure URIs used to listen for incoming requests, see :ref:`iproto.listen <configuration_reference_iproto_listen>`.
 
-    :rtype: string
+    :rtype: string | string[]
 
     **Example**
 


### PR DESCRIPTION
The box.info.listen is capable of returningan an array of strings if several URIs are configured. 
Fixes #5092