### PR TITLE
TCM: fix example in the `http.tls.cipher-suites` option

### DIFF
--- a/doc/tooling/tcm/tcm_configuration_reference.rst
+++ b/doc/tooling/tcm/tcm_configuration_reference.rst
@@ -693,9 +693,10 @@ The ``http`` group defines parameters of HTTP connections between |tcm| and clie
 
    The example below shows how to configure cipher suites:
 
-   .. code-block:: yaml
+   ..  code-block:: yaml
 
        http:
+         tls:
            cipher-suites:
              - TLS_AES_256_GCM_SHA384
              - TLS_AES_128_GCM_SHA256


### PR DESCRIPTION
> Я подозреваю, что тут в конфиге должна быть не опция http.cipher-suites, а опция http.tls.cipher-suites
> 
> * https://gitlab.corp.mail.ru/tarantool/tarantool-cluster-manager/-/blob/master/server/tcm.example.yml?ref_type=heads#L41
> * https://www.tarantool.io/ru/doc/latest/tooling/tcm/tcm_configuration_reference/#confval-http.tls.cipher-suites (похоже, что тут в платформенной доке в примере такая же ошибка)


Fixes https://github.com/tarantool/doc/issues/5453

Staging: https://docs.d.tarantool.io/ru/doc/gh-5453-tcm-example/tooling/tcm/tcm_configuration_reference/#confval-http.tls.cipher-suites