### PR TITLE
doc: drop layout specification at index level

### DIFF
--- a/doc/platform/engines/memcs.rst
+++ b/doc/platform/engines/memcs.rst
@@ -80,14 +80,17 @@ Dictionary encoding
 -------------------
 
 MemCS supports **dictionary encoding** for string columns. It stores unique string values in a shared dictionary and replaces repeated values with small integer IDs.
-Dictionary encoding is enabled via the :ref:`layout <index_opts_layout>` option:
+Dictionary encoding is enabled via the ``layout`` option in the space format:
 
 .. code-block:: lua
 
-    local s = box.schema.create_space('test', {
-        engine = 'memcs', format = format, field_count = field_count,
+    local format = {
+        {name = 'id', type = 'uint64'},
+        {name = 'name', type = 'string', layout = 'dict'},
+    }
+    box.schema.create_space('test', {
+        engine = 'memcs', format = format, field_count = #format,
     })
-    s:create_index('pk', {layout = 'dict'})
 
 **Limitations:**
 
@@ -112,31 +115,10 @@ Memory used by the dictionary is included in ``space:bsize()`` statistics.
 Column layouts
 ~~~~~~~~~~~~~~
 
-MemCS supports specifying **column layouts** at multiple levels. The precedence is as follows (from highest to lowest):
-
-1. Within :ref:`covers <index_opts_covers>` in index definition
-2. Within :ref:`layout <index_opts_layout>` in index definition (default for nullable fields)
-3. Within `format` in space definition
+MemCS supports specifying **column layouts** using the ``layout`` option in the space format:
 
 .. code-block:: lua
 
-    -- 1. In covers
-    box.space.test:create_index('sk', {
-        parts = {'c2', 'c3'},
-        covers = {
-            {'c4', layout = 'plain'},
-            {'c5', layout = 'null_rle'},
-        },
-    })
-
-    -- 2. In layout
-    box.space.test:create_index('sk', {
-        parts = {'c2', 'c3'},
-        covers = {'c4', 'c5'},
-        layout = 'null_rle',
-    })
-
-    -- 3. In format
     box.space.test:format({
         {name = "c2", type = "number"},
         {name = "c3", type = "number"},
@@ -159,11 +141,7 @@ By default, NULL values are stored explicitly and consume the same amount of mem
 However, RLE encoding of NULLs is also supported via the ``null_rle`` layout.
 For example, in a column with 90% evenly distributed NULL values, RLE encoding reduces memory consumption by approximately 5 times.
 
-The ``null_rle`` layout can be specified at three levels:
-
-* Within ``covers`` in an index definition (highest precedence)
-* Within ``layout`` in an index definition (default for nullable fields)
-* Within ``format`` when defining a space (lowest precedence)
+The ``null_rle`` layout can be specified in the space format for nullable non-key fields.
 
 
 .. _memcs-lz4-compression:

--- a/doc/reference/reference_lua/box_space/create_index.rst
+++ b/doc/reference/reference_lua/box_space/create_index.rst
@@ -265,50 +265,6 @@ index_opts
         | Default: :ref:`vinyl.run_size_ratio <configuration_reference_vinyl_run_size_ratio>`
 
 
-    ..  _index_opts_layout:
-
-    .. data:: layout
-
-        **MemCS only**
-
-        Specify how a column within the index is physically stored.
-
-        Possible values:
-
-        * If not set (or set to `plain`), the default plain layout is used.
-        * If set to `null_rle`, run-length encoding of `NULL` values is used. Applies to nullable columns that are not listed in index `parts`.
-
-        For example:
-
-        .. code-block:: lua
-
-           local format = {
-               { 'c1', 'unsigned' },
-               { 'c2', 'unsigned', is_nullable = true },
-               { 'c3', 'unsigned', is_nullable = true },
-               { 'c4', 'unsigned' },
-               { 'c5', 'unsigned', is_nullable = true },
-           }
-
-           box.schema.create_space('test', {
-               engine = 'memcs', format = format, field_count = #format
-           })
-
-           box.space.test:create_index('primary', {
-               parts = { 'c1' }, layout = 'null_rle'
-           })
-
-           box.space.test:create_index('secondary', {
-               parts = { 'c1', 'c2' }, covers = { 'c3', 'c4' }, layout = 'null_rle'
-           })
-
-        In this example, the `null_rle` layout is applied to `c2`, `c3`, `c5`
-        in the primary index, and to `c3` in the secondary index.
-
-        |
-        | Type: string
-        | Default: not set
-
     ..  _index_opts_covers:
 
     .. data:: covers
@@ -316,7 +272,6 @@ index_opts
         **MemCS only**
 
         Specify a list of non-key fields stored in the index (covering index).
-        `covers` also allows specifying a per-column :ref:`layout <index_opts_layout>` for covered fields.
 
         For example:
 
@@ -324,15 +279,10 @@ index_opts
 
             box.space.test:create_index('sk', {
                 parts = {'c2', 'c3'},
-                covers = {
-                    {'c4', layout = 'plain'},
-                    {'c5', layout = 'null_rle'},
-                },
+                covers = {'c4', 'c5'},
             })
 
-        In this example, `c4` is stored using the `plain` layout, while `c5` is stored using the `null_rle` layout.
-        Per-column layouts specified in covers take precedence over the index-wide `layout` option and any layout specified in the space format.
-
+        |
         | Type: table
         | Default: not set
 

--- a/doc/release/3.7.0.rst
+++ b/doc/release/3.7.0.rst
@@ -75,7 +75,7 @@ Dictionary encoding for string columns
 :ref:`MemCS <engines-memcs>` can store string values in a **dictionary-encoded** form: unique strings are kept in a shared dictionary, while rows store integer IDs referencing dictionary entries.
 This is most effective for columns with many repeated values (for example, statuses, categories, event types).
 
-Dictionary encoding is enabled via the :ref:`layout <index_opts_layout>` option:
+Dictionary encoding is enabled via the ``layout`` option:
 
 .. code-block:: lua
 


### PR DESCRIPTION
We drop layout specification at index level altogether in https://github.com/tarantool/tarantool-ee/commit/6a01330df4fea5c608b2b9b36b137fa83e9269b8. So let's clean it from documentation skipping usual procedure with TarantoolBot request to avoid users confusion.

Created with the help of AI.