### PR TITLE
doc: update SDK changelog

### DIFF
--- a/doc/release/enterprise-changelog.rst
+++ b/doc/release/enterprise-changelog.rst
@@ -19,29 +19,28 @@ For example: ``2.11.1-0-gc42d9735b-r589``.
 -   ``REVISION`` is the SDK revision. Besides Tarantool itself, it includes the ``tt`` utility, a set of open and closed source modules, and examples. Learn more from :ref:`Package contents <enterprise-package-contents>`.
 
 r703
----
+----
 
 -   Bumped ``checks`` version to `3.4.0 <https://github.com/tarantool/checks/releases/tag/3.4.0>`__.
 -   Bumped Cartridge version to `2.16.4 <https://github.com/tarantool/cartridge/releases/tag/2.16.4)>`__.
 -   Bumped ``vshard`` version to `0.1.37 <https://github.com/tarantool/vshard/releases/tag/0.1.37>`__.
 
 r702
----
+----
 
 -   Bumped ``tarantool-2.11`` series to `2.11.8 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.8>`__.
 
 r696
----
-
+----
 -   Moved CI files from ``sdk-ci`` repository.
 
 r695
----
+----
 
 -   Bumped ``tt-ee`` version to `v2.11.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.11.0>`__.
 
 r694
----
+----
 
 -   Replaced Cartridge EE with Cartridge CE `2.16.3 <https://github.com/tarantool/cartridge/releases/tag/2.16.3>`__.
 -   Added CRUD CE `1.6.1 <https://github.com/tarantool/crud/releases/tag/1.6.1>`__.
@@ -53,17 +52,17 @@ r694
 -   Moved to community edition modules.
 
 r693
----
+----
 
 -   Fixed ``glibc`` package URL to archived.
 
 r692
----
+----
 
 -   Added manual trigger job to run tests to generate ``certificate of compliance``. Ready for Astra Linux.
 
 r691
----
+----
 
 -   Bumped Cartridge version to `2.16.2 <https://github.com/tarantool/cartridge/releases/tag/2.16.2>`__.
 -   Bumped metrics version to `1.4.0 <https://github.com/tarantool/metrics/releases/tag/1.4.0>`__.
@@ -71,102 +70,102 @@ r691
 -   Bumped ``crud-ee`` version to `1.7.4 <https://gitlab.corp.mail.ru/tarantool/tdb/crud-ee/-/tags/1.7.4>`__.
 
 r690
----
+----
 
 -   Bumped ``tt-ee`` version to `v2.10.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.10.1>`__.
 
 r689
----
+----
 
 -   Bumped Cartridge version to `2.16.0 <https://github.com/tarantool/cartridge/releases/tag/2.16.0>`__.
 
 r688
----
+----
 
 -   Bumped ``vshard-ee`` version to `0.1.34 <https://github.com/tarantool/vshard-ee/releases/tag/0.1.34>`__.
 
 r687
----
+----
 
 -   Bumped Cartridge version to `2.15.4 <https://github.com/tarantool/cartridge/releases/tag/2.15.4>`__.
 
 r686
----
+----
 
 -   Bumped ``tt-ee`` version to `v2.10.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.10.0>`__.
 
 r685
----
+----
 
 -   Bumped ``migrations-ee`` version to `1.3.2 <https://github.com/tarantool/migrations-ee/releases/tag/1.3.2>`__.
 
 r684
----
+----
 
 -   Bumped ``tarantool-2.11`` series to `2.11.7 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.7>`__.
 
 r683
----
+----
 
 -   Bumped Kafka version to `1.6.10 <https://github.com/tarantool/kafka/releases/tag/1.6.10>`__.
 
 r682
----
+----
 
 -   Bumped Cartridge version to `2.15.3 <https://github.com/tarantool/cartridge/releases/tag/2.15.3>`__.
 
 r681
----
+----
 
 -   Bumped ``vshard-ee`` version to `0.1.33 <https://github.com/tarantool/vshard-ee/releases/tag/0.1.33>`__.
 
 r680
----
+----
 
 -   Bumped ``tt-ee`` version to `v2.9.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.9.1>`__.
 
 r679
----
+----
 
 -   Bumped ``tt-ee`` version to `v2.9.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.9.0>`__.
 -   Bumped Cartridge version to `2.15.2 <https://github.com/tarantool/cartridge/releases/tag/2.15.2>`__.
 -   Bumped ``membership`` version to `2.5.2 <https://github.com/tarantool/membership/releases/tag/2.5.2>`__.
 
 r677
----
+----
 
 -   Bumped Cartridge version to `2.15.1 <https://github.com/tarantool/cartridge/releases/tag/2.15.1>`__.
 -   Bumped ``tt-ee`` version to `v2.8.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.8.1>`__.
 -   Bumped ``vshard-ee`` version to `0.1.32 <https://github.com/tarantool/vshard-ee/releases/tag/0.1.32)>`__.
 
 r673
----
+----
 
 -   Bumped Cartridge version to `2.15.0 <https://github.com/tarantool/cartridge/releases/tag/2.15.0>`__.
 -   Bumped ``membership`` version to `2.5.1 <https://github.com/tarantool/membership/releases/tag/2.5.1)>`__.
 -   Bumped ``expirationd-ee`` version to `1.8.0 <https://gitlab.corp.mail.ru/tarantool/tdb/expirationd-ee/-/blob/master/CHANGELOG.md?ref_type=heads#180---2024-08-30)>`__.
 
 r672
----
+----
 
 -   Bumped ``tarantool-2.11`` series to `2.11.6 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.6>`__.
 -   Bumped ``tt-ee`` version to `v2.8.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.8.0>`__.
 -   Bumped ``migrations-ee`` version to `1.3.1 <https://github.com/tarantool/migrations-ee/releases/tag/1.3.1>`__.
 
 r669
----
+----
 
 -   Bumped Cartridge version to `2.14.0 <https://github.com/tarantool/cartridge/releases/tag/2.14.0>`__.
 -   Bumped ``membership`` version to `2.4.6 <https://github.com/tarantool/membership/releases/tag/2.4.6)>`__.
 
 r662
----
+----
 
 -   Bumped ``vshard-ee`` version to `0.1.31 <https://github.com/tarantool/vshard-ee/releases/tag/0.1.31>`__.
 -   Bumped ``tt-ee`` version to `v2.7.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.7.0)>`__.
 
 r660
----
+----
 
 -   Bumped ``tt-ee`` version to `v2.6.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.6.0>`__.
 -   Bumped Cartridge version to `2.13.0 <https://github.com/tarantool/cartridge/releases/tag/2.13.0>`__.
@@ -174,7 +173,7 @@ r660
 -   Bumped ``http`` version to `1.7.0 <https://github.com/tarantool/http/releases/tag/1.7.0>`__.
 
 r659
----
+----
 
 -   Bumped ``tarantool-2.11`` series to `2.11.5 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.5>`__.
 -   Bumped ``tt-ee`` version to `v2.5.2 <https://github.com/tarantool/tt-ee/releases/tag/v2.5.2>`__.
@@ -183,54 +182,54 @@ r659
 -   Bumped ``tt-ee`` version to `v2.5.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.5.0>`__.
 
 r654
----
+----
 
 -   Moved ``cartridge-auth-extension`` to **stable** directory.
 -   Bumped ``crud-ee`` version to `1.7.1 <https://github.com/tarantool/crud-ee/releases/tag/1.7.1>`__.
 -   Bumped ``migrations-ee`` version to `1.3.0 <https://github.com/tarantool/migrations-ee/releases/tag/1.3.0>`__.
 
 r653
----
+----
 
 -   Bumped Cartridge version to `2.12.4 <https://github.com/tarantool/cartridge/releases/tag/2.12.4>`__.
 -   Bumped ``vshard`` version to `0.1.29 <https://github.com/tarantool/vshard/releases/tag/0.1.29>`__.
 -   Bumped ``http`` version to `1.6.0 <https://github.com/tarantool/http/releases/tag/1.6.0>`__.
 
 r652
----
+----
 
 -   Bumped ``tarantool-2.11`` series to `2.11.4 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.4>`__.
 -   Bumped Cartridge version to `2.12.3 <https://github.com/tarantool/cartridge/releases/tag/2.12.3>`__.
 
 r650
----
+----
 
 -   Bumped ``tt-ee`` version to `v2.4.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.4.0>`__.
 -   Bumped ``queue`` version to `1.4.2 <https://github.com/tarantool/queue/releases/tag/1.4.2>`__.
 -   Added Migration Guide to bundle.
 
 r647
----
+----
 
 -   Updated Oracle to `1.5.0 <https://github.com/tarantool/oracle/releases/tag/1.5.0>`__ for x86_64.
 -   Updated ``oci`` to `21.14 <https://github.com/tarantool/oci/releases/tag/21.14>`__ for x86_64.
 
 r646
----
+----
 
 -   Moved to enterprise edition modules.
 -   Fixed Docker image due to CentOS 7 EOL.
 -   Fixed CI/CD workflows running inside CentOS 7.
 
 r643
----
+----
 
 -   Bumped ``tt-ee`` version to `v2.3.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.3.1>`__.
 -   Enabled ``tt`` bash completion.
 -   Updated Kafka to `1.6.8 <https://github.com/tarantool/kafka/releases/tag/1.6.8>`__.
 
 r640
----
+----
 
 -   Updated Docker image
 -   Updated CMake to 3.20.6.
@@ -238,33 +237,33 @@ r640
 -   Fixed installation of Python 3.6.
 
 r639
