### PR TITLE
Updates info on Java Connectors

### DIFF
--- a/doc/connector/java.rst
+++ b/doc/connector/java.rst
@@ -3,7 +3,22 @@
 Java
 ====
 
-There are two Java connectors available:
+The following Java connectors are available:
+
+*   `tarantool-java-SDK <https://tarantool.github.io/tarantool-java-sdk/>`__ is
+    the primary connector that is actively being developed and maintained. This
+    connector supports current Tarantool versions and features. Support for
+    `Spring Data <https://projects.spring.io/spring-data/>`__ and
+    `Testcontainers <https://www.testcontainers.org/>`__ is implemented as modules within the
+    Tarantool Java SDK project, providing seamless integration with these frameworks.
+    * Separate documentation is available for each major and minor Tarantool Java SDK version,
+    for example: https://tarantool.github.io/tarantool-java-sdk/1.5.*/
+    * For the most up-to-date documentation (including the latest changes and features),
+    please refer to the dev version: https://tarantool.github.io/tarantool-java-sdk/dev/
+
+.. NOTE::
+
+   The connectors below are either deprecated or are planned for deprecation.
 
 *   `cartridge-java <http://github.com/tarantool/cartridge-java/>`__
     supports both single Tarantool nodes and clusters,
@@ -15,15 +30,3 @@ There are two Java connectors available:
     and offers JDBC interface support for single Tarantool nodes.
     This module *isn't currently maintained* and
     does not support the newest 2.x Tarantool features or Tarantool clusters.
-
-The following modules support Java libraries and frameworks:
-
-*   `TestContainers Tarantool module <http://github.com/tarantool/cartridge-java-testcontainers/>`__
-    adds support for the popular `TestContainers framework <https://www.testcontainers.org/>`__
-    used for integration testing of Java applications.
-*   `Spring Data Tarantool module <http://github.com/tarantool/cartridge-springdata/>`__
-    adds support for the `Spring framework <https://projects.spring.io/spring-data/>`__.
-
-    Check out the
-    `Spring Pet Clinic project <http://github.com/tarantool/spring-petclinic-tarantool/>`__
-    to get familiar with using this module in real applications.

--- a/doc/connector/java.rst
+++ b/doc/connector/java.rst
@@ -11,9 +11,10 @@ The following Java connectors are available:
     `Spring Data <https://projects.spring.io/spring-data/>`__ and
     `Testcontainers <https://www.testcontainers.org/>`__ is implemented as modules within the
     Tarantool Java SDK project, providing seamless integration with these frameworks.
-    * Separate documentation is available for each major and minor Tarantool Java SDK version,
+
+    *   Separate documentation is available for each major and minor Tarantool Java SDK version,
     for example: https://tarantool.github.io/tarantool-java-sdk/1.5.*/
-    * For the most up-to-date documentation (including the latest changes and features),
+    *   For the most up-to-date documentation (including the latest changes and features),
     please refer to the dev version: https://tarantool.github.io/tarantool-java-sdk/dev/
 
 .. NOTE::


### PR DESCRIPTION
Adds details on tarantool-java-sdk connector as the mainely supported connector. Other java connectors are marked as planned for deprecation

Fixes #5556 