### PR TITLE
Adds description of the on_event callback to custom application roles

### DIFF
--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -81,16 +81,13 @@ The ``on_event`` callback returns 3 arguments, when it is called:
    - ``config.apply`` if the callback was triggered by a configuration update;
 
    - ``box.status`` if it was triggered by the ``box.status`` system event.
-- ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
-If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
+- ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event. If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 
 ..  NOTE::
 
-- All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process.
-Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
+   - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process. Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
 
-- All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback,
-it is logged with the ``error`` level and the series execution continues.
+   - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with the ``error`` level and the series execution continues.
 
 Creating a custom role includes the following steps:
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -90,7 +90,6 @@ The ``on_event`` callback provides 3 arguments, when it is called:
     - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with ``error`` level 
     and the series execution continues.
 
-
 Creating a custom role includes the following steps:
 
 #.  (Optional) Define the role configuration schema.

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -84,8 +84,8 @@ The ``on_event`` callback provides 3 arguments, when it is called:
 
 ..  NOTE::
 
-    - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration 
-    process. Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
+    - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process. 
+    Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
 
     - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with ``error`` level 
     and the series execution continues.

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -74,12 +74,12 @@ defined by roles dependencies.
 
 The ``on_event`` callback provides 3 arguments, when it is called:
 
-    - ``config``, which is the configuration of the role;
+    - ``config``, which contains the configuration of the role;
 
     - ``key``, which reflects the trigger event:
-
-        - ``config.apply`` if the callback was triggered by a configuration update; 
+        - ``config.apply`` if the callback was triggered by a configuration update;
         - ``box.status`` if it was triggered by the ``box.status`` system event.
+
     - ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
     If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -81,13 +81,16 @@ The ``on_event`` callback returns 3 arguments, when it is called:
    - ``config.apply`` if the callback was triggered by a configuration update;
 
    - ``box.status`` if it was triggered by the ``box.status`` system event.
-- ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event. If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
+- ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
+  If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 
 ..  NOTE::
 
-   - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process. Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
+   - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process.
+     Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
 
-   - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with the ``error`` level and the series execution continues.
+   - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged
+     with the ``error`` level and the series execution continues.
 
 Creating a custom role includes the following steps:
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -77,8 +77,11 @@ The ``on_event`` callback provides 3 arguments, when it is called:
 - ``config``, which contains the configuration of the role;
 
 - ``key``, which reflects the trigger event:
+
    - ``config.apply`` if the callback was triggered by a configuration update;
+
    - ``box.status`` if it was triggered by the ``box.status`` system event.
+
 - ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
 If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -68,7 +68,7 @@ A custom application role is an object which implements custom functions or logi
 For example, a logging role can be created to add logging functionality on top of the built-in one.
 
 Since version :doc:`3.4.0 </release/3.4.0>`, you can define an ``on_event`` callback for custom roles. The ``on_event`` callback is called
-every time a ``box.status`` system event is broadcasted, or after the ``apply`` action of the configuration update is finished.
+every time a ``box.status`` system event is broadcasted.
 If multiple custom roles have the ``on_event`` callback defined, these callbacks are called one after another in the order
 defined by roles dependencies.
 
@@ -111,11 +111,10 @@ As a result, a role module should return an object that has corresponding functi
         stop = function() -- ... -- end,
         dependencies = { -- ... -- },
         on_event = function(config, key, value)
-        local log = require('log')
-
-        log.info('roles_cfg.my_role.foo: ' .. config.foo)
-        log.info('on_event is triggered by ' .. key)
-        log.info('is_ro: ' .. value.is_ro)
+            local log = require('log')
+            log.info('roles_cfg.my_role.foo: ' .. config.foo)
+            log.info('on_event is triggered by ' .. key)
+            log.info('is_ro: ' .. value.is_ro)
         end,
     }
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -72,11 +72,11 @@ every time a ``box.status`` system event is broadcasted, or after the ``apply`` 
 If multiple custom roles have the ``on_event`` callback defined, these callbacks are called one after another in the order
 defined by roles dependencies.
 
-The ``on_event`` callback provides 3 arguments, when it is called:
+The ``on_event`` callback returns 3 arguments, when it is called:
 
 - ``config``, which contains the configuration of the role;
 