----
+----
 
 -   Enabled back ``aarch64`` jobs.
 -   Temporary disabled ``aarch64`` jobs.
 
 r637
----
+----
 
 -   Updated metrics to `1.1.0 <https://github.com/tarantool/metrics/releases/tag/1.1.0>`__.
 -   Updated ``queue`` to `1.4.1 <https://github.com/tarantool/queue/releases/tag/1.4.1>`__.
 -   Updated CRUD to `1.5.2 <https://github.com/tarantool/crud/releases/tag/1.5.2>`__.
 
 r636
----
+----
 
 -   Updated Cartridge to `2.11.0 <https://github.com/tarantool/cartridge/releases/tag/2.11.0>`__.
 -   Updated ``ddl`` to `1.7.1 <https://github.com/tarantool/ddl/releases/tag/1.7.1>`__.
 -   Updated ``vshard`` to `0.1.27 <https://github.com/tarantool/vshard/releases/tag/0.1.27>`__.
 
 r635
----
+----
 
 -   Adjusted CI workflows for ``1.x-2.x`` development branch.
 -   Deleted ``tarantool-master`` submodule.
 
 r633
----
+----
 
 -   Updated CRUD to `1.5.1 <https://github.com/tarantool/crud/releases/tag/1.5.1>`__.
 -   Updated ``sideservice`` to `0.2.1 <https://github.com/tarantool/sideservice/releases/tag/0.2.1>`__.
@@ -272,7 +271,7 @@ r633
 -   Updated ``httpgo-crud`` to `0.1.1  <https://github.com/tarantool/httpgo-crud/releases/tag/0.1.1>`__.
 
 r632
----
+----
 
 -   Updated cartridge-cli to `2.12.12 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.12>`__.
 -   ``tt`` used instead of ``tarantoolctl`` for build/test routines.
@@ -280,7 +279,7 @@ r632
 -   Bumped ``tarantool-2.11`` to 2.11.3.
 
 r628
----
+----
 
 -   Updated Cartridge to `2.10.0  <https://github.com/tarantool/cartridge/releases/tag/2.10.0>`__.
 -   Updated ``membership`` to `2.4.4  <https://github.com/tarantool/membership/releases/tag/2.4.4>`__.
@@ -288,7 +287,7 @@ r628
 -   Updated ``graphqlapi`` to `0.0.11 <https://github.com/tarantool/graphqlapi/releases/tag/0.0.11>`__.
 
 r627
----
+----
 
 -   Updated ``expirationd`` to `1.6.0 <https://github.com/tarantool/expirationd/releases/tag/1.6.0>`__.
 -   Updated ``sharded-queue`` to `1.0.0 <https://github.com/tarantool/sharded-queue/releases/tag/1.0.0>`__.
@@ -296,7 +295,7 @@ r627
 -   Updated cartridge-cli to `2.12.11 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.11>`__.
 
 r623
----
+----
 
 -   Updated ``tt-ee`` to `2.2.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.2.1>`__.
 -   Updated CRUD to `1.5.0 <https://github.com/tarantool/crud/releases/tag/1.5.0>`__.
@@ -304,14 +303,14 @@ r623
 -   Updated Cartridge to `2.9.0 <https://github.com/tarantool/cartridge/releases/tag/2.9.0>`__.
 
 r619
----
+----
 
 -   Updated bundle ``tt-ee`` aarch64.
 -   Updated ``tt-ee`` to `2.2.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.2.0>`__.
 -   Fixed running Tarantool tests on RED OS.
 
 r616
----
+----
 
 -   Updated CRUD to `1.4.3 <https://github.com/tarantool/crud/releases/tag/1.4.3>`__.
 -   Updated ``luatest`` to `1.0.1 <https://github.com/tarantool/luatest/releases/tag/1.0.1>`__.
@@ -319,7 +318,7 @@ r616
 -   Updated ``tt-ee`` to `2.1.2 <https://github.com/tarantool/tt-ee/releases/tag/v2.1.2>`__.
 
 r613
----
+----
 
 -   Updated Cartridge to `2.8.5 <https://github.com/tarantool/cartridge/releases/tag/2.8.5>`__.
 -   Updated CRUD to `1.4.2 <https://github.com/tarantool/crud/releases/tag/1.4.2>`__.
@@ -330,19 +329,19 @@ r613
 -   Updated ``vshard`` to `0.1.26 <https://github.com/tarantool/vshard/releases/tag/0.1.26>`__.
 
 r609
----
+----
 
 -   Updated ``httpgo`` to `0.2.1 <https://github.com/tarantool/httpgo/releases/tag/0.2.1>`__.
 -   Added ``httpgo-crud`` `0.1.0 <https://github.com/tarantool/httpgo-crud/releases/tag/0.1.0>`__.
 -   Updated ``tarantool-2.11`` to 2.11.2.
 
 r606
----
+----
 
 -   Updated ``tarantool-master`` to 3.0.0-beta1.
 
 r605
----
+----
 
 -   Updated Cartridge to `2.8.4 <https://github.com/tarantool/cartridge/releases/tag/2.8.4>`__.
 -   Updated CRUD to `1.4.1 <https://github.com/tarantool/crud/releases/tag/1.4.1>`__.
@@ -351,13 +350,13 @@ r605
 -   Updated ``tt-ee`` to `2.0.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.0.0>`__.
 
 r598
----
+----
 
 -   Updated cartridge-cli to `2.12.9 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.7>`__.
 -   Updated ``tt-ee`` to `1.3.1 <https://github.com/tarantool/tt-ee/releases/tag/v1.3.1>`__.
 
 r595
----
+----
 
 -   Updated ``tt-ee`` to `1.3.0 <https://github.com/tarantool/tt-ee/releases/tag/v1.3.0>`__.
 -   Updated Cartridge to `2.8.3 <https://github.com/tarantool/cartridge/releases/tag/2.8.3>`__.
@@ -370,7 +369,7 @@ r595
 
 
 r589
----
+----
 
 -   Updated ``tarantool-2.10`` to 2.10.8.
 -   Updated ``tarantool-master`` to 3.0.0-alpha3.
@@ -383,13 +382,13 @@ r589
 -   Added ``sideservice`` `0.1.0 <https://github.com/tarantool/sideservice/releases/tag/0.1.0>`__.
 
 r579
----
+----
 
 -   Updated cartridge-cli to `2.12.7 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.7>`__.
 -   Updated ``tarantool-2.11`` to 2.11.1.
 
 r577
----
+----
 
 -   Added CRUD `1.2.0 <https://github.com/tarantool/crud/releases/tag/1.2.0>`__.
 -   Added ``ddl`` `1.6.3 <https://github.com/tarantool/ddl/releases/tag/1.6.3>`__.
@@ -399,7 +398,7 @@ r577
 -   Updated cartridge-cli to `2.12.6 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.6>`__.
 
 r563
----
+----
 
 -   Updated ``tarantool-2.10`` to 2.10.7.
 -   Updated ``tarantool-2.11`` to 2.11.0.
@@ -411,13 +410,13 @@ r563
 -   Added ``http`` `1.5.0 <https://github.com/tarantool/http/releases/tag/1.5.0>`__.
 
 r557
----
+----
 
 -   Added checks `3.3.0 <https://github.com/tarantool/checks/releases/tag/3.3.0>`__.
 -   Updated cartridge-cli to `2.12.5 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.5>`__.
 
 r553
----
+----
 
 -   Added ``tt-ee`` and ``tt`` environment configuration.
 -   Added CRUD `1.1.1 <https://github.com/tarantool/crud/releases/tag/1.1.1>`__.
@@ -433,47 +432,47 @@ r553
 -   Added Kafka `1.6.5 <https://github.com/tarantool/kafka/releases/tag/1.6.5>`__.
 
 r549
----
+----
 
 -   Updated ``tarantool-2.10`` to 2.10.6.
 
 r545
----
+----
 
 -   Updated ``tarantool-2.11`` to 2.11.0-rc2.
 
 r543
----
+----
 
 -   Added the ``tarantool-2.11`` submodule.
 
 r542
----
+----
 
 -   Updated ``tarantool-1.10`` to 1.10.15.
 
 r541
----
+----
 
 -   Updated ``tarantool-master`` to ``3.0.0-entrypoint``.
 
 r540
----
+----
 
 -   Updated ``tarantool-2.10`` to 2.10.5.
 
 r539
----
+----
 
 -   Added ``vshard`` `0.1.22 <https://github.com/tarantool/vshard/releases/tag/0.1.22>`__.
 
 r538
----
+----
 
 -   Updated ``tarantool-2.8`` to apply 2 hotfixes.
 
 r537
----
+----
 
 -   Fixed non-interactive installation of the ``brew`` package.
 
@@ -483,28 +482,28 @@ r537
     time.
 
 r536
----
+----
 
 -   Added the missing property ``2.10`` for scope ``CACHE`` in CMakeLists.txt.
 
 r535
----
+----
 
 -   Added ``expirationd`` `1.3.1 <https://github.com/tarantool/expirationd/releases/tag/1.3.1>`__.
 
 r534
----
+----
 
 -   Added CRUD `1.0.0 <https://github.com/tarantool/crud/releases/tag/1.0.0>`__.
 
 r533
----
+----
 
 -   Used runners with label ``regular`` for builds and the tagged release
     workflow.
 
 r532
----
+----
 
 -   Added ``http`` `1.4.0 <https://github.com/tarantool/http/releases/tag/1.4.0>`__.
 -   Added ``space-explorer`` `1.1.7 <https://github.com/tarantool/space-explorer/releases/tag/1.1.7>`__.
