### PR TITLE
Add notes for EE customers about ATE and centralized configuration storages

### DIFF
--- a/doc/platform/configuration/configuration_etcd.rst
+++ b/doc/platform/configuration/configuration_etcd.rst
@@ -241,6 +241,9 @@ Configuring connection to a storage
 
 To use a configuration from a centralized storage for your cluster, you need to provide connection settings in a local configuration file.
 
+..  include:: /platform/configuration/configuration_etcd.rst
+    :start-after: ee_note_centralized_config_start
+    :end-before: ee_note_centralized_config_end
 
 .. _centralized_configuration_storage_connect_tarantool:
 
@@ -291,14 +294,29 @@ You can find the full example here: `config_etcd <https://github.com/tarantool/d
 Starting a cluster
 ------------------
 
+.. ate_note_run_instances_start
+
+..  note::
+
+    To run instances in production, it is recommended to use Ansible Tarantool Enterprise installer (ATE).
+    ATE is a set of Ansible playbooks that are used to deploy and maintain Tarantool Enterprise products.
+    `ATE documentation <https://www.tarantool.io/ru/devops/latest>`__ is available to users logged in on the Tarantool website.
+
+.. ate_note_run_instances_end
+
 The :ref:`tt <tt-cli>` utility is the recommended way to start Tarantool instances.
 You can learn how to do this from the :ref:`Starting and stopping instances <admin-start_stop_instance>` section.
 
 You can also use the ``tarantool`` command to :ref:`start a Tarantool instance <configuration_run_instance_tarantool>`.
-In this case, you can eliminate creating a :ref:`local configuration  <centralized_configuration_storage_connect>` and provide connection settings using the following :ref:`environment variables <configuration_environment_variable>`:
+In this case, you can eliminate creating a :ref:`local configuration  <centralized_configuration_storage_connect>` and
+provide connection settings using the following :ref:`environment variables <configuration_environment_variable>`:
 
 *   Tarantool-based storage: ``TT_CONFIG_STORAGE_ENDPOINTS`` and ``TT_CONFIG_STORAGE_PREFIX``.
 *   etcd-based storage: ``TT_CONFIG_ETCD_ENDPOINTS`` and ``TT_CONFIG_ETCD_PREFIX``.
+
+..  include:: /platform/configuration/configuration_etcd.rst
+    :start-after: ee_note_centralized_config_start
+    :end-before: ee_note_centralized_config_end
 
 The example below shows how to provide etcd connection settings and start cluster instances using the ``tarantool`` command:
 

--- a/doc/tooling/tt_cli/start_stop_instance.rst
+++ b/doc/tooling/tt_cli/start_stop_instance.rst
@@ -3,6 +3,10 @@
 Starting and stopping instances
 ===============================
 
+..  include:: /platform/configuration/configuration_etcd.rst
+    :start-after: ate_note_run_instances_start
+    :end-before: ate_note_run_instances_end
+
 This section describes how to manage instances in a Tarantool cluster using the :ref:`tt <tt-cli>` utility.
 A cluster can include multiple instances that run different code.
 A typical example is a cluster application that includes router and storage instances.


### PR DESCRIPTION
Add the following notes:

- Add a note for Enterprise customers that ATE should be used for running instances in production
- ETCD|Tarantool config storage config is an enterprise only feature.

Fixes #4136

Deployment:
- https://docs.d.tarantool.io/en/doc/gh-4136-ate-note/platform/configuration/configuration_etcd/#configuring-connection-to-a-storage
- https://docs.d.tarantool.io/en/doc/gh-4136-ate-note/platform/configuration/configuration_etcd/#starting-a-cluster
- https://docs.d.tarantool.io/en/doc/gh-4136-ate-note/tooling/tt_cli/start_stop_instance/