-- ``key``, which reflects the trigger event:
+- ``key``, which reflects the trigger event and is set to:
 
    - ``config.apply`` if the callback was triggered by a configuration update;
 
@@ -87,11 +87,11 @@ If the callback is triggered by a configuration update, the ``value`` shows the 
 
 ..  NOTE::
 
-   - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process.
-   Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
+ - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process.
+ Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
 
-   - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged
-   with the ``error`` level and the series execution continues.
+ - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback,
+ it is logged with the ``error`` level and the series execution continues.
 
 Creating a custom role includes the following steps:
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -64,6 +64,30 @@ Creating a custom role
 Overview
 ~~~~~~~~
 
+A custom application role is an object which implements custom functions or logic adding to Tarantool's built-in roles and roles provided by third-party Lua modules.
+For example, a logging role can be created to add logging functionality on top of the built-in one.
+
+Since version :doc:`3.4.0 </release/3.4.0>`, you can define an ``on_event`` callback for custom roles. The ``on_event`` callback is called
+every time a ``box.status`` system event is broadcasted, or after the ``apply`` action of the configuration update is finished.
+If multiple custom roles have the ``on_event`` callback defined, these callbacks are called one after another in the order
+defined by roles dependencies.
+The ``on_event`` callback provides 3 arguments, when it is called:
+
+- ``config``, which is the configuration of the role;
+- ``key``, which reflects the trigger event: 
+    - ``config.apply`` if the callback was triggered by a configuration update; 
+    - ``box.status`` if it was triggered by the ``box.status`` system event.
+- ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event. 
+    If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
+
+..  NOTE::
+
+    - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration 
+    process. Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
+    - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with ``error`` level 
+    and the series execution continues.
+
+
 Creating a custom role includes the following steps:
 
 #.  (Optional) Define the role configuration schema.
@@ -71,6 +95,7 @@ Creating a custom role includes the following steps:
 #.  Define a function that applies a validated configuration.
 #.  Define a function that stops a role.
 #.  (Optional) Define roles from which this custom role depends on.
+#.  (Optional) Define the ``on_event`` callback function.
 
 As a result, a role module should return an object that has corresponding functions and fields specified:
 
@@ -81,6 +106,13 @@ As a result, a role module should return an object that has corresponding functi
         apply = function() -- ... -- end,
         stop = function() -- ... -- end,
         dependencies = { -- ... -- },
+        on_event = function(config, key, value)
+        local log = require('log')
+
+    log.info('roles_cfg.my_role.foo: ' .. config.foo)
+    log.info('on_event is triggered by ' .. key)
+    log.info('is_ro: ' .. value.is_ro)
+    end,
     }
 
 The examples below show how to do this.

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -79,16 +79,16 @@ The ``on_event`` callback provides 3 arguments, when it is called:
 
         - ``config.apply`` if the callback was triggered by a configuration update; 
         - ``box.status`` if it was triggered by the ``box.status`` system event.
-    - ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event. 
+    - ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
     If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 
 ..  NOTE::
 
-    - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process. 
+    - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process.
     Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
 
-    - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with ``error`` level 
-    and the series execution continues.
+    - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with
+    the ``error`` level and the series execution continues.
 
 Creating a custom role includes the following steps:
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -74,16 +74,17 @@ defined by roles dependencies.
 The ``on_event`` callback provides 3 arguments, when it is called:
 
 - ``config``, which is the configuration of the role;
-- ``key``, which reflects the trigger event: 
+- ``key``, which reflects the trigger event:
     - ``config.apply`` if the callback was triggered by a configuration update; 
     - ``box.status`` if it was triggered by the ``box.status`` system event.
-- ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event. 
+- ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
     If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 
 ..  NOTE::
 
     - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration 
     process. Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
+
     - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with ``error`` level 
     and the series execution continues.
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -80,16 +80,13 @@ The ``on_event`` callback provides 3 arguments, when it is called:
         - ``config.apply`` if the callback was triggered by a configuration update;
         - ``box.status`` if it was triggered by the ``box.status`` system event.
 
-    - ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
-    If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
+    - ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event. If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 
 ..  NOTE::
 
-    - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process.
-    Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
+    - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process. Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
 