@@ -513,62 +512,62 @@ r532
 -   Added Cartridge `2.7.8 <https://github.com/tarantool/cartridge/releases/tag/2.7.8>`__.
 
 r531
----
+----
 
 -   Added the ``-DENABLE_LTO=ON``  flag for tarantool-ee@master branch to
     CMakeLists.txt
 
 r530
----
+----
 
 -   Upgraded ``devtoolset`` from 8 to 9. It was required for upgrading ``ld`` from
     2.30 to 2.31+ for LTO.
 
 
 r529
----
+----
 
 -  Updated tarantool’s ``master`` branch to a recent revision.
 
 r528
----
+----
 
 -  Fixed code style in the Linux and MacOS workflows.
 
 r527
----
+----
 
 -  Reliably installed packages in MacOS builds.
 
 r526
----
+----
 
 -   Refactored the way that GC64 builds are defined in the build workflow.
     There are no changes to the composition of resulting bundles.
 
 r525
----
+----
 
 -   Added alerting failures in builds on stable branches and integration testing
     to VK Teams chats.
 
 r524
----
+----
 
 -   Updated to fresh tarantool master (``2.11.0-entrypoint-107-ga18449d``)
 
 r523
----
+----
 
 -   Added Cartridge `2.7.7 <https://github.com/tarantool/cartridge/releases/tag/2.7.7>`__.
 
 r522
----
+----
 
 -   Outdated workflow runs are now canceled to save CI time.
 
 r521
----
+----
 
 -   Added CRUD `0.14.1 <https://github.com/tarantool/crud/releases/tag/0.14.1>`__.
 -   Added ``expirationd`` `1.3.0 <https://github.com/tarantool/expirationd/releases/tag/1.3.0>`__.
@@ -576,7 +575,7 @@ r521
 -   Added queue `1.2.2 <https://github.com/tarantool/queue/releases/tag/1.2.2>`__.
 
 r520
----
+----
 
 Release SDK by tags:
 
@@ -585,7 +584,7 @@ Release SDK by tags:
 -   Added consistency check for all versions.
 
 r519
----
+----
 
 *   On feature branches, SDK is now rebuilt only on relevant changes.
 

--- a/doc/release/enterprise-changelog.rst
+++ b/doc/release/enterprise-changelog.rst
@@ -46,8 +46,8 @@ r694
 -   Added CRUD CE `1.6.1 <https://github.com/tarantool/crud/releases/tag/1.6.1>`__.
 -   Added  ``expirationd`` CE `1.7.0 <https://github.com/tarantool/expirationd/releases/tag/1.7.0>`__.
 -   Added ``ddl`` CE `1.7.1 <https://github.com/tarantool/ddl/releases/tag/1.7.1>`__.
--   Bumped metrics version to `1.5.0 <https://github.com/tarantool/metrics/releases/tag/1.5.0>`__.
--   Added migrations CE `1.1.0 <https://github.com/tarantool/migrations/releases/tag/1.1.0>`__.
+-   Bumped ``metrics`` version to `1.5.0 <https://github.com/tarantool/metrics/releases/tag/1.5.0>`__.
+-   Added ``migrations`` CE `1.1.0 <https://github.com/tarantool/migrations/releases/tag/1.1.0>`__.
 -   Added ``vshard`` CE `0.1.36 <https://github.com/tarantool/vshard/releases/tag/0.1.36>`__.
 -   Moved to community edition modules.
 
@@ -65,7 +65,7 @@ r691
 ----
 
 -   Bumped Cartridge version to `2.16.2 <https://github.com/tarantool/cartridge/releases/tag/2.16.2>`__.
--   Bumped metrics version to `1.4.0 <https://github.com/tarantool/metrics/releases/tag/1.4.0>`__.
+-   Bumped ``metrics`` version to `1.4.0 <https://github.com/tarantool/metrics/releases/tag/1.4.0>`__.
 -   Bumped ``http`` version to `1.8.0 <https://github.com/tarantool/http/releases/tag/1.8.0)>`__.
 -   Bumped ``crud-ee`` version to `1.7.4 <https://gitlab.corp.mail.ru/tarantool/tdb/crud-ee/-/tags/1.7.4>`__.
 
@@ -217,7 +217,7 @@ r647
 r646
 ----
 
--   Moved to enterprise edition modules.
+-   Moved to Enterprise Edition modules.
 -   Fixed Docker image due to CentOS 7 EOL.
 -   Fixed CI/CD workflows running inside CentOS 7.
 
@@ -245,7 +245,7 @@ r639
 r637
 ----
 
--   Updated metrics to `1.1.0 <https://github.com/tarantool/metrics/releases/tag/1.1.0>`__.
+-   Updated ``metrics`` to `1.1.0 <https://github.com/tarantool/metrics/releases/tag/1.1.0>`__.
 -   Updated ``queue`` to `1.4.1 <https://github.com/tarantool/queue/releases/tag/1.4.1>`__.
 -   Updated CRUD to `1.5.2 <https://github.com/tarantool/crud/releases/tag/1.5.2>`__.
 
@@ -273,7 +273,7 @@ r633
 r632
 ----
 
--   Updated cartridge-cli to `2.12.12 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.12>`__.
+-   Updated ``cartridge-cli`` to `2.12.12 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.12>`__.
 -   ``tt`` used instead of ``tarantoolctl`` for build/test routines.
 -   Made Tarantool and bundle versions correct.
 -   Bumped ``tarantool-2.11`` to 2.11.3.
@@ -291,8 +291,8 @@ r627
 
 -   Updated ``expirationd`` to `1.6.0 <https://github.com/tarantool/expirationd/releases/tag/1.6.0>`__.
 -   Updated ``sharded-queue`` to `1.0.0 <https://github.com/tarantool/sharded-queue/releases/tag/1.0.0>`__.
--   Dropped building macOS bundles.
--   Updated cartridge-cli to `2.12.11 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.11>`__.
+-   Dropped building MacOS bundles.
+-   Updated ``cartridge-cli`` to `2.12.11 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.11>`__.
 
 r623
 ----
@@ -314,7 +314,7 @@ r616
 
 -   Updated CRUD to `1.4.3 <https://github.com/tarantool/crud/releases/tag/1.4.3>`__.
 -   Updated ``luatest`` to `1.0.1 <https://github.com/tarantool/luatest/releases/tag/1.0.1>`__.
--   Updated migrations to `0.7.0 <https://github.com/tarantool/migrations/releases/tag/0.7.0>`__.
+-   Updated ``migrations`` to `0.7.0 <https://github.com/tarantool/migrations/releases/tag/0.7.0>`__.
 -   Updated ``tt-ee`` to `2.1.2 <https://github.com/tarantool/tt-ee/releases/tag/v2.1.2>`__.
 
 r613
@@ -352,7 +352,7 @@ r605
 r598
 ----
 
--   Updated cartridge-cli to `2.12.9 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.7>`__.
+-   Updated ``cartridge-cli`` to `2.12.9 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.7>`__.
 -   Updated ``tt-ee`` to `1.3.1 <https://github.com/tarantool/tt-ee/releases/tag/v1.3.1>`__.
 
 r595
@@ -373,7 +373,7 @@ r589
 
 -   Updated ``tarantool-2.10`` to 2.10.8.
 -   Updated ``tarantool-master`` to 3.0.0-alpha3.
--   Updated migrations to `0.6.0 <https://github.com/tarantool/migrations/releases/tag/0.6.0>`__.
+-   Updated ``migrations`` to `0.6.0 <https://github.com/tarantool/migrations/releases/tag/0.6.0>`__.
 -   Updated ``tt-ee`` to `1.2.0 <https://github.com/tarantool/tt-ee/releases/tag/v1.2.0>`__.
 -   Updated ``space-explorer`` to `1.1.8 <https://github.com/tarantool/space-explorer/releases/tag/1.1.8>`__.
 -   Updated ``cartridge-metrics-role`` to `0.1.1 <https://github.com/tarantool/cartridge-metrics-role/releases/tag/0.1.1>`__.
@@ -384,7 +384,7 @@ r589
 r579
 ----
 
--   Updated cartridge-cli to `2.12.7 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.7>`__.
+-   Updated ``cartridge-cli`` to `2.12.7 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.7>`__.
 -   Updated ``tarantool-2.11`` to 2.11.1.
 
 r577
@@ -395,7 +395,7 @@ r577
 -   Added ``sharded-queue`` `0.1.0 <https://github.com/tarantool/sharded-queue/releases/tag/0.1.0>`__.
 -   Added ``ddl`` `1.6.4 <https://github.com/tarantool/ddl/releases/tag/1.6.4>`__.
 -   Updated ``tt-ee`` to `1.1.2 <https://github.com/tarantool/tt-ee/releases/tag/v1.1.2>`__.
--   Updated cartridge-cli to `2.12.6 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.6>`__.
+-   Updated ``cartridge-cli`` to `2.12.6 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.6>`__.
 
 r563
 ----
@@ -404,7 +404,7 @@ r563
 -   Updated ``tarantool-2.11`` to 2.11.0.
 -   Added Kafka `1.6.6 <https://github.com/tarantool/kafka/releases/tag/1.6.6>`__.
 -   Added ``vshard`` `0.1.24 <https://github.com/tarantool/vshard/releases/tag/0.1.24>`__.
