### PR TITLE
Audit log: fix insert key typo

### DIFF
--- a/doc/platform/security/audit_log.rst
+++ b/doc/platform/security/audit_log.rst
@@ -209,7 +209,7 @@ If the ``extract_key`` option is set to ``true``, the audit system prints the pr
       "user": "admin",
       "type": "space_insert",
       "tag": "",
-      "description": "Insert key [2] into space bands"
+      "description": "Insert key [1] into space bands"
     }
 
 If the ``extract_key`` option is set to ``false``, the audit system prints the full tuple like this:


### PR DESCRIPTION
As we see below, the full tuple contains primary key value `1`.

https://github.com/tarantool/doc/blob/e1addab0d29958f31b9374edce39149f6abea413/doc/platform/security/audit_log.rst?plain=1#L229