### PR TITLE
Updates default value for replication_sync_timeout

### DIFF
--- a/doc/reference/configuration/cfg_replication.rst
+++ b/doc/reference/configuration/cfg_replication.rst
@@ -401,8 +401,8 @@
     .. NOTE::
 
         The default ``replication_sync_timeout`` value can be changed to the old default value (300) by using the ``compat`` module.
-        More information on changing the default value via the ``compat`` module 
-        see in :ref:`Default value for replication_sync_timeout <compat-option-replication-timeout>`.
+        For more information on changing the default value via the ``compat`` module, 
+        see :ref:`Default value for replication_sync_timeout <compat-option-replication-timeout>`.
 
 .. _cfg_replication-replication_timeout:
 

--- a/doc/reference/configuration/cfg_replication.rst
+++ b/doc/reference/configuration/cfg_replication.rst
@@ -394,14 +394,14 @@
 
     |
     | Type: float
-    | Default: 300
+    | Default: 0
     | Environment variable: TT_REPLICATION_SYNC_TIMEOUT
     | Dynamic: yes
 
     .. NOTE::
 
-        The default ``replication_sync_timeout`` value is going to be changed in future versions from ``300`` to ``0``.
-        You can learn the reasoning behind this decision from the :ref:`Default value for replication_sync_timeout <compat-option-replication-timeout>` topic, which also describes how to try the new behavior in the current version.
+        The default ``replication_sync_timeout`` value can be changed to 300 by using the ``compat`` module.
+        More information on how to change the default value see in :ref:`Default value for replication_sync_timeout <compat-option-replication-timeout>`.
 
 .. _cfg_replication-replication_timeout:
 

--- a/doc/reference/configuration/cfg_replication.rst
+++ b/doc/reference/configuration/cfg_replication.rst
@@ -400,8 +400,9 @@
 
     .. NOTE::
 
-        The default ``replication_sync_timeout`` value can be changed to 300 by using the ``compat`` module.
-        More information on how to change the default value see in :ref:`Default value for replication_sync_timeout <compat-option-replication-timeout>`.
+        The default ``replication_sync_timeout`` value can be changed to the old default value (300) by using the ``compat`` module.
+        More information on changing the default value via the ``compat`` module 
+        see in :ref:`Default value for replication_sync_timeout <compat-option-replication-timeout>`.
 
 .. _cfg_replication-replication_timeout:
 

--- a/doc/reference/reference_lua/box_cfg.rst
+++ b/doc/reference/reference_lua/box_cfg.rst
@@ -76,7 +76,7 @@ default settings to all the parameters:
       replication_connect_timeout  = 30
       replication_skip_conflict    = false
       replication_sync_lag         = 10
-      replication_sync_timeout     = 300
+      replication_sync_timeout     = 0
       replication_timeout          = 1
       slab_alloc_factor            = 1.05
       snap_io_rate_limit           = nil


### PR DESCRIPTION
* Changes default value in the description from 300 to 0 
Fixes #5183

Deployment: 
- https://docs.d.tarantool.io/en/doc/gh-5183-fix-default-timeout-value/reference/configuration/#confval-replication_sync_timeout
- https://docs.d.tarantool.io/en/doc/gh-5183-fix-default-timeout-value/reference/reference_lua/box_cfg/