--   Added metrics `1.0.0 <https://github.com/tarantool/metrics/releases/tag/1.0.0>`__.
+-   Added ``metrics`` `1.0.0 <https://github.com/tarantool/metrics/releases/tag/1.0.0>`__.
 -   Added ``cartridge-metrics-role`` `0.1.0 <https://github.com/tarantool/cartridge-metrics-role/releases/tag/0.1.0>`__.
 -   Added Cartridge `2.8.0 <https://github.com/tarantool/cartridge/releases/tag/2.8.0>`__.
 -   Added ``http`` `1.5.0 <https://github.com/tarantool/http/releases/tag/1.5.0>`__.
@@ -413,7 +413,7 @@ r557
 ----
 
 -   Added checks `3.3.0 <https://github.com/tarantool/checks/releases/tag/3.3.0>`__.
--   Updated cartridge-cli to `2.12.5 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.5>`__.
+-   Updated ``cartridge-cli`` to `2.12.5 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.5>`__.
 
 r553
 ----
@@ -424,8 +424,8 @@ r553
 -   Added ``expirationd`` `1.4.0 <https://github.com/tarantool/expirationd/releases/tag/1.4.0>`__.
 -   Added ``graphql`` `0.3.0 <https://github.com/tarantool/graphql/releases/tag/0.3.0>`__.
 -   Added ``graphqlapi`` `0.0.10 <https://github.com/tarantool/graphqlapi/releases/tag/0.0.10>`__.
--   Added metrics `0.17.0 <https://github.com/tarantool/metrics/releases/tag/0.17.0>`__.
--   Added migrations `0.5.0 <https://github.com/tarantool/migrations/releases/tag/0.5.0>`__.
+-   Added ``metrics`` `0.17.0 <https://github.com/tarantool/metrics/releases/tag/0.17.0>`__.
+-   Added ``migrations`` `0.5.0 <https://github.com/tarantool/migrations/releases/tag/0.5.0>`__.
 -   Added Oracle `1.4.0 <https://github.com/tarantool/oracle/releases/tag/1.4.0>`__.
 -   Added Cartridge `2.7.9 <https://github.com/tarantool/cartridge/releases/tag/2.7.9>`__.
 -   Added ``vshard`` `0.1.23 <https://github.com/tarantool/vshard/releases/tag/0.1.23>`__.
@@ -475,9 +475,7 @@ r537
 ----
 
 -   Fixed non-interactive installation of the ``brew`` package.
-
 -   Changed the owner of the ``/usr/local/bin`` directory.
-
 -   Installed ``awscli@1`` instead of ``awscli`` since it takes much less
     time.
 
@@ -507,15 +505,15 @@ r532
 
 -   Added ``http`` `1.4.0 <https://github.com/tarantool/http/releases/tag/1.4.0>`__.
 -   Added ``space-explorer`` `1.1.7 <https://github.com/tarantool/space-explorer/releases/tag/1.1.7>`__.
--   Added ``checks `3.2.0 <https://github.com/tarantool/checks/releases/tag/3.2.0>`__.
--   Added metrics `0.16.0 <https://github.com/tarantool/metrics/releases/tag/0.16.0>`__.
+-   Added ``checks`` `3.2.0 <https://github.com/tarantool/checks/releases/tag/3.2.0>`__.
+-   Added ``metrics`` `0.16.0 <https://github.com/tarantool/metrics/releases/tag/0.16.0>`__.
 -   Added Cartridge `2.7.8 <https://github.com/tarantool/cartridge/releases/tag/2.7.8>`__.
 
 r531
 ----
 
--   Added the ``-DENABLE_LTO=ON``  flag for tarantool-ee@master branch to
-    CMakeLists.txt
+-   Added the ``-DENABLE_LTO=ON``  flag for ``tarantool-ee@master`` branch to
+    CMakeLists.txt.
 
 r530
 ----
@@ -571,8 +569,8 @@ r521
 
 -   Added CRUD `0.14.1 <https://github.com/tarantool/crud/releases/tag/0.14.1>`__.
 -   Added ``expirationd`` `1.3.0 <https://github.com/tarantool/expirationd/releases/tag/1.3.0>`__.
--   Added metrics `0.15.1 <https://github.com/tarantool/metrics/releases/tag/0.15.1>`__.
--   Added queue `1.2.2 <https://github.com/tarantool/queue/releases/tag/1.2.2>`__.
+-   Added ``metrics`` `0.15.1 <https://github.com/tarantool/metrics/releases/tag/0.15.1>`__.
+-   Added ``queue`` `1.2.2 <https://github.com/tarantool/queue/releases/tag/1.2.2>`__.
 
 r520
 ----
@@ -591,9 +589,9 @@ r519
 r518
 ----
 
-*   Added frontend core `8.2.1 <https://github.com/tarantool/frontend-core/releases/tag/8.2.1>`__.
+*   Added ``frontend-core`` `8.2.1 <https://github.com/tarantool/frontend-core/releases/tag/8.2.1>`__.
 *   Added ``vshard`` `0.1.21 <https://github.com/tarantool/vshard/releases/tag/0.1.21>`__.
-*   Added http `1.3.0 <https://github.com/tarantool/http/releases/tag/1.3.0>`__.
+*   Added ``http`` `1.3.0 <https://github.com/tarantool/http/releases/tag/1.3.0>`__.
 *   Added Cartridge `2.7.6 <https://github.com/tarantool/cartridge/releases/tag/2.7.6>`__.
 
 r517
@@ -616,7 +614,7 @@ r514
 ----
 
 *   Remove the local registry and setup using GitHub registry.
-*   Sync rocks cache to s3 and back.
+*   Sync rocks cache to S3 and back.
 *   Setup using shared runners.
 *   Refactor and format ``ci-linux.yml`` and ``ci-macos.yml``.
 

--- a/doc/release/enterprise-changelog.rst
+++ b/doc/release/enterprise-changelog.rst
@@ -50,7 +50,7 @@ r694
 -   Bumped ``metrics`` version to `1.5.0 <https://github.com/tarantool/metrics/releases/tag/1.5.0>`__.
 -   Added ``migrations`` CE `1.1.0 <https://github.com/tarantool/migrations/releases/tag/1.1.0>`__.
 -   Added ``vshard`` CE `0.1.36 <https://github.com/tarantool/vshard/releases/tag/0.1.36>`__.
--   Moved to community edition modules.
+-   Moved to Community Edition modules.
 
 r693
 ----

--- a/doc/release/enterprise-changelog.rst
+++ b/doc/release/enterprise-changelog.rst
@@ -18,6 +18,7 @@ For example: ``2.11.1-0-gc42d9735b-r589``.
 -   ``TARANTOOL_BASE_VERSION`` is the Community version which the Enterprise version is based on.
 -   ``REVISION`` is the SDK revision. Besides Tarantool itself, it includes the ``tt`` utility, a set of open and closed source modules, and examples. Learn more from :ref:`Package contents <enterprise-package-contents>`.
 
+
 r703
 ----
 
@@ -231,7 +232,7 @@ r643
 r640
 ----
 
--   Updated Docker image
+-   Updated Docker image.
 -   Updated CMake to 3.20.6.
 -   Installed dependencies for building OpenSSL.
 -   Fixed installation of Python 3.6.
@@ -338,7 +339,7 @@ r609
 r606
 ----
 
--   Updated ``tarantool-master`` to 3.0.0-beta1.
+-   Updated ``tarantool-master`` to ``3.0.0-beta1``.
 
 r605
 ----
@@ -372,7 +373,7 @@ r589
 ----
 
 -   Updated ``tarantool-2.10`` to 2.10.8.
--   Updated ``tarantool-master`` to 3.0.0-alpha3.
+-   Updated ``tarantool-master`` to ``3.0.0-alpha3``.
 -   Updated ``migrations`` to `0.6.0 <https://github.com/tarantool/migrations/releases/tag/0.6.0>`__.
 -   Updated ``tt-ee`` to `1.2.0 <https://github.com/tarantool/tt-ee/releases/tag/v1.2.0>`__.
 -   Updated ``space-explorer`` to `1.1.8 <https://github.com/tarantool/space-explorer/releases/tag/1.1.8>`__.
@@ -482,7 +483,7 @@ r537
 r536
 ----
 
--   Added the missing property ``2.10`` for scope ``CACHE`` in CMakeLists.txt.
+-   Added the missing property ``2.10`` for scope ``CACHE`` in ``CMakeLists.txt``.
 
 r535
 ----

--- a/doc/release/enterprise-changelog.rst
+++ b/doc/release/enterprise-changelog.rst
@@ -18,281 +18,573 @@ For example: ``2.11.1-0-gc42d9735b-r589``.
 -   ``TARANTOOL_BASE_VERSION`` is the Community version which the Enterprise version is based on.
 -   ``REVISION`` is the SDK revision. Besides Tarantool itself, it includes the ``tt`` utility, a set of open and closed source modules, and examples. Learn more from :ref:`Package contents <enterprise-package-contents>`.
 
-616
+r703
 ---
 
