### PR TITLE
doc: add index_opts_layout option

### DIFF
--- a/doc/reference/reference_lua/box_space/create_index.rst
+++ b/doc/reference/reference_lua/box_space/create_index.rst
@@ -275,7 +275,7 @@ index_opts
 
         Possible values:
 
-        * If not set (or set to an empty string), the default plain layout is used.
+        * If not set (or set to `plain`), the default plain layout is used.
         * If set to `null_rle`, run-length encoding of `NULL` values is used. Applies to nullable columns that are not listed in index `parts`.
 
         For example:
@@ -302,7 +302,7 @@ index_opts
                parts = { 'c1', 'c2' }, covers = { 'c3', 'c4' }, layout = 'null_rle'
            })
 
-        In this example, the `null_rle` layout is applied to `c2, `c3`, `c5`
+        In this example, the `null_rle` layout is applied to `c2`, `c3`, `c5`
         in the primary index, and to `c3` in the secondary index.
 
         |

--- a/doc/reference/reference_lua/box_space/create_index.rst
+++ b/doc/reference/reference_lua/box_space/create_index.rst
@@ -264,6 +264,51 @@ index_opts
         | Type: number
         | Default: :ref:`vinyl.run_size_ratio <configuration_reference_vinyl_run_size_ratio>`
 
+
+    ..  _index_opts_layout:
+
+    .. data:: layout
+
+        **MemCS only**
+
+        Specify how a column within the index is physically stored.
+
+        Possible values:
+
+        * If not set (or set to an empty string), the default plain layout is used.
+        * If set to `null_rle`, run-length encoding of `NULL` values is used. Applies to nullable columns that are not listed in index `parts`.
+
+        For example:
+
+        .. code-block:: lua
+
+           local format = {
+               { 'c1', 'unsigned' },
+               { 'c2', 'unsigned', is_nullable = true },
+               { 'c3', 'unsigned', is_nullable = true },
+               { 'c4', 'unsigned' },
+               { 'c5', 'unsigned', is_nullable = true },
+           }
+
+           box.schema.create_space('test', {
+               engine = 'memcs', format = format, field_count = #format
+           })
+
+           box.space.test:create_index('primary', {
+               parts = { 'c1' }, layout = 'null_rle'
+           })
+
+           box.space.test:create_index('secondary', {
+               parts = { 'c1', 'c2' }, covers = { 'c3', 'c4' }, layout = 'null_rle'
+           })
+
+        In this example, the `null_rle` layout is applied to `c2, `c3`, `c5`
+        in the primary index, and to `c3` in the secondary index.
+
+        |
+        | Type: string
+        | Default: not set
+
 .. _key_part_object:
 
 key_part


### PR DESCRIPTION
Added documentation for the `index_opts.layout` option (MemCS): described what it does, listed supported values, clarified when it applies, and provided a Lua example. Also added the type and default value.

Fixes: https://github.com/tarantool/doc/issues/5067

Development: https://docs.d.tarantool.io/en/doc/doc-memcs-layout-option/reference/reference_lua/box_space/create_index/#lua-data.index_opts.layout
.