-    - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with
-    the ``error`` level and the series execution continues.
+    - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with the ``error`` level and the series execution continues.
 
 Creating a custom role includes the following steps:
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -73,11 +73,13 @@ If multiple custom roles have the ``on_event`` callback defined, these callbacks
 defined by roles dependencies.
 The ``on_event`` callback provides 3 arguments, when it is called:
 
-- ``config``, which is the configuration of the role;
-- ``key``, which reflects the trigger event:
-    - ``config.apply`` if the callback was triggered by a configuration update; 
-    - ``box.status`` if it was triggered by the ``box.status`` system event.
-- ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
+    - ``config``, which is the configuration of the role;
+
+    - ``key``, which reflects the trigger event:
+
+        - ``config.apply`` if the callback was triggered by a configuration update; 
+        - ``box.status`` if it was triggered by the ``box.status`` system event.
+    - ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event. 
     If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 
 ..  NOTE::
@@ -110,10 +112,10 @@ As a result, a role module should return an object that has corresponding functi
         on_event = function(config, key, value)
         local log = require('log')
 
-    log.info('roles_cfg.my_role.foo: ' .. config.foo)
-    log.info('on_event is triggered by ' .. key)
-    log.info('is_ro: ' .. value.is_ro)
-    end,
+        log.info('roles_cfg.my_role.foo: ' .. config.foo)
+        log.info('on_event is triggered by ' .. key)
+        log.info('is_ro: ' .. value.is_ro)
+        end,
     }
 
 The examples below show how to do this.

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -81,17 +81,16 @@ The ``on_event`` callback returns 3 arguments, when it is called:
    - ``config.apply`` if the callback was triggered by a configuration update;
 
    - ``box.status`` if it was triggered by the ``box.status`` system event.
-
 - ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
 If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 
 ..  NOTE::
 
- - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process.
- Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
+- All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process.
+Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
 
- - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback,
- it is logged with the ``error`` level and the series execution continues.
+- All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback,
+it is logged with the ``error`` level and the series execution continues.
 
 Creating a custom role includes the following steps:
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -74,19 +74,21 @@ defined by roles dependencies.
 
 The ``on_event`` callback provides 3 arguments, when it is called:
 
-    - ``config``, which contains the configuration of the role;
+- ``config``, which contains the configuration of the role;
 
-    - ``key``, which reflects the trigger event:
-        - ``config.apply`` if the callback was triggered by a configuration update;
-        - ``box.status`` if it was triggered by the ``box.status`` system event.
-
-    - ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event. If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
+- ``key``, which reflects the trigger event:
+   - ``config.apply`` if the callback was triggered by a configuration update;
+   - ``box.status`` if it was triggered by the ``box.status`` system event.
+- ``value``, which shows and logs the information about the instance status as in the trigger ``box.status`` system event.
+If the callback is triggered by a configuration update, the ``value`` shows the information of the most recent ``box.status`` system event.
 
 ..  NOTE::
 
-    - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process. Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
+   - All ``on_event`` callbacks with the ``config.apply`` key  are executed as a part of the configuration process.
+   Process statuses ``ready`` or ``check_warnings`` are reached only after all such ``on_event`` callbacks are done.
 
-    - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged with the ``error`` level and the series execution continues.
+   - All ``on_event`` callbacks are executed inside of a ``pcall``. If an error is raised for a callback, it is logged
+   with the ``error`` level and the series execution continues.
 
 Creating a custom role includes the following steps:
 

--- a/doc/platform/app/app_roles.rst
+++ b/doc/platform/app/app_roles.rst
@@ -71,6 +71,7 @@ Since version :doc:`3.4.0 </release/3.4.0>`, you can define an ``on_event`` call
 every time a ``box.status`` system event is broadcasted, or after the ``apply`` action of the configuration update is finished.
 If multiple custom roles have the ``on_event`` callback defined, these callbacks are called one after another in the order
 defined by roles dependencies.
+
 The ``on_event`` callback provides 3 arguments, when it is called:
 
     - ``config``, which is the configuration of the role;


### PR DESCRIPTION
* Added general info about custom roles as an intro to the section
* Fixes #4666

Deployment: https://docs.d.tarantool.io/ru/doc/gh-4666-on-event-callback-for-roles/platform/app/app_roles/#creating-a-custom-role