--   Updated crud to `1.4.3 <https://github.com/tarantool/crud/releases/tag/1.4.3>`__.
--   Updated luatest to `1.0.1 <https://github.com/tarantool/luatest/releases/tag/1.0.1>`__.
+-   Bumped ``checks`` version to `3.4.0 <https://github.com/tarantool/checks/releases/tag/3.4.0>`__.
+-   Bumped Cartridge version to `2.16.4 <https://github.com/tarantool/cartridge/releases/tag/2.16.4)>`__.
+-   Bumped ``vshard`` version to `0.1.37 <https://github.com/tarantool/vshard/releases/tag/0.1.37>`__.
+
+r702
+---
+
+-   Bumped ``tarantool-2.11`` series to `2.11.8 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.8>`__.
+
+r696
+---
+
+-   Moved CI files from ``sdk-ci`` repository.
+
+r695
+---
+
+-   Bumped ``tt-ee`` version to `v2.11.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.11.0>`__.
+
+r694
+---
+
+-   Replaced Cartridge EE with Cartridge CE `2.16.3 <https://github.com/tarantool/cartridge/releases/tag/2.16.3>`__.
+-   Added CRUD CE `1.6.1 <https://github.com/tarantool/crud/releases/tag/1.6.1>`__.
+-   Added  ``expirationd`` CE `1.7.0 <https://github.com/tarantool/expirationd/releases/tag/1.7.0>`__.
+-   Added ``ddl`` CE `1.7.1 <https://github.com/tarantool/ddl/releases/tag/1.7.1>`__.
+-   Bumped metrics version to `1.5.0 <https://github.com/tarantool/metrics/releases/tag/1.5.0>`__.
+-   Added migrations CE `1.1.0 <https://github.com/tarantool/migrations/releases/tag/1.1.0>`__.
+-   Added ``vshard`` CE `0.1.36 <https://github.com/tarantool/vshard/releases/tag/0.1.36>`__.
+-   Moved to community edition modules.
+
+r693
+---
+
+-   Fixed ``glibc`` package URL to archived.
+
+r692
+---
+
+-   Added manual trigger job to run tests to generate ``certificate of compliance``. Ready for Astra Linux.
+
+r691
+---
+
+-   Bumped Cartridge version to `2.16.2 <https://github.com/tarantool/cartridge/releases/tag/2.16.2>`__.
+-   Bumped metrics version to `1.4.0 <https://github.com/tarantool/metrics/releases/tag/1.4.0>`__.
+-   Bumped ``http`` version to `1.8.0 <https://github.com/tarantool/http/releases/tag/1.8.0)>`__.
+-   Bumped ``crud-ee`` version to `1.7.4 <https://gitlab.corp.mail.ru/tarantool/tdb/crud-ee/-/tags/1.7.4>`__.
+
+r690
+---
+
+-   Bumped ``tt-ee`` version to `v2.10.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.10.1>`__.
+
+r689
+---
+
+-   Bumped Cartridge version to `2.16.0 <https://github.com/tarantool/cartridge/releases/tag/2.16.0>`__.
+
+r688
+---
+
+-   Bumped ``vshard-ee`` version to `0.1.34 <https://github.com/tarantool/vshard-ee/releases/tag/0.1.34>`__.
+
+r687
+---
+
+-   Bumped Cartridge version to `2.15.4 <https://github.com/tarantool/cartridge/releases/tag/2.15.4>`__.
+
+r686
+---
+
+-   Bumped ``tt-ee`` version to `v2.10.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.10.0>`__.
+
+r685
+---
+
+-   Bumped ``migrations-ee`` version to `1.3.2 <https://github.com/tarantool/migrations-ee/releases/tag/1.3.2>`__.
+
+r684
+---
+
+-   Bumped ``tarantool-2.11`` series to `2.11.7 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.7>`__.
+
+r683
+---
+
+-   Bumped Kafka version to `1.6.10 <https://github.com/tarantool/kafka/releases/tag/1.6.10>`__.
+
+r682
+---
+
+-   Bumped Cartridge version to `2.15.3 <https://github.com/tarantool/cartridge/releases/tag/2.15.3>`__.
+
+r681
+---
+
+-   Bumped ``vshard-ee`` version to `0.1.33 <https://github.com/tarantool/vshard-ee/releases/tag/0.1.33>`__.
+
+r680
+---
+
+-   Bumped ``tt-ee`` version to `v2.9.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.9.1>`__.
+
+r679
+---
+
+-   Bumped ``tt-ee`` version to `v2.9.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.9.0>`__.
+-   Bumped Cartridge version to `2.15.2 <https://github.com/tarantool/cartridge/releases/tag/2.15.2>`__.
+-   Bumped ``membership`` version to `2.5.2 <https://github.com/tarantool/membership/releases/tag/2.5.2>`__.
+
+r677
+---
+
+-   Bumped Cartridge version to `2.15.1 <https://github.com/tarantool/cartridge/releases/tag/2.15.1>`__.
+-   Bumped ``tt-ee`` version to `v2.8.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.8.1>`__.
+-   Bumped ``vshard-ee`` version to `0.1.32 <https://github.com/tarantool/vshard-ee/releases/tag/0.1.32)>`__.
+
+r673
+---
+
+-   Bumped Cartridge version to `2.15.0 <https://github.com/tarantool/cartridge/releases/tag/2.15.0>`__.
+-   Bumped ``membership`` version to `2.5.1 <https://github.com/tarantool/membership/releases/tag/2.5.1)>`__.
+-   Bumped ``expirationd-ee`` version to `1.8.0 <https://gitlab.corp.mail.ru/tarantool/tdb/expirationd-ee/-/blob/master/CHANGELOG.md?ref_type=heads#180---2024-08-30)>`__.
+
+r672
+---
+
+-   Bumped ``tarantool-2.11`` series to `2.11.6 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.6>`__.
+-   Bumped ``tt-ee`` version to `v2.8.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.8.0>`__.
+-   Bumped ``migrations-ee`` version to `1.3.1 <https://github.com/tarantool/migrations-ee/releases/tag/1.3.1>`__.
+
+r669
+---
+
+-   Bumped Cartridge version to `2.14.0 <https://github.com/tarantool/cartridge/releases/tag/2.14.0>`__.
+-   Bumped ``membership`` version to `2.4.6 <https://github.com/tarantool/membership/releases/tag/2.4.6)>`__.
+
+r662
+---
+
+-   Bumped ``vshard-ee`` version to `0.1.31 <https://github.com/tarantool/vshard-ee/releases/tag/0.1.31>`__.
+-   Bumped ``tt-ee`` version to `v2.7.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.7.0)>`__.
+
+r660
+---
+
+-   Bumped ``tt-ee`` version to `v2.6.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.6.0>`__.
+-   Bumped Cartridge version to `2.13.0 <https://github.com/tarantool/cartridge/releases/tag/2.13.0>`__.
+-   Bumped ``vshard`` version to `0.1.30 <https://github.com/tarantool/vshard/releases/tag/0.1.30>`__.
+-   Bumped ``http`` version to `1.7.0 <https://github.com/tarantool/http/releases/tag/1.7.0>`__.
+
+r659
+---
+
+-   Bumped ``tarantool-2.11`` series to `2.11.5 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.5>`__.
+-   Bumped ``tt-ee`` version to `v2.5.2 <https://github.com/tarantool/tt-ee/releases/tag/v2.5.2>`__.
+-   Updated Kafka to `1.6.9 <https://github.com/tarantool/kafka/releases/tag/1.6.9>`__.
+-   Bumped ``tt-ee`` version to `v2.5.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.5.1>`__.
+-   Bumped ``tt-ee`` version to `v2.5.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.5.0>`__.
+
+r654
+---
+
+-   Moved ``cartridge-auth-extension`` to **stable** directory.
+-   Bumped ``crud-ee`` version to `1.7.1 <https://github.com/tarantool/crud-ee/releases/tag/1.7.1>`__.
+-   Bumped ``migrations-ee`` version to `1.3.0 <https://github.com/tarantool/migrations-ee/releases/tag/1.3.0>`__.
+
+r653
+---
+
+-   Bumped Cartridge version to `2.12.4 <https://github.com/tarantool/cartridge/releases/tag/2.12.4>`__.
+-   Bumped ``vshard`` version to `0.1.29 <https://github.com/tarantool/vshard/releases/tag/0.1.29>`__.
+-   Bumped ``http`` version to `1.6.0 <https://github.com/tarantool/http/releases/tag/1.6.0>`__.
+
+r652
+---
+
+-   Bumped ``tarantool-2.11`` series to `2.11.4 <https://github.com/tarantool/tarantool-ee/releases/tag/2.11.4>`__.
+-   Bumped Cartridge version to `2.12.3 <https://github.com/tarantool/cartridge/releases/tag/2.12.3>`__.
+
+r650
+---
+
+-   Bumped ``tt-ee`` version to `v2.4.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.4.0>`__.
+-   Bumped ``queue`` version to `1.4.2 <https://github.com/tarantool/queue/releases/tag/1.4.2>`__.
+-   Added Migration Guide to bundle.
+
+r647
+---
+
+-   Updated Oracle to `1.5.0 <https://github.com/tarantool/oracle/releases/tag/1.5.0>`__ for x86_64.
+-   Updated ``oci`` to `21.14 <https://github.com/tarantool/oci/releases/tag/21.14>`__ for x86_64.
+
+r646
+---
+
+-   Moved to enterprise edition modules.
+-   Fixed Docker image due to CentOS 7 EOL.
+-   Fixed CI/CD workflows running inside CentOS 7.
+
+r643
+---
+
+-   Bumped ``tt-ee`` version to `v2.3.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.3.1>`__.
+-   Enabled ``tt`` bash completion.
+-   Updated Kafka to `1.6.8 <https://github.com/tarantool/kafka/releases/tag/1.6.8>`__.
+
+r640
+---
+
+-   Updated Docker image
+-   Updated CMake to 3.20.6.
+-   Installed dependencies for building OpenSSL.
+-   Fixed installation of Python 3.6.
+
+r639
+---
+
+-   Enabled back ``aarch64`` jobs.
+-   Temporary disabled ``aarch64`` jobs.
+
+r637
+---
+
+-   Updated metrics to `1.1.0 <https://github.com/tarantool/metrics/releases/tag/1.1.0>`__.
+-   Updated ``queue`` to `1.4.1 <https://github.com/tarantool/queue/releases/tag/1.4.1>`__.
+-   Updated CRUD to `1.5.2 <https://github.com/tarantool/crud/releases/tag/1.5.2>`__.
+
+r636
+---
+
+-   Updated Cartridge to `2.11.0 <https://github.com/tarantool/cartridge/releases/tag/2.11.0>`__.
+-   Updated ``ddl`` to `1.7.1 <https://github.com/tarantool/ddl/releases/tag/1.7.1>`__.
+-   Updated ``vshard`` to `0.1.27 <https://github.com/tarantool/vshard/releases/tag/0.1.27>`__.
+
+r635
+---
+
+-   Adjusted CI workflows for ``1.x-2.x`` development branch.
+-   Deleted ``tarantool-master`` submodule.
+
+r633
+---
+
+-   Updated CRUD to `1.5.1 <https://github.com/tarantool/crud/releases/tag/1.5.1>`__.
+-   Updated ``sideservice`` to `0.2.1 <https://github.com/tarantool/sideservice/releases/tag/0.2.1>`__.
+-   Updated ``httpgo`` to `0.2.2 <https://github.com/tarantool/httpgo/releases/tag/0.2.2>`__.
+-   Updated ``httpgo-crud`` to `0.1.1  <https://github.com/tarantool/httpgo-crud/releases/tag/0.1.1>`__.
+
+r632
+---
+
+-   Updated cartridge-cli to `2.12.12 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.12>`__.
+-   ``tt`` used instead of ``tarantoolctl`` for build/test routines.
+-   Made Tarantool and bundle versions correct.
+-   Bumped ``tarantool-2.11`` to 2.11.3.
+
+r628
+---
+
+-   Updated Cartridge to `2.10.0  <https://github.com/tarantool/cartridge/releases/tag/2.10.0>`__.
+-   Updated ``membership`` to `2.4.4  <https://github.com/tarantool/membership/releases/tag/2.4.4>`__.
+-   Updated ``ddl`` to `1.7.0  <https://github.com/tarantool/ddl/releases/tag/1.7.0>`__.
+-   Updated ``graphqlapi`` to `0.0.11 <https://github.com/tarantool/graphqlapi/releases/tag/0.0.11>`__.
+
+r627
+---
+
+-   Updated ``expirationd`` to `1.6.0 <https://github.com/tarantool/expirationd/releases/tag/1.6.0>`__.
+-   Updated ``sharded-queue`` to `1.0.0 <https://github.com/tarantool/sharded-queue/releases/tag/1.0.0>`__.
+-   Dropped building macOS bundles.
+-   Updated cartridge-cli to `2.12.11 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.11>`__.
+
+r623
+---
+
+-   Updated ``tt-ee`` to `2.2.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.2.1>`__.
+-   Updated CRUD to `1.5.0 <https://github.com/tarantool/crud/releases/tag/1.5.0>`__.
+-   Updated ``membership`` to `2.4.3 <https://github.com/tarantool/membership/releases/tag/2.4.3>`__.
+-   Updated Cartridge to `2.9.0 <https://github.com/tarantool/cartridge/releases/tag/2.9.0>`__.
+
+r619
+---
+
+-   Updated bundle ``tt-ee`` aarch64.
+-   Updated ``tt-ee`` to `2.2.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.2.0>`__.
+-   Fixed running Tarantool tests on RED OS.
+
+r616
+---
+
+-   Updated CRUD to `1.4.3 <https://github.com/tarantool/crud/releases/tag/1.4.3>`__.
+-   Updated ``luatest`` to `1.0.1 <https://github.com/tarantool/luatest/releases/tag/1.0.1>`__.
 -   Updated migrations to `0.7.0 <https://github.com/tarantool/migrations/releases/tag/0.7.0>`__.
