### PR TITLE
Add ``name`` parameter and ``box.error.is`` function description to ``box.error``.

### DIFF
--- a/doc/reference/reference_lua/box_error.rst
+++ b/doc/reference/reference_lua/box_error.rst
@@ -277,7 +277,7 @@ Below is a list of ``box.error`` functions and related objects.
             - Set the specified error as the last system error explicitly
         
         *   - :doc:`./box_error/is`
-            - Verify whether the specified argument is an error
+            - Verify whether the specified argument is an error cdata object
 
         *   - :doc:`./box_error/error_object`
             - An object that defines an error

--- a/doc/reference/reference_lua/box_error.rst
+++ b/doc/reference/reference_lua/box_error.rst
@@ -275,6 +275,9 @@ Below is a list of ``box.error`` functions and related objects.
 
         *   - :doc:`./box_error/set`
             - Set the specified error as the last system error explicitly
+        
+        *   - :doc:`./box_error/is`
+            - Verify whether the specified argument is an error
 
         *   - :doc:`./box_error/error_object`
             - An object that defines an error
@@ -288,4 +291,5 @@ Below is a list of ``box.error`` functions and related objects.
     box_error/clear
     box_error/new
     box_error/set
+    box_error/is
     box_error/error_object

--- a/doc/reference/reference_lua/box_error/error_object.rst
+++ b/doc/reference/reference_lua/box_error/error_object.rst
@@ -189,3 +189,13 @@ error_object
 
         For the ``box.error.READONLY`` error, returns the current election term (see :ref:`box.info.election.term <box_info_election>`).
         This attribute may present if the :ref:`error reason <box_error-reason>` is ``election`` or ``synchro``.
+
+    .. _box_error-name:
+
+    .. data:: name
+
+        **Since:** :doc:`3.1.0 </release/3.1.0>`
+
+        Returns the name of the error used at creation.
+
+    

--- a/doc/reference/reference_lua/box_error/error_object.rst
+++ b/doc/reference/reference_lua/box_error/error_object.rst
@@ -196,6 +196,6 @@ error_object
 
         **Since:** :doc:`3.1.0 </release/3.1.0>`
 
-        Returns the name of the error used at creation.
+        Returns the name of the error.
 
     

--- a/doc/reference/reference_lua/box_error/is.rst
+++ b/doc/reference/reference_lua/box_error/is.rst
@@ -10,7 +10,7 @@ box.error.is()
 
     The ``box.error.is`` function allows verify whether the specified argument is an error cdata object.
 
-    :param object object: the name of the othe object to be verified.
+    :param object object: the object to be verified.
 
     **Return type:**
     boolean

--- a/doc/reference/reference_lua/box_error/is.rst
+++ b/doc/reference/reference_lua/box_error/is.rst
@@ -4,25 +4,26 @@
 box.error.is()
 ===============================================================================
 
-.. function:: box.error.is(object_name)
+.. function:: box.error.is(object)
 
     **Since:** :doc:`3.2.0 </release/3.2.0>`
 
-    The ``box.error.is`` function allows verify whether the specified argument is an error.
+    The ``box.error.is`` function allows verify whether the specified argument is an error cdata object.
 
-    :param object_name object_name: the subject of the request
+    :param object object: the name of the othe object to be verified.
 
     **Return type:**
     boolean
 
     **Example**
 
-        ..  code-block:: lua
-            tarantool> box.error.is(box.error.new(box.error.UNKNOWN))
-            ---
-            - true
-            ...
-            tarantool> box.error.is('foo')
-            ---
-            - false
-            ...
+    ..  code-block:: lua
+
+        tarantool> box.error.is(box.error.new(box.error.UNKNOWN))
+        ---
+        - true
+        ...
+        tarantool> box.error.is('foo')
+        ---
+        - false
+        ...

--- a/doc/reference/reference_lua/box_error/is.rst
+++ b/doc/reference/reference_lua/box_error/is.rst
@@ -1,0 +1,28 @@
+.. _box_error-is:
+
+===============================================================================
+box.error.is()
+===============================================================================
+
+.. function:: box.error.is(object_name)
+
+    **Since:** :doc:`3.2.0 </release/3.2.0>`
+
+    The ``box.error.is`` function allows verify whether the specified argument is an error.
+
+    :param object_name object_name: the subject of the request
+
+    **Return type:**
+    boolean
+
+    **Example**
+
+        ..  code-block:: lua
+            tarantool> box.error.is(box.error.new(box.error.UNKNOWN))
+            ---
+            - true
+            ...
+            tarantool> box.error.is('foo')
+            ---
+            - false
+            ...


### PR DESCRIPTION
Since 3.1.0 there has been the ``name`` parameter,which returns the name of the error used at creation. 
Fixes #4150