### PR TITLE
Adds hierarchy table description

### DIFF
--- a/doc/reference/reference_lua/box_info/config.rst
+++ b/doc/reference/reference_lua/box_info/config.rst
@@ -15,6 +15,9 @@ box.info.config
 
     Since version :doc:`3.3.0 </release/3.3.0>`
     Returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
+    These names are taken directly from the ``--name`` CLI option (or the ``TT_INSTANCE_NAME`` environment variable) 
+    and the cluster configuration. This means they are always present if the YAML configuration flow is in use, 
+    disregarding the database status (whether upgraded, writable or not).
 
     :rtype: table
 
@@ -30,7 +33,7 @@ box.info.config
             active: *0
           alerts: []
           hierarchy:
-            group: group-001
-            replicaset: replicaset-001
-            instance: instance-001
+            group: storages
+            replicaset: storage-a
+            instance: storage-a-002
         ...

--- a/doc/reference/reference_lua/box_info/config.rst
+++ b/doc/reference/reference_lua/box_info/config.rst
@@ -13,8 +13,7 @@ box.info.config
     The instance's state in regard to configuration.
     Note that ``box.info.config`` returns the instance's state obtained using :ref:`config:info('v2') <config_api_reference_info>`.
 
-    Since version :doc:`3.3.0 </release/3.3.0>`.
-    Returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
+    Since version :doc:`3.3.0 </release/3.3.0>` returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
     These names are taken directly from the ``--name`` CLI option (or the ``TT_INSTANCE_NAME`` environment variable) 
     and the cluster configuration. This means they are always present if the YAML configuration flow is in use, 
     disregarding the database status (whether upgraded, writable or not).

--- a/doc/reference/reference_lua/box_info/config.rst
+++ b/doc/reference/reference_lua/box_info/config.rst
@@ -13,6 +13,9 @@ box.info.config
     The instance's state in regard to configuration.
     Note that ``box.info.config`` returns the instance's state obtained using :ref:`config:info('v2') <config_api_reference_info>`.
 
+    Since version :doc:`3.3.0 </release/3.3.0>`
+    Returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
+
     :rtype: table
 
     **Example**
@@ -26,4 +29,8 @@ box.info.config
             last: &0 []
             active: *0
           alerts: []
+          hierarchy:
+            group: group-001
+            replicaset: replicaset-001
+            instance: instance-001
         ...

--- a/doc/reference/reference_lua/box_info/config.rst
+++ b/doc/reference/reference_lua/box_info/config.rst
@@ -13,7 +13,7 @@ box.info.config
     The instance's state in regard to configuration.
     Note that ``box.info.config`` returns the instance's state obtained using :ref:`config:info('v2') <config_api_reference_info>`.
 
-    Since version :doc:`3.3.0 </release/3.3.0>`
+    Since version :doc:`3.3.0 </release/3.3.0>`.
     Returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
     These names are taken directly from the ``--name`` CLI option (or the ``TT_INSTANCE_NAME`` environment variable) 
     and the cluster configuration. This means they are always present if the YAML configuration flow is in use, 

--- a/doc/reference/reference_lua/box_info/info.rst
+++ b/doc/reference/reference_lua/box_info/info.rst
@@ -17,7 +17,7 @@ box.info()
     :return: keys and values in the submodule
     :rtype:  table
 
-    Since version :doc:`3.3.0 </release/3.3.0>`
+    Since version :doc:`3.3.0 </release/3.3.0>`.
     Returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
     These names are taken directly from the ``--name`` CLI option (or the ``TT_INSTANCE_NAME`` environment variable) 
     and the cluster configuration. This means they are always present if the YAML configuration flow is in use, 

--- a/doc/reference/reference_lua/box_info/info.rst
+++ b/doc/reference/reference_lua/box_info/info.rst
@@ -17,8 +17,7 @@ box.info()
     :return: keys and values in the submodule
     :rtype:  table
 
-    Since version :doc:`3.3.0 </release/3.3.0>`.
-    Returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
+    Since version :doc:`3.3.0 </release/3.3.0>` returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
     These names are taken directly from the ``--name`` CLI option (or the ``TT_INSTANCE_NAME`` environment variable) 
     and the cluster configuration. This means they are always present if the YAML configuration flow is in use, 
     disregarding the database status (whether upgraded, writable or not).

--- a/doc/reference/reference_lua/box_info/info.rst
+++ b/doc/reference/reference_lua/box_info/info.rst
@@ -19,6 +19,9 @@ box.info()
 
     Since version :doc:`3.3.0 </release/3.3.0>`
     Returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
+    These names are taken directly from the ``--name`` CLI option (or the ``TT_INSTANCE_NAME`` environment variable) 
+    and the cluster configuration. This means they are always present if the YAML configuration flow is in use, 
+    disregarding the database status (whether upgraded, writable or not).
 
     **Example**
 
@@ -98,7 +101,7 @@ box.info()
               active: *0
             alerts: []
             hierarchy:
-              group: group-001
-              replicaset: replicaset-001
-              instance: instance-001
+              group: storages
+              replicaset: storage-a
+              instance: storage-a-002
         ...

--- a/doc/reference/reference_lua/box_info/info.rst
+++ b/doc/reference/reference_lua/box_info/info.rst
@@ -17,6 +17,9 @@ box.info()
     :return: keys and values in the submodule
     :rtype:  table
 
+    Since version :doc:`3.3.0 </release/3.3.0>`
+    Returns the ``hierarchy`` table, showing names of the group, replicaset, and the instance itself.
+
     **Example**
 
     This example is for a master-replica set that contains one master instance
@@ -94,4 +97,8 @@ box.info()
               last: &0 []
               active: *0
             alerts: []
+            hierarchy:
+              group: group-001
+              replicaset: replicaset-001
+              instance: instance-001
         ...

--- a/doc/reference/reference_lua/config.rst
+++ b/doc/reference/reference_lua/config.rst
@@ -161,7 +161,7 @@ config API
 
                 Since version :doc:`3.3.0 </release/3.3.0>`
 
-                 -   ``hierarchy`` -- table, showing names of the group, replicaset, and the instance itself. 
+                 -   ``hierarchy`` -- table, showing names of the group, replicaset, and the instance itself.
                  These names are taken directly from the ``--name`` CLI option (or the ``TT_INSTANCE_NAME`` environment variable) 
                  and the cluster configuration. This means they are always present if the YAML configuration flow is in use, 
                  disregarding the database status (whether upgraded, writable or not).

--- a/doc/reference/reference_lua/config.rst
+++ b/doc/reference/reference_lua/config.rst
@@ -161,7 +161,10 @@ config API
 
                 Since version :doc:`3.3.0 </release/3.3.0>`
 
-                 -   ``hierarchy`` -- table, showing names of the group, replicaset, and the instance itself.
+                 -   ``hierarchy`` -- table, showing names of the group, replicaset, and the instance itself. 
+                 These names are taken directly from the ``--name`` CLI option (or the ``TT_INSTANCE_NAME`` environment variable) 
+                 and the cluster configuration. This means they are always present if the YAML configuration flow is in use, 
+                 disregarding the database status (whether upgraded, writable or not).
 
         Below are a few examples demonstrating how the ``info()`` output might look.
 
@@ -265,9 +268,9 @@ config API
                   3, crit, 4, warn, 5, info, 6, verbose, 7, debug'
                 timestamp: 2024-07-03T15:22:06.438275Z
               hierarchy:
-                group: group-001
-                replicaset: replicaset-001
-                instance: instance-001
+                group: group001
+                replicaset: replicaset001
+                instance: instance001
             ...
 
 

--- a/doc/reference/reference_lua/config.rst
+++ b/doc/reference/reference_lua/config.rst
@@ -159,6 +159,10 @@ config API
 
                  -   ``alerts`` -- warnings or errors raised on an attempt to apply the configuration
 
+                Since version :doc:`3.3.0 </release/3.3.0>`
+
+                 -   ``hierarchy`` -- table, showing names of the group, replicaset, and the instance itself.
+
         Below are a few examples demonstrating how the ``info()`` output might look.
 
         **Example: no configuration warnings or errors**
@@ -174,6 +178,10 @@ config API
                 last: &0 []
                 active: *0
               alerts: []
+              hierarchy:
+                group: group-001
+                replicaset: replicaset-001
+                instance: instance-001
             ...
 
         **Example: configuration warnings**
@@ -196,6 +204,10 @@ config API
                   upgrade has not been performed, or the privilege write has failed (separate
                   alert reported)
                 timestamp: 2024-07-03T18:09:18.826138+0300
+              hierarchy:
+                group: group-001
+                replicaset: replicaset-001
+                instance: instance-001
             ...
 
         This warning is cleared when the ``bands`` space is created.
@@ -219,6 +231,10 @@ config API
                   allowed: 0, fatal, 1, syserror, 2, error, 3, crit, 4, warn, 5, info, 6, verbose,
                   7, debug'
                 timestamp: 2024-07-03T18:13:19.755454+0300
+              hierarchy:
+                group: group-001
+                replicaset: replicaset-001
+                instance: instance-001
             ...
 
         **Example: configuration errors (centralized configuration storage)**
@@ -248,6 +264,10 @@ config API
                   8, but only the following values are allowed: 0, fatal, 1, syserror, 2, error,
                   3, crit, 4, warn, 5, info, 6, verbose, 7, debug'
                 timestamp: 2024-07-03T15:22:06.438275Z
+              hierarchy:
+                group: group-001
+                replicaset: replicaset-001
+                instance: instance-001
             ...
 
 


### PR DESCRIPTION
* Since 3.3.0 the ``hierarchy`` table shows names of the group, replicaset, and the instance itself 
* Table is reported in ``config:info()``; ``config:info('v2')``; ``box.info.config`` 
* Fixes #4608