--   Updated tt-ee to `2.1.2 <https://github.com/tarantool/tt-ee/releases/tag/v2.1.2>`__.
+-   Updated ``tt-ee`` to `2.1.2 <https://github.com/tarantool/tt-ee/releases/tag/v2.1.2>`__.
 
-613
+r613
 ---
 
--   Updated cartridge to `2.8.5 <https://github.com/tarantool/cartridge/releases/tag/2.8.5>`__.
--   Updated crud to `1.4.2 <https://github.com/tarantool/crud/releases/tag/1.4.2>`__.
--   Added frontend-core `8.2.2 <https://github.com/tarantool/frontend-core/releases/tag/8.2.2>`__.
--   Updated membership to `2.4.2 <https://github.com/tarantool/membership/releases/tag/2.4.2>`__.
--   Updated sideservice to `0.2.0 <https://github.com/tarantool/sideservice/releases/tag/0.2.0>`__.
--   Updated tt-ee to `2.1.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.1.1>`__.
--   Updated vshard to `0.1.26 <https://github.com/tarantool/vshard/releases/tag/0.1.26>`__.
+-   Updated Cartridge to `2.8.5 <https://github.com/tarantool/cartridge/releases/tag/2.8.5>`__.
+-   Updated CRUD to `1.4.2 <https://github.com/tarantool/crud/releases/tag/1.4.2>`__.
+-   Added ``frontend-core`` `8.2.2 <https://github.com/tarantool/frontend-core/releases/tag/8.2.2>`__.
+-   Updated ``membership`` to `2.4.2 <https://github.com/tarantool/membership/releases/tag/2.4.2>`__.
+-   Updated ``sideservice`` to `0.2.0 <https://github.com/tarantool/sideservice/releases/tag/0.2.0>`__.
+-   Updated ``tt-ee`` to `2.1.1 <https://github.com/tarantool/tt-ee/releases/tag/v2.1.1>`__.
+-   Updated ``vshard`` to `0.1.26 <https://github.com/tarantool/vshard/releases/tag/0.1.26>`__.
 
-609
+r609
 ---
 
--   Updated httpgo to `0.2.1 <https://github.com/tarantool/httpgo/releases/tag/0.2.1>`__.
--   Added httpgo-crud `0.1.0 <https://github.com/tarantool/httpgo-crud/releases/tag/0.1.0>`__.
+-   Updated ``httpgo`` to `0.2.1 <https://github.com/tarantool/httpgo/releases/tag/0.2.1>`__.
+-   Added ``httpgo-crud`` `0.1.0 <https://github.com/tarantool/httpgo-crud/releases/tag/0.1.0>`__.
 -   Updated ``tarantool-2.11`` to 2.11.2.
 
-606
+r606
 ---
 
 -   Updated ``tarantool-master`` to 3.0.0-beta1.
 
-605
+r605
 ---
 
--   Updated cartridge to `2.8.4 <https://github.com/tarantool/cartridge/releases/tag/2.8.4>`__.
--   Updated crud to `1.4.1 <https://github.com/tarantool/crud/releases/tag/1.4.1>`__.
--   Updated ddl to `1.6.5 <https://github.com/tarantool/ddl/releases/tag/1.6.5>`__.
--   Added httpgo `0.2.0 <https://github.com/tarantool/httpgo/releases/tag/0.2.0>`__.
--   Updated tt-ee to `2.0.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.0.0>`__.
+-   Updated Cartridge to `2.8.4 <https://github.com/tarantool/cartridge/releases/tag/2.8.4>`__.
+-   Updated CRUD to `1.4.1 <https://github.com/tarantool/crud/releases/tag/1.4.1>`__.
+-   Updated ``ddl`` to `1.6.5 <https://github.com/tarantool/ddl/releases/tag/1.6.5>`__.
+-   Added ``httpgo`` `0.2.0 <https://github.com/tarantool/httpgo/releases/tag/0.2.0>`__.
+-   Updated ``tt-ee`` to `2.0.0 <https://github.com/tarantool/tt-ee/releases/tag/v2.0.0>`__.
 
-598
+r598
 ---
 
 -   Updated cartridge-cli to `2.12.9 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.7>`__.
--   Updated tt-ee to `1.3.1 <https://github.com/tarantool/tt-ee/releases/tag/v1.3.1>`__.
+-   Updated ``tt-ee`` to `1.3.1 <https://github.com/tarantool/tt-ee/releases/tag/v1.3.1>`__.
 
-595
+r595
 ---
 
--   Updated tt-ee to `1.3.0 <https://github.com/tarantool/tt-ee/releases/tag/v1.3.0>`__.
--   Updated cartridge to `2.8.3 <https://github.com/tarantool/cartridge/releases/tag/2.8.3>`__.
--   Updated cartridge-cli-extensions to `1.1.2 <https://github.com/tarantool/cartridge-cli-extensions/releases/tag/1.1.2>`__.
--   Updated crud to `1.3.0 <https://github.com/tarantool/crud/releases/tag/1.3.0>`__.
--   Updated queue to `1.3.3 <https://github.com/tarantool/queue/releases/tag/1.3.3>`__.
--   Updated sharded-queue to `0.1.1 <https://github.com/tarantool/sharded-queue/releases/tag/0.1.1>`__.
--   Updated membership to `2.4.1 <https://github.com/tarantool/membership/releases/tag/2.4.1>`__.
+-   Updated ``tt-ee`` to `1.3.0 <https://github.com/tarantool/tt-ee/releases/tag/v1.3.0>`__.
+-   Updated Cartridge to `2.8.3 <https://github.com/tarantool/cartridge/releases/tag/2.8.3>`__.
+-   Updated ``cartridge-cli-extensions`` to `1.1.2 <https://github.com/tarantool/cartridge-cli-extensions/releases/tag/1.1.2>`__.
+-   Updated CRUD to `1.3.0 <https://github.com/tarantool/crud/releases/tag/1.3.0>`__.
+-   Updated ``queue`` to `1.3.3 <https://github.com/tarantool/queue/releases/tag/1.3.3>`__.
+-   Updated ``sharded-queue`` to `0.1.1 <https://github.com/tarantool/sharded-queue/releases/tag/0.1.1>`__.
+-   Updated ``membership`` to `2.4.1 <https://github.com/tarantool/membership/releases/tag/2.4.1>`__.
 -   Added tests for Astra Linux 1.7.
 
 
