### PR TITLE
Add a note about `memtx.memory` estimation to 2.11 docs

### DIFF
--- a/doc/reference/configuration/cfg_storage.rst
+++ b/doc/reference/configuration/cfg_storage.rst
@@ -29,6 +29,16 @@
     configuration and workload, Tarantool can consume up to 20% more than the
     ``memtx_memory`` limit.
 
+
+    ..  NOTE::
+
+        By default, the memory size (``memtx_memory``) parameter is set to 256 MB.
+        Before deploying a cluster, calculate the necessary amount of memory with a reserve and specify it in the
+        ``memtx_memory`` option.
+        Starting a cluster with the default memory size value may lead to memory exhaustion and make further writes
+        to the replica instance impossible.
+
+
     | Type: float
     | Default: 256 * 1024 * 1024 = 268435456 bytes
     | Minimum: 33554432 bytes (32 MB)

--- a/doc/reference/configuration/cfg_storage.rst
+++ b/doc/reference/configuration/cfg_storage.rst
@@ -36,7 +36,7 @@
         Before deploying a cluster, calculate the necessary amount of memory with a reserve and specify it in the
         ``memtx_memory`` option.
         Starting a cluster with the default memory size value may lead to memory exhaustion and make further writes
-        to the replica instance impossible.
+        to the instance impossible.
 
 
     | Type: float


### PR DESCRIPTION
Fixes https://github.com/tarantool/doc/issues/5525

Doc deployment: https://docs.d.tarantool.io/en/doc/2.11-memtx-memory/reference/configuration/#confval-memtx_memory