### PR TITLE
Adds description of the ```#``` lua operator usage to key_def

### DIFF
--- a/doc/reference/reference_lua/key_def.rst
+++ b/doc/reference/reference_lua/key_def.rst
@@ -38,7 +38,7 @@ to extract or compare the index key values.
 
     Example: ``key_def.new({{type = 'string', collation = 'unicode', field = 2}})``
 
-    You can use the standard lua operator ``#`` (__len metamethod) to check the ``key_def`` length (parts count).
+    Since version :doc:`3.2.0 </release/3.2.0>`, you can use the standard lua operator ``#`` (__len metamethod) to check the ``key_def`` length (parts count).
 
     **Example**
 

--- a/doc/reference/reference_lua/key_def.rst
+++ b/doc/reference/reference_lua/key_def.rst
@@ -38,6 +38,15 @@ to extract or compare the index key values.
 
     Example: ``key_def.new({{type = 'string', collation = 'unicode', field = 2}})``
 
+    You can use the standard lua operator ``#`` (__len metamethod) to check the ``key_def`` length (parts count).
+
+    **Example**
+
+    ..  code-block:: lua
+
+        function is_full_pkey(space, key)
+        return #space.index[0].parts == #key
+        end
 
 ..  _key_def-object:
 


### PR DESCRIPTION
Standard lua operator ``#`` (__len metamethod) can be used to check the ``key_def`` length (parts count) Fixes #4275