-589
+r589
 ---
 
 -   Updated ``tarantool-2.10`` to 2.10.8.
 -   Updated ``tarantool-master`` to 3.0.0-alpha3.
 -   Updated migrations to `0.6.0 <https://github.com/tarantool/migrations/releases/tag/0.6.0>`__.
--   Updated tt-ee to `1.2.0 <https://github.com/tarantool/tt-ee/releases/tag/v1.2.0>`__.
--   Updated space-explorer to `1.1.8 <https://github.com/tarantool/space-explorer/releases/tag/1.1.8>`__.
--   Updated cartridge-metrics-role to `0.1.1 <https://github.com/tarantool/cartridge-metrics-role/releases/tag/0.1.1>`__.
--   Updated cartridge to `2.8.2 <https://github.com/tarantool/cartridge/releases/tag/2.8.2>`__.
--   Updated expirationd to `1.5.0 <https://github.com/tarantool/expirationd/releases/tag/1.5.0>`__.
--   Added sideservice `0.1.0 <https://github.com/tarantool/sideservice/releases/tag/0.1.0>`__.
+-   Updated ``tt-ee`` to `1.2.0 <https://github.com/tarantool/tt-ee/releases/tag/v1.2.0>`__.
+-   Updated ``space-explorer`` to `1.1.8 <https://github.com/tarantool/space-explorer/releases/tag/1.1.8>`__.
+-   Updated ``cartridge-metrics-role`` to `0.1.1 <https://github.com/tarantool/cartridge-metrics-role/releases/tag/0.1.1>`__.
+-   Updated Cartridge to `2.8.2 <https://github.com/tarantool/cartridge/releases/tag/2.8.2>`__.
+-   Updated ``expirationd`` to `1.5.0 <https://github.com/tarantool/expirationd/releases/tag/1.5.0>`__.
+-   Added ``sideservice`` `0.1.0 <https://github.com/tarantool/sideservice/releases/tag/0.1.0>`__.
 
-579
+r579
 ---
 
 -   Updated cartridge-cli to `2.12.7 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.7>`__.
 -   Updated ``tarantool-2.11`` to 2.11.1.
 
-577
+r577
 ---
 
--   Added crud `1.2.0 <https://github.com/tarantool/crud/releases/tag/1.2.0>`__.
--   Added ddl `1.6.3 <https://github.com/tarantool/ddl/releases/tag/1.6.3>`__.
--   Added sharded-queue `0.1.0 <https://github.com/tarantool/sharded-queue/releases/tag/0.1.0>`__.
--   Added ddl `1.6.4 <https://github.com/tarantool/ddl/releases/tag/1.6.4>`__.
--   Updated tt-ee to `1.1.2 <https://github.com/tarantool/tt-ee/releases/tag/v1.1.2>`__.
+-   Added CRUD `1.2.0 <https://github.com/tarantool/crud/releases/tag/1.2.0>`__.
+-   Added ``ddl`` `1.6.3 <https://github.com/tarantool/ddl/releases/tag/1.6.3>`__.
+-   Added ``sharded-queue`` `0.1.0 <https://github.com/tarantool/sharded-queue/releases/tag/0.1.0>`__.
+-   Added ``ddl`` `1.6.4 <https://github.com/tarantool/ddl/releases/tag/1.6.4>`__.
+-   Updated ``tt-ee`` to `1.1.2 <https://github.com/tarantool/tt-ee/releases/tag/v1.1.2>`__.
 -   Updated cartridge-cli to `2.12.6 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.6>`__.
 
-563
+r563
 ---
 
 -   Updated ``tarantool-2.10`` to 2.10.7.
 -   Updated ``tarantool-2.11`` to 2.11.0.
--   Added kafka `1.6.6 <https://github.com/tarantool/kafka/releases/tag/1.6.6>`__.
--   Added vshard `0.1.24 <https://github.com/tarantool/vshard/releases/tag/0.1.24>`__.
+-   Added Kafka `1.6.6 <https://github.com/tarantool/kafka/releases/tag/1.6.6>`__.
+-   Added ``vshard`` `0.1.24 <https://github.com/tarantool/vshard/releases/tag/0.1.24>`__.
 -   Added metrics `1.0.0 <https://github.com/tarantool/metrics/releases/tag/1.0.0>`__.
--   Added cartridge-metrics-role `0.1.0 <https://github.com/tarantool/cartridge-metrics-role/releases/tag/0.1.0>`__.
--   Added cartridge `2.8.0 <https://github.com/tarantool/cartridge/releases/tag/2.8.0>`__.
--   Added http `1.5.0 <https://github.com/tarantool/http/releases/tag/1.5.0>`__.
+-   Added ``cartridge-metrics-role`` `0.1.0 <https://github.com/tarantool/cartridge-metrics-role/releases/tag/0.1.0>`__.
+-   Added Cartridge `2.8.0 <https://github.com/tarantool/cartridge/releases/tag/2.8.0>`__.
+-   Added ``http`` `1.5.0 <https://github.com/tarantool/http/releases/tag/1.5.0>`__.
 
-557
+r557
 ---
 
 -   Added checks `3.3.0 <https://github.com/tarantool/checks/releases/tag/3.3.0>`__.
 -   Updated cartridge-cli to `2.12.5 <https://github.com/tarantool/cartridge-cli/releases/tag/2.12.5>`__.
 
-553
+r553
 ---
 
 -   Added ``tt-ee`` and ``tt`` environment configuration.
--   Added crud `1.1.1 <https://github.com/tarantool/crud/releases/tag/1.1.1>`__.
--   Added avro-schema `3.1.1 <https://github.com/tarantool/avro-schema/releases/tag/3.1.0>`__.
--   Added expirationd `1.4.0 <https://github.com/tarantool/expirationd/releases/tag/1.4.0>`__.
--   Added graphql `0.3.0 <https://github.com/tarantool/graphql/releases/tag/0.3.0>`__.
--   Added graphqlapi `0.0.10 <https://github.com/tarantool/graphqlapi/releases/tag/0.0.10>`__.
+-   Added CRUD `1.1.1 <https://github.com/tarantool/crud/releases/tag/1.1.1>`__.
+-   Added ``avro-schema`` `3.1.1 <https://github.com/tarantool/avro-schema/releases/tag/3.1.0>`__.
+-   Added ``expirationd`` `1.4.0 <https://github.com/tarantool/expirationd/releases/tag/1.4.0>`__.
+-   Added ``graphql`` `0.3.0 <https://github.com/tarantool/graphql/releases/tag/0.3.0>`__.
+-   Added ``graphqlapi`` `0.0.10 <https://github.com/tarantool/graphqlapi/releases/tag/0.0.10>`__.
 -   Added metrics `0.17.0 <https://github.com/tarantool/metrics/releases/tag/0.17.0>`__.
 -   Added migrations `0.5.0 <https://github.com/tarantool/migrations/releases/tag/0.5.0>`__.
--   Added oracle `1.4.0 <https://github.com/tarantool/oracle/releases/tag/1.4.0>`__.
--   Added cartridge `2.7.9 <https://github.com/tarantool/cartridge/releases/tag/2.7.9>`__.
--   Added vshard `0.1.23 <https://github.com/tarantool/vshard/releases/tag/0.1.23>`__.
--   Added kafka `1.6.5 <https://github.com/tarantool/kafka/releases/tag/1.6.5>`__.
+-   Added Oracle `1.4.0 <https://github.com/tarantool/oracle/releases/tag/1.4.0>`__.
+-   Added Cartridge `2.7.9 <https://github.com/tarantool/cartridge/releases/tag/2.7.9>`__.
+-   Added ``vshard`` `0.1.23 <https://github.com/tarantool/vshard/releases/tag/0.1.23>`__.
+-   Added Kafka `1.6.5 <https://github.com/tarantool/kafka/releases/tag/1.6.5>`__.
 
-549
+r549
 ---
 
 -   Updated ``tarantool-2.10`` to 2.10.6.
 
-545
+r545
 ---
 
 -   Updated ``tarantool-2.11`` to 2.11.0-rc2.
 
-543
+r543
 ---
 
 -   Added the ``tarantool-2.11`` submodule.
 
-542
+r542
 ---
 
 -   Updated ``tarantool-1.10`` to 1.10.15.
 
-541
+r541
 ---
 
--  Updated ``tarantool-master`` to ``3.0.0-entrypoint``.
+-   Updated ``tarantool-master`` to ``3.0.0-entrypoint``.
 
-540
+r540
 ---
 
 -   Updated ``tarantool-2.10`` to 2.10.5.
 
-539
+r539
 ---
 
--   Added vshard `0.1.22 <https://github.com/tarantool/vshard/releases/tag/0.1.22>`__.
+-   Added ``vshard`` `0.1.22 <https://github.com/tarantool/vshard/releases/tag/0.1.22>`__.
 
-538
+r538
 ---
 
 -   Updated ``tarantool-2.8`` to apply 2 hotfixes.
 
-537
+r537
 ---
 
--   Fix non-interactive installation of the ``brew`` package.
+-   Fixed non-interactive installation of the ``brew`` package.
 
 -   Changed the owner of the ``/usr/local/bin`` directory.
 
 -   Installed ``awscli@1`` instead of ``awscli`` since it takes much less
     time.
 
-536
+r536
 ---
 
 -   Added the missing property ``2.10`` for scope ``CACHE`` in CMakeLists.txt.
 
-535
+r535
 ---
 
--   Added expirationd `1.3.1 <https://github.com/tarantool/expirationd/releases/tag/1.3.1>`__.
+-   Added ``expirationd`` `1.3.1 <https://github.com/tarantool/expirationd/releases/tag/1.3.1>`__.
 
-534
+r534
 ---
 
--   Added crud `1.0.0 <https://github.com/tarantool/crud/releases/tag/1.0.0>`__.
+-   Added CRUD `1.0.0 <https://github.com/tarantool/crud/releases/tag/1.0.0>`__.
 
-533
+r533
 ---
 
--   Use runners with label ``regular`` for builds and the tagged release
+-   Used runners with label ``regular`` for builds and the tagged release
     workflow.
 
-532
+r532
 ---
 
--   Added http `1.4.0 <https://github.com/tarantool/http/releases/tag/1.4.0>`__.
--   Added space-explorer `1.1.7 <https://github.com/tarantool/space-explorer/releases/tag/1.1.7>`__.
--   Added checks `3.2.0 <https://github.com/tarantool/checks/releases/tag/3.2.0>`__.
+-   Added ``http`` `1.4.0 <https://github.com/tarantool/http/releases/tag/1.4.0>`__.
+-   Added ``space-explorer`` `1.1.7 <https://github.com/tarantool/space-explorer/releases/tag/1.1.7>`__.
+-   Added ``checks `3.2.0 <https://github.com/tarantool/checks/releases/tag/3.2.0>`__.
 -   Added metrics `0.16.0 <https://github.com/tarantool/metrics/releases/tag/0.16.0>`__.
--   Added cartridge `2.7.8 <https://github.com/tarantool/cartridge/releases/tag/2.7.8>`__.
+-   Added Cartridge `2.7.8 <https://github.com/tarantool/cartridge/releases/tag/2.7.8>`__.
 
-531
+r531
 ---
 
 -   Added the ``-DENABLE_LTO=ON``  flag for tarantool-ee@master branch to
     CMakeLists.txt
 
-530
+r530
 ---
 
--   Upgraded devtoolset from 8 to 9. It was required for upgrading ld from
+-   Upgraded ``devtoolset`` from 8 to 9. It was required for upgrading ``ld`` from
     2.30 to 2.31+ for LTO.
 
 
-529
+r529
 ---
 
--  Updated tarantool’s master branch to a recent revision.
+-  Updated tarantool’s ``master`` branch to a recent revision.
 
-528
+r528
 ---
 
--  Fixed code style in the Linux and macOS workflows.
+-  Fixed code style in the Linux and MacOS workflows.
 
-527
+r527
 ---
 
--  Reliably install packages in macOS builds.
+-  Reliably installed packages in MacOS builds.
 
-526
+r526
 ---
 
 -   Refactored the way that GC64 builds are defined in the build workflow.
     There are no changes to the composition of resulting bundles.
 
-525
+r525
 ---
 
 -   Added alerting failures in builds on stable branches and integration testing
     to VK Teams chats.
 
-524
+r524
 ---
 
 -   Updated to fresh tarantool master (``2.11.0-entrypoint-107-ga18449d``)
 
-523
+r523
 ---
 
--   Added cartridge `2.7.7 <https://github.com/tarantool/cartridge/releases/tag/2.7.7>`__.
+-   Added Cartridge `2.7.7 <https://github.com/tarantool/cartridge/releases/tag/2.7.7>`__.
 
-522
+r522
 ---
 
 -   Outdated workflow runs are now canceled to save CI time.
 
-521
+r521
 ---
 
--   Added crud `0.14.1 <https://github.com/tarantool/crud/releases/tag/0.14.1>`__.
--   Added expirationd `1.3.0 <https://github.com/tarantool/expirationd/releases/tag/1.3.0>`__.
+-   Added CRUD `0.14.1 <https://github.com/tarantool/crud/releases/tag/0.14.1>`__.
+-   Added ``expirationd`` `1.3.0 <https://github.com/tarantool/expirationd/releases/tag/1.3.0>`__.
 -   Added metrics `0.15.1 <https://github.com/tarantool/metrics/releases/tag/0.15.1>`__.
 -   Added queue `1.2.2 <https://github.com/tarantool/queue/releases/tag/1.2.2>`__.
 
-520
+r520
 ---
 
 Release SDK by tags:
 
 -   Run workflow in SDK docker container.
--   Upload SDK files for 1.10, 2.8, 2.10 versions to release folder.
--   Add consistency check for all versions.
+-   Uploaded SDK files for 1.10, 2.8, 2.10 versions to release folder.
+-   Added consistency check for all versions.
 
-519
+r519
 ---
 
 *   On feature branches, SDK is now rebuilt only on relevant changes.
@@ -301,9 +593,9 @@ r518
 ----
 
 *   Added frontend core `8.2.1 <https://github.com/tarantool/frontend-core/releases/tag/8.2.1>`__.
-*   Added vshard `0.1.21 <https://github.com/tarantool/vshard/releases/tag/0.1.21>`__.
+*   Added ``vshard`` `0.1.21 <https://github.com/tarantool/vshard/releases/tag/0.1.21>`__.
 *   Added http `1.3.0 <https://github.com/tarantool/http/releases/tag/1.3.0>`__.
-*   Added cartridge `2.7.6 <https://github.com/tarantool/cartridge/releases/tag/2.7.6>`__.
+*   Added Cartridge `2.7.6 <https://github.com/tarantool/cartridge/releases/tag/2.7.6>`__.
 
 r517
 ----
@@ -332,18 +624,18 @@ r514
 r513
 ----
 
-*   Removed kafka 1.5.0 due to a build issue with Tarantool 2.10.3 and higher.
-*   Updated kafka to version `1.6.2 <https://github.com/tarantool/kafka/releases/tag/1.6.2>`__.
+*   Removed Kafka 1.5.0 due to a build issue with Tarantool 2.10.3 and higher.
+*   Updated Kafka to version `1.6.2 <https://github.com/tarantool/kafka/releases/tag/1.6.2>`__.
 
 r512
 ----
 
-* Updated tuple-keydef to version `0.0.3 <https://github.com/tarantool/tuple-keydef/releases/tag/0.0.3>`__.
+* Updated ``tuple-keydef`` to version `0.0.3 <https://github.com/tarantool/tuple-keydef/releases/tag/0.0.3>`__.
 
 r511
 ----
 
-*   Enabled parallel build of rocks for macOS in CI.
+*   Enabled parallel build of rocks for MacOS in CI.
 
 r510
 ----
@@ -351,7 +643,7 @@ r510
 *   Updated Tarantool to 2.10.3.
 *   Added a readable error for the case when the flight recoder fails
     to write data due to insufficient free space on the disk device.
-    Previously, it was sending a `SIGBUS` error (:tarantool-ee-issue:`196`).
+    Previously, it was sending a ``SIGBUS`` error (:tarantool-ee-issue:`196`).
 *   Fixed a crash in the flight recorder caused by non-thread-safe log
     recording from multiple threads (:tarantool-ee-issue:`226`).
 
@@ -372,7 +664,7 @@ r498
 *   Updated LZ4 to version 1.9.3. Fixed `CVE-2021-3520 <https://github.com/advisories/GHSA-gmc7-pqv9-966m>`__.
 *   Fixed replication reconnect failure after disabling SSL encryption (:tarantool-ee-issue:`137`).
 *   Fixed a crash that occurred while tyring to start an instance that has
-    a compressed memtx space (:tarantool-ee-issue:`171`).
+    a compressed ``memtx`` space (:tarantool-ee-issue:`171`).
 *   Fixed `CVE-2022-29242 <https://www.cve.org/CVERecord?id=CVE-2022-29242>`__ in GOST SSL engine.
 *   Fixed a bug in the flight recorder reader implementation that resulted in
     a hang or error while trying to open an empty section (:tarantool-ee-issue:`187`).
@@ -424,7 +716,7 @@ Vinyl
 Lua
 ^^^
 
-*   Added support of console autocompletion for net.box objects ``stream``
+*   Added support of console autocompletion for ``net.box`` objects ``stream``
     and ``future`` (:tarantool-issue:`6305`).
 
 Datetime
@@ -474,7 +766,7 @@ Core
 Replication
 ^^^^^^^^^^^
 
-*   Fixed potential obsolete data write in synchronious replication
+*   Fixed potential obsolete data write in synchronous replication
     due to race in accessing terms while disk write operation is in
     progress and not yet completed.
 *   Fixed replicas failing to bootstrap when master is just re-started (:tarantool-issue:`6966`).
@@ -512,7 +804,7 @@ Net.box
 ^^^^^^^
 
 *   Changed the type of the error returned by net.box on timeout
-    from ClientError to TimedOut (:tarantool-issue:`6144`).
+    from ``ClientError`` to ``TimedOut`` (:tarantool-issue:`6144`).
 
 r457
 ----


### PR DESCRIPTION
source: https://gitlab.corp.mail.ru/tarantool/delivery/sdk/-/tags

deployment: https://docs.d.tarantool.io/en/doc/doc-sdk-changelog/release/enterprise-changelog/

fixes: https://github.com/tarantool/doc